### PR TITLE
fix: Event Payload page link

### DIFF
--- a/src/docs/sdk/index.mdx
+++ b/src/docs/sdk/index.mdx
@@ -9,7 +9,7 @@ typically look and behave.
 - <Link to="/sdk/overview">Overview</Link>
 - <Link to="/sdk/unified-api">Unified API</Link>
 - <Link to="/sdk/features">Expected Features</Link>
-- <Link to="/sdk/event-payloads/index">Event Payloads</Link>
+- <Link to="/sdk/event-payloads/overview">Event Payloads</Link>
 - <Link to="/sdk/data-handling">Data Handling</Link>
 - <Link to="/sdk/store">Store Endpoint</Link>
 - <Link to="/sdk/envelopes">Envelopes</Link>


### PR DESCRIPTION
"/sdk/event-payloads/index" -> "/sdk/event-payloads/overview"