### PR TITLE
Add zsh examples to environment docs (and simplify shell)

### DIFF
--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -4,10 +4,6 @@ title: "Development Environment"
 
 This guide steps you through configuring a local development environment for the Sentry server on macOS. If you're using another operating system the instructions are still roughly the same, but we don't maintain any official documentation for anything else for now.
 
-#### A quick note on Bash vs Zsh
-
-macOS Catalina will recommend that you use `zsh` instead of `bash`. While the differences are minimal, this guide primarily covers Bash. Verify your shell by running `echo $SHELL`.
-
 ## Clone the Repository
 
 To get started, clone the repo at [https://github.com/getsentry/sentry](https://github.com/getsentry/sentry) - or, your fork.
@@ -35,22 +31,28 @@ To install the required versions of Python you'll need to run `pyenv install`. T
 
 After this, if you type `which python`, you should see something like `/usr/bin/python`... this means `python` will resolve to the system's python. You'll need to make some manual changes to your shell initialization files, if you want your shell to see pyenv's python.
 
-Make sure your `~/.bash_profile` contains the following:
+If you're using bash, make sure your `~/.bash_profile` contains the following:
 
-```bash
+```bash {filename: ~/.bash_profile}
 source ~/.bashrc
-```
 
-And your `~/.bashrc`:
+````
 
-```bash
+Configure your shell to load pyenv:
+
+```bash {filename: ~/.bashrc}
 eval "$(pyenv init -)"
 ```
+
+```bash {filename: ~/.zshrc} {tabTitle: Zsh}
+eval "$(pyenv init -)"
+```
+
 
 Once that's done, your shell needs to be reloaded. You can either reload it in-place, or close your terminal and start it again and cd into sentry. To reload it, run:
 
 ```bash
-PATH="" exec /bin/bash -l
+exec "$SHELL"
 ```
 
 If it worked, running `which python` should result in something like `/Users/you/.pyenv/shims/python`.
@@ -83,10 +85,11 @@ curl https://get.volta.sh | bash
 The volta installer will tell you to "open a new terminal to start using Volta", but you don't have to! You can just reload your shell like before:
 
 ```bash
-PATH="" exec /bin/bash -l
+exec "$SHELL"
 ```
 
-This works because the volta installer conveniently made changes to your shell installation files for you, but it's good to verify. Your `~/.bash_profile` should be the same, but make sure your `~/.bashrc` looks like this:
+
+This works because the volta installer conveniently made changes to your shell installation files for your shell's startup script:
 
 ```bash
 eval "$(pyenv init -)"
@@ -103,21 +106,25 @@ node -v
 
 Volta intercepts this and automatically downloads and installs the node version in sentry's `package.json`.
 
-
 ## direnv
 
 We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
 
-You need to install it, and add the following snippet to the end of your `~/.bashrc` file:
+You need to install it, and add the following snippet to the end of your startup script:
 
-```bash
+```bash {filename: ~/.bashrc}
 eval "$(direnv hook bash)"
 ```
+
+```zsh {filename: ~/.zshrc} {tabTitle: Zsh}
+eval "$(direnv hook zsh)"
+```
+
 
 And after doing that, reload your shell:
 
 ```bash
-PATH="" exec /bin/bash -l
+exec "$SHELL"
 ```
 
 Any time the `.envrc` configuration changes (including the first time) you will be prompted to run `direnv allow` before any of the configuration will run. This is for security purposes and you are encouraged to inspect the changes before running this command.
@@ -137,7 +144,8 @@ Once this command has finished you'll have Sentry installed in development mode 
 ## Running the Development Server
 
 <Alert title="Tip!" level="info">
-    If you would like to import an example dataset, running `./bin/load-mocks` will add a few example projects and teams to the main organization.
+  If you would like to import an example dataset, running `./bin/load-mocks`
+  will add a few example projects and teams to the main organization.
 </Alert>
 
 Once you’ve successfully stood up your datastore, you can now run the development server:
@@ -151,5 +159,9 @@ If you are developing for aesthetics only and do not rely on the async workers, 
 If you would like to be able to run `devserver` outside of your root checkout, you can install `webpack` globally with `npm install -g webpack`.
 
 <Alert title="Note" level="info">
-    When asked for the root address of the server, make sure that you use <a href="http://localhost:8000">http://localhost:8000</a>, as both, protocol <em>and</em> port are required in order for DNS and some pages urls to be displayed correctly.
+  When asked for the root address of the server, make sure that you use{" "}
+  <a href="http://localhost:8000">http://localhost:8000</a>, as both, protocol{" "}
+  <em>and</em> port are required in order for DNS and some pages urls to be
+  displayed correctly.
 </Alert>
+````


### PR DESCRIPTION
- Remove subjective "how to reload shell" (let folks figure out their own edge cases)
- Add cold-folded zsh examples
- Simplify a few language bits