### PR TITLE
feat: Bare import syntax for mdx includes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,6 +42,9 @@ const getPlugins = () => {
             resolve: require.resolve("./plugins/gatsby-plugin-code-tabs"),
           },
           {
+            resolve: require.resolve("./plugins/gatsby-plugin-include"),
+          },
+          {
             resolve: "gatsby-remark-prismjs",
             options: {
               noInlineHighlight: true,

--- a/plugins/gatsby-plugin-include/__tests__/__snapshots__/index.js.snap
+++ b/plugins/gatsby-plugin-include/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,786 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-plugin-code-tabs does not fold code blocks on different levels 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "checked": null,
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Position {
+                    "end": Object {
+                      "column": 15,
+                      "line": 2,
+                      "offset": 15,
+                    },
+                    "indent": Array [],
+                    "start": Object {
+                      "column": 4,
+                      "line": 2,
+                      "offset": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "a list here",
+                },
+              ],
+              "position": Position {
+                "end": Object {
+                  "column": 15,
+                  "line": 2,
+                  "offset": 15,
+                },
+                "indent": Array [],
+                "start": Object {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 4,
+                },
+              },
+              "type": "paragraph",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "jsx",
+                  "value": "<CodeTabs hideTabBar={true}>",
+                },
+                Object {
+                  "type": "jsx",
+                  "value": "<CodeBlock language=\\"plain\\" title=\\"\\" filename=\\"\\">",
+                },
+                Object {
+                  "lang": "plain",
+                  "meta": null,
+                  "position": Position {
+                    "end": Object {
+                      "column": 7,
+                      "line": 5,
+                      "offset": 49,
+                    },
+                    "indent": Array [
+                      4,
+                      4,
+                    ],
+                    "start": Object {
+                      "column": 4,
+                      "line": 3,
+                      "offset": 19,
+                    },
+                  },
+                  "type": "code",
+                  "value": "inside list",
+                },
+                Object {
+                  "type": "jsx",
+                  "value": "</CodeBlock>",
+                },
+                Object {
+                  "type": "jsx",
+                  "value": "</CodeTabs>",
+                },
+              ],
+              "data": Object {
+                "hName": "div",
+                "hProperties": Object {
+                  "className": "code-tabs-wrapper",
+                },
+              },
+              "lang": "plain",
+              "meta": null,
+              "position": Position {
+                "end": Object {
+                  "column": 7,
+                  "line": 5,
+                  "offset": 49,
+                },
+                "indent": Array [
+                  4,
+                  4,
+                ],
+                "start": Object {
+                  "column": 4,
+                  "line": 3,
+                  "offset": 19,
+                },
+              },
+              "type": "element",
+              "value": "inside list",
+            },
+          ],
+          "position": Position {
+            "end": Object {
+              "column": 7,
+              "line": 5,
+              "offset": 49,
+            },
+            "indent": Array [
+              1,
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "spread": false,
+          "type": "listItem",
+        },
+      ],
+      "ordered": true,
+      "position": Position {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+          "offset": 49,
+        },
+        "indent": Array [
+          1,
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "spread": false,
+      "start": 1,
+      "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={true}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"plain\\" title=\\"\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "plain",
+          "meta": null,
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 9,
+              "offset": 76,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 7,
+              "offset": 51,
+            },
+          },
+          "type": "code",
+          "value": "outside list",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "plain",
+      "meta": null,
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 9,
+          "offset": 76,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 7,
+          "offset": 51,
+        },
+      },
+      "type": "element",
+      "value": "outside list",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 10,
+      "offset": 77,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`gatsby-plugin-code-tabs does not fold code blocks split by a paragraph 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={true}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"python\\" title=\\"\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "python",
+          "meta": null,
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 4,
+              "offset": 35,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "type": "code",
+          "value": "print \\"Hello World!\\"",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "python",
+      "meta": null,
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 4,
+          "offset": 35,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "type": "element",
+      "value": "print \\"Hello World!\\"",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 16,
+              "line": 6,
+              "offset": 52,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 37,
+            },
+          },
+          "type": "text",
+          "value": "some text here:",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 16,
+          "line": 6,
+          "offset": 52,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 37,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={true}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"javascript\\" title=\\"\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "javascript",
+          "meta": null,
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 10,
+              "offset": 100,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 8,
+              "offset": 54,
+            },
+          },
+          "type": "code",
+          "value": "console.log(\\"Hello World!\\");",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "javascript",
+      "meta": null,
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 10,
+          "offset": 100,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 8,
+          "offset": 54,
+        },
+      },
+      "type": "element",
+      "value": "console.log(\\"Hello World!\\");",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 11,
+      "offset": 101,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`gatsby-plugin-code-tabs folds two code blocks 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={false}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"python\\" title=\\"\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "python",
+          "meta": null,
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 4,
+              "offset": 35,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "type": "code",
+          "value": "print \\"Hello World!\\"",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"javascript\\" title=\\"\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "javascript",
+          "meta": null,
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 8,
+              "offset": 83,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 37,
+            },
+          },
+          "type": "code",
+          "value": "console.log(\\"Hello World!\\");",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "python",
+      "meta": null,
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 4,
+          "offset": 35,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "type": "element",
+      "value": "print \\"Hello World!\\"",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 9,
+      "offset": 84,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`gatsby-plugin-code-tabs supports filenames 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={false}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"plain\\" title=\\"Hello\\" filename=\\"hello.txt\\">",
+        },
+        Object {
+          "lang": "plain",
+          "meta": "{tabTitle: Hello} {filename: hello.txt}",
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 4,
+              "offset": 59,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "type": "code",
+          "value": "first",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"plain\\" title=\\"Goodbye\\" filename=\\"goodbye.txt\\">",
+        },
+        Object {
+          "lang": "plain",
+          "meta": "{tabTitle: Goodbye} {filename: goodbye.txt}",
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 8,
+              "offset": 124,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 61,
+            },
+          },
+          "type": "code",
+          "value": "second",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "plain",
+      "meta": "{tabTitle: Hello} {filename: hello.txt}",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 4,
+          "offset": 59,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "type": "element",
+      "value": "first",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 9,
+      "offset": 125,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`gatsby-plugin-code-tabs supports tab titles 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<CodeTabs hideTabBar={false}>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"plain\\" title=\\"Hello\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "plain",
+          "meta": "{tabTitle: Hello}",
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 4,
+              "offset": 37,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "type": "code",
+          "value": "first",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "<CodeBlock language=\\"plain\\" title=\\"Goodbye\\" filename=\\"\\">",
+        },
+        Object {
+          "lang": "plain",
+          "meta": "{tabTitle: Goodbye}",
+          "position": Position {
+            "end": Object {
+              "column": 4,
+              "line": 8,
+              "offset": 78,
+            },
+            "indent": Array [
+              1,
+              1,
+            ],
+            "start": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 39,
+            },
+          },
+          "type": "code",
+          "value": "second",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeBlock>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</CodeTabs>",
+        },
+      ],
+      "data": Object {
+        "hName": "div",
+        "hProperties": Object {
+          "className": "code-tabs-wrapper",
+        },
+      },
+      "lang": "plain",
+      "meta": "{tabTitle: Hello}",
+      "position": Position {
+        "end": Object {
+          "column": 4,
+          "line": 4,
+          "offset": 37,
+        },
+        "indent": Array [
+          1,
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "type": "element",
+      "value": "first",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 1,
+      "line": 9,
+      "offset": 79,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/plugins/gatsby-plugin-include/__tests__/__snapshots__/index.js.snap
+++ b/plugins/gatsby-plugin-include/__tests__/__snapshots__/index.js.snap
@@ -1,148 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gatsby-plugin-code-tabs does not fold code blocks on different levels 1`] = `
+exports[`gatsby-plugin-include resolves one import 1`] = `
 Object {
   "children": Array [
     Object {
-      "children": Array [
-        Object {
-          "checked": null,
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "position": Position {
-                    "end": Object {
-                      "column": 15,
-                      "line": 2,
-                      "offset": 15,
-                    },
-                    "indent": Array [],
-                    "start": Object {
-                      "column": 4,
-                      "line": 2,
-                      "offset": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "a list here",
-                },
-              ],
-              "position": Position {
-                "end": Object {
-                  "column": 15,
-                  "line": 2,
-                  "offset": 15,
-                },
-                "indent": Array [],
-                "start": Object {
-                  "column": 4,
-                  "line": 2,
-                  "offset": 4,
-                },
-              },
-              "type": "paragraph",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "jsx",
-                  "value": "<CodeTabs hideTabBar={true}>",
-                },
-                Object {
-                  "type": "jsx",
-                  "value": "<CodeBlock language=\\"plain\\" title=\\"\\" filename=\\"\\">",
-                },
-                Object {
-                  "lang": "plain",
-                  "meta": null,
-                  "position": Position {
-                    "end": Object {
-                      "column": 7,
-                      "line": 5,
-                      "offset": 49,
-                    },
-                    "indent": Array [
-                      4,
-                      4,
-                    ],
-                    "start": Object {
-                      "column": 4,
-                      "line": 3,
-                      "offset": 19,
-                    },
-                  },
-                  "type": "code",
-                  "value": "inside list",
-                },
-                Object {
-                  "type": "jsx",
-                  "value": "</CodeBlock>",
-                },
-                Object {
-                  "type": "jsx",
-                  "value": "</CodeTabs>",
-                },
-              ],
-              "data": Object {
-                "hName": "div",
-                "hProperties": Object {
-                  "className": "code-tabs-wrapper",
-                },
-              },
-              "lang": "plain",
-              "meta": null,
-              "position": Position {
-                "end": Object {
-                  "column": 7,
-                  "line": 5,
-                  "offset": 49,
-                },
-                "indent": Array [
-                  4,
-                  4,
-                ],
-                "start": Object {
-                  "column": 4,
-                  "line": 3,
-                  "offset": 19,
-                },
-              },
-              "type": "element",
-              "value": "inside list",
-            },
-          ],
-          "position": Position {
-            "end": Object {
-              "column": 7,
-              "line": 5,
-              "offset": 49,
-            },
-            "indent": Array [
-              1,
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 2,
-              "offset": 1,
-            },
-          },
-          "spread": false,
-          "type": "listItem",
-        },
-      ],
-      "ordered": true,
       "position": Position {
         "end": Object {
-          "column": 7,
-          "line": 5,
-          "offset": 49,
+          "column": 1,
+          "line": 3,
+          "offset": 21,
         },
         "indent": Array [
-          1,
-          1,
           1,
         ],
         "start": Object {
@@ -151,84 +19,34 @@ Object {
           "offset": 1,
         },
       },
-      "spread": false,
-      "start": 1,
-      "type": "list",
+      "type": "import",
+      "value": "import ImportedComponent0 from \\"./foo.mdx\\";",
     },
     Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={true}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"plain\\" title=\\"\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "plain",
-          "meta": null,
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 9,
-              "offset": 76,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 7,
-              "offset": 51,
-            },
-          },
-          "type": "code",
-          "value": "outside list",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "plain",
-      "meta": null,
       "position": Position {
         "end": Object {
-          "column": 4,
-          "line": 9,
-          "offset": 76,
+          "column": 1,
+          "line": 3,
+          "offset": 21,
         },
         "indent": Array [
-          1,
           1,
         ],
         "start": Object {
           "column": 1,
-          "line": 7,
-          "offset": 51,
+          "line": 2,
+          "offset": 1,
         },
       },
-      "type": "element",
-      "value": "outside list",
+      "type": "jsx",
+      "value": "<ImportedComponent0/>",
     },
   ],
   "position": Object {
     "end": Object {
       "column": 1,
-      "line": 10,
-      "offset": 77,
+      "line": 3,
+      "offset": 21,
     },
     "start": Object {
       "column": 1,
@@ -240,540 +58,87 @@ Object {
 }
 `;
 
-exports[`gatsby-plugin-code-tabs does not fold code blocks split by a paragraph 1`] = `
+exports[`gatsby-plugin-include resolves two imports 1`] = `
 Object {
   "children": Array [
     Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={true}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"python\\" title=\\"\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "python",
-          "meta": null,
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 4,
-              "offset": 35,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 2,
-              "offset": 1,
-            },
-          },
-          "type": "code",
-          "value": "print \\"Hello World!\\"",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "python",
-      "meta": null,
       "position": Position {
         "end": Object {
-          "column": 4,
-          "line": 4,
-          "offset": 35,
-        },
-        "indent": Array [
-          1,
-          1,
-        ],
-        "start": Object {
-          "column": 1,
+          "column": 20,
           "line": 2,
-          "offset": 1,
-        },
-      },
-      "type": "element",
-      "value": "print \\"Hello World!\\"",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "position": Position {
-            "end": Object {
-              "column": 16,
-              "line": 6,
-              "offset": 52,
-            },
-            "indent": Array [],
-            "start": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 37,
-            },
-          },
-          "type": "text",
-          "value": "some text here:",
-        },
-      ],
-      "position": Position {
-        "end": Object {
-          "column": 16,
-          "line": 6,
-          "offset": 52,
+          "offset": 20,
         },
         "indent": Array [],
         "start": Object {
           "column": 1,
-          "line": 6,
-          "offset": 37,
+          "line": 2,
+          "offset": 1,
         },
       },
-      "type": "paragraph",
+      "type": "import",
+      "value": "import ImportedComponent0 from \\"./foo.mdx\\";",
     },
     Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={true}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"javascript\\" title=\\"\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "javascript",
-          "meta": null,
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 10,
-              "offset": 100,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 8,
-              "offset": 54,
-            },
-          },
-          "type": "code",
-          "value": "console.log(\\"Hello World!\\");",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "javascript",
-      "meta": null,
       "position": Position {
         "end": Object {
-          "column": 4,
-          "line": 10,
-          "offset": 100,
+          "column": 1,
+          "line": 5,
+          "offset": 42,
         },
         "indent": Array [
-          1,
           1,
         ],
         "start": Object {
           "column": 1,
-          "line": 8,
-          "offset": 54,
+          "line": 4,
+          "offset": 22,
         },
       },
-      "type": "element",
-      "value": "console.log(\\"Hello World!\\");",
+      "type": "import",
+      "value": "import ImportedComponent1 from \\"./bar.mdx\\";",
     },
-  ],
-  "position": Object {
-    "end": Object {
-      "column": 1,
-      "line": 11,
-      "offset": 101,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "type": "root",
-}
-`;
-
-exports[`gatsby-plugin-code-tabs folds two code blocks 1`] = `
-Object {
-  "children": Array [
     Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={false}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"python\\" title=\\"\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "python",
-          "meta": null,
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 4,
-              "offset": 35,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 2,
-              "offset": 1,
-            },
-          },
-          "type": "code",
-          "value": "print \\"Hello World!\\"",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"javascript\\" title=\\"\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "javascript",
-          "meta": null,
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 8,
-              "offset": 83,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 37,
-            },
-          },
-          "type": "code",
-          "value": "console.log(\\"Hello World!\\");",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "python",
-      "meta": null,
       "position": Position {
         "end": Object {
-          "column": 4,
-          "line": 4,
-          "offset": 35,
+          "column": 20,
+          "line": 2,
+          "offset": 20,
         },
-        "indent": Array [
-          1,
-          1,
-        ],
+        "indent": Array [],
         "start": Object {
           "column": 1,
           "line": 2,
           "offset": 1,
         },
       },
-      "type": "element",
-      "value": "print \\"Hello World!\\"",
+      "type": "jsx",
+      "value": "<ImportedComponent0/>",
     },
-  ],
-  "position": Object {
-    "end": Object {
-      "column": 1,
-      "line": 9,
-      "offset": 84,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "type": "root",
-}
-`;
-
-exports[`gatsby-plugin-code-tabs supports filenames 1`] = `
-Object {
-  "children": Array [
     Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={false}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"plain\\" title=\\"Hello\\" filename=\\"hello.txt\\">",
-        },
-        Object {
-          "lang": "plain",
-          "meta": "{tabTitle: Hello} {filename: hello.txt}",
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 4,
-              "offset": 59,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 2,
-              "offset": 1,
-            },
-          },
-          "type": "code",
-          "value": "first",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"plain\\" title=\\"Goodbye\\" filename=\\"goodbye.txt\\">",
-        },
-        Object {
-          "lang": "plain",
-          "meta": "{tabTitle: Goodbye} {filename: goodbye.txt}",
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 8,
-              "offset": 124,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 61,
-            },
-          },
-          "type": "code",
-          "value": "second",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "plain",
-      "meta": "{tabTitle: Hello} {filename: hello.txt}",
       "position": Position {
         "end": Object {
-          "column": 4,
-          "line": 4,
-          "offset": 59,
+          "column": 1,
+          "line": 5,
+          "offset": 42,
         },
         "indent": Array [
-          1,
           1,
         ],
         "start": Object {
           "column": 1,
-          "line": 2,
-          "offset": 1,
-        },
-      },
-      "type": "element",
-      "value": "first",
-    },
-  ],
-  "position": Object {
-    "end": Object {
-      "column": 1,
-      "line": 9,
-      "offset": 125,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "type": "root",
-}
-`;
-
-exports[`gatsby-plugin-code-tabs supports tab titles 1`] = `
-Object {
-  "children": Array [
-    Object {
-      "children": Array [
-        Object {
-          "type": "jsx",
-          "value": "<CodeTabs hideTabBar={false}>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"plain\\" title=\\"Hello\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "plain",
-          "meta": "{tabTitle: Hello}",
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 4,
-              "offset": 37,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 2,
-              "offset": 1,
-            },
-          },
-          "type": "code",
-          "value": "first",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "<CodeBlock language=\\"plain\\" title=\\"Goodbye\\" filename=\\"\\">",
-        },
-        Object {
-          "lang": "plain",
-          "meta": "{tabTitle: Goodbye}",
-          "position": Position {
-            "end": Object {
-              "column": 4,
-              "line": 8,
-              "offset": 78,
-            },
-            "indent": Array [
-              1,
-              1,
-            ],
-            "start": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 39,
-            },
-          },
-          "type": "code",
-          "value": "second",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeBlock>",
-        },
-        Object {
-          "type": "jsx",
-          "value": "</CodeTabs>",
-        },
-      ],
-      "data": Object {
-        "hName": "div",
-        "hProperties": Object {
-          "className": "code-tabs-wrapper",
-        },
-      },
-      "lang": "plain",
-      "meta": "{tabTitle: Hello}",
-      "position": Position {
-        "end": Object {
-          "column": 4,
           "line": 4,
-          "offset": 37,
-        },
-        "indent": Array [
-          1,
-          1,
-        ],
-        "start": Object {
-          "column": 1,
-          "line": 2,
-          "offset": 1,
+          "offset": 22,
         },
       },
-      "type": "element",
-      "value": "first",
+      "type": "jsx",
+      "value": "<ImportedComponent1/>",
     },
   ],
   "position": Object {
     "end": Object {
       "column": 1,
-      "line": 9,
-      "offset": 79,
+      "line": 5,
+      "offset": 42,
     },
     "start": Object {
       "column": 1,

--- a/plugins/gatsby-plugin-include/__tests__/index.js
+++ b/plugins/gatsby-plugin-include/__tests__/index.js
@@ -1,0 +1,86 @@
+const Remark = require("remark");
+const toString = require("mdast-util-to-string");
+const visit = require("unist-util-visit");
+
+const plugin = require("../");
+
+const remark = new Remark().data("settings", {
+  commonmark: true,
+  footnotes: true,
+  pedantic: true,
+});
+
+describe("gatsby-plugin-code-tabs", () => {
+  it("folds two code blocks", () => {
+    const markdownAST = remark.parse(`
+~~~python
+print "Hello World!"
+~~~
+
+~~~javascript
+console.log("Hello World!");
+~~~
+`);
+    const transformed = plugin({ markdownAST }, {});
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it("does not fold code blocks split by a paragraph", () => {
+    const markdownAST = remark.parse(`
+~~~python
+print "Hello World!"
+~~~
+
+some text here:
+
+~~~javascript
+console.log("Hello World!");
+~~~
+`);
+    const transformed = plugin({ markdownAST }, {});
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it("does not fold code blocks on different levels", () => {
+    const markdownAST = remark.parse(`
+1. a list here
+   ~~~plain
+   inside list
+   ~~~
+
+~~~plain
+outside list
+~~~
+`);
+    const transformed = plugin({ markdownAST }, {});
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it("supports tab titles", () => {
+    const markdownAST = remark.parse(`
+~~~plain {tabTitle: Hello}
+first
+~~~
+
+~~~plain {tabTitle: Goodbye}
+second
+~~~
+`);
+    const transformed = plugin({ markdownAST }, {});
+    expect(transformed).toMatchSnapshot();
+  });
+
+  it("supports filenames", () => {
+    const markdownAST = remark.parse(`
+~~~plain {tabTitle: Hello} {filename: hello.txt}
+first
+~~~
+
+~~~plain {tabTitle: Goodbye} {filename: goodbye.txt}
+second
+~~~
+`);
+    const transformed = plugin({ markdownAST }, {});
+    expect(transformed).toMatchSnapshot();
+  });
+});

--- a/plugins/gatsby-plugin-include/__tests__/index.js
+++ b/plugins/gatsby-plugin-include/__tests__/index.js
@@ -1,84 +1,32 @@
 const Remark = require("remark");
 const toString = require("mdast-util-to-string");
 const visit = require("unist-util-visit");
+const remarkMdx = require("remark-mdx");
 
 const plugin = require("../");
 
-const remark = new Remark().data("settings", {
-  commonmark: true,
-  footnotes: true,
-  pedantic: true,
-});
+const remark = new Remark()
+  .data("settings", {
+    commonmark: true,
+    footnotes: true,
+    pedantic: true,
+  })
+  .use(remarkMdx);
 
-describe("gatsby-plugin-code-tabs", () => {
-  it("folds two code blocks", () => {
+describe("gatsby-plugin-include", () => {
+  it("resolves one import", () => {
     const markdownAST = remark.parse(`
-~~~python
-print "Hello World!"
-~~~
-
-~~~javascript
-console.log("Hello World!");
-~~~
+import "./foo.mdx";
 `);
     const transformed = plugin({ markdownAST }, {});
     expect(transformed).toMatchSnapshot();
   });
 
-  it("does not fold code blocks split by a paragraph", () => {
+  it("resolves two imports", () => {
     const markdownAST = remark.parse(`
-~~~python
-print "Hello World!"
-~~~
+import "./foo.mdx";
 
-some text here:
-
-~~~javascript
-console.log("Hello World!");
-~~~
-`);
-    const transformed = plugin({ markdownAST }, {});
-    expect(transformed).toMatchSnapshot();
-  });
-
-  it("does not fold code blocks on different levels", () => {
-    const markdownAST = remark.parse(`
-1. a list here
-   ~~~plain
-   inside list
-   ~~~
-
-~~~plain
-outside list
-~~~
-`);
-    const transformed = plugin({ markdownAST }, {});
-    expect(transformed).toMatchSnapshot();
-  });
-
-  it("supports tab titles", () => {
-    const markdownAST = remark.parse(`
-~~~plain {tabTitle: Hello}
-first
-~~~
-
-~~~plain {tabTitle: Goodbye}
-second
-~~~
-`);
-    const transformed = plugin({ markdownAST }, {});
-    expect(transformed).toMatchSnapshot();
-  });
-
-  it("supports filenames", () => {
-    const markdownAST = remark.parse(`
-~~~plain {tabTitle: Hello} {filename: hello.txt}
-first
-~~~
-
-~~~plain {tabTitle: Goodbye} {filename: goodbye.txt}
-second
-~~~
+import "./bar.mdx";
 `);
     const transformed = plugin({ markdownAST }, {});
     expect(transformed).toMatchSnapshot();

--- a/plugins/gatsby-plugin-include/index.js
+++ b/plugins/gatsby-plugin-include/index.js
@@ -1,0 +1,42 @@
+const visit = require("unist-util-visit");
+
+module.exports = ({ markdownAST }, {}) => {
+  const imports = {};
+  let idx = 0;
+
+  visit(markdownAST, "import", (node) => {
+    const match = node.value.match(/^\s*import\s"([^"]*\.mdx)"\s*;?\s*$/);
+    let componentName = null;
+    if (match) {
+      const path = match[1];
+      if (imports[path]) {
+        componentName = imports[path].componentName;
+      } else {
+        imports[path] = {
+          componentName: (componentName = `ImportedComponent${idx++}`),
+          position: node.position,
+        };
+      }
+    }
+
+    if (componentName) {
+      node.type = "jsx";
+      node.value = `<${componentName}/>`;
+    }
+  });
+
+  const importList = Object.entries(imports);
+  if (importList.length > 0) {
+    markdownAST.children = importList
+      .map(([path, { componentName, position }]) => {
+        return {
+          type: "import",
+          value: `import ${componentName} from "${path}";`,
+          position,
+        };
+      })
+      .concat(markdownAST.children);
+  }
+
+  return markdownAST;
+};

--- a/plugins/gatsby-plugin-include/package.json
+++ b/plugins/gatsby-plugin-include/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gatsby-plugin-include",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "peerDependencies": {
+    "gatsby": "^2.0.0"
+  },
+  "dependencies": {
+    "unist-util-visit": "^1.4.1"
+  }
+}


### PR DESCRIPTION
Adds a shorthand for mdx imports:

```markdown
import "./foo.mdx"
```

as a shorthand for

```markdown
import Foo from "./foo.mdx"

<Foo/>
```