### PR TITLE
fix: Describe actual supported content-encoding for /store/

### DIFF
--- a/src/docs/sdk/store.mdx
+++ b/src/docs/sdk/store.mdx
@@ -50,15 +50,16 @@ Content-Type: application/json
 
 ## Request Compression
 
-In addition to standard `content-encoding`, this endpoint accepts gzip
-compressed JSON in a base64 wrapper which is detected regardless of the header.
-This allows you to send compressed events in very restrictive environments. Do
-not set a `content-encoding` header in this case. 
+In addition to <Link to="/sdk/overview">`content-encoding` supported by all
+ingestion endpoints</Link>, this endpoint accepts zlib compressed JSON in a
+base64 wrapper which is detected regardless of the header. This allows you to
+send compressed events in very restrictive environments. Do not set a
+`content-encoding` header in this case.
 
 In pseudo code, this maps to:
 
 ```py
-compressed = base64_encode(gzip.compress(payload))
+compressed = base64_encode(zlib.compress(payload))
 ```
 
 ## Size Limits

--- a/src/docs/sdk/store.mdx
+++ b/src/docs/sdk/store.mdx
@@ -50,11 +50,11 @@ Content-Type: application/json
 
 ## Request Compression
 
-In addition to <Link to="/sdk/overview">`content-encoding` supported by all
-ingestion endpoints</Link>, this endpoint accepts zlib compressed JSON in a
-base64 wrapper which is detected regardless of the header. This allows you to
-send compressed events in very restrictive environments. Do not set a
-`content-encoding` header in this case.
+In addition to <Link to="/sdk/overview#request-compression">`content-encoding`
+supported by all ingestion endpoints</Link>, this endpoint accepts zlib
+compressed JSON in a base64 wrapper which is detected regardless of the header.
+This allows you to send compressed events in very restrictive environments. Do
+not set a `content-encoding` header in this case.
 
 In pseudo code, this maps to:
 


### PR DESCRIPTION
Turns out that in Relay and in Sentry we only supported `zlib+base64` (with header).