### PR TITLE
fix: Split up code samples

### DIFF
--- a/src/docs/services/metrics.mdx
+++ b/src/docs/services/metrics.mdx
@@ -24,6 +24,8 @@ Datadog will require you to install the `datadog` package into your Sentry envir
 $ pip install datadog
 ```
 
+<Break/>
+
 ```python
 SENTRY_METRICS_BACKEND = 'sentry.metrics.datadog.DatadogMetricsBackend'
 SENTRY_METRICS_OPTIONS = {
@@ -44,6 +46,8 @@ You must also install the `datadog` Python package into your Sentry environment:
 ```bash
 $ pip install datadog
 ```
+
+</Break>
 
 ```python
 SENTRY_METRICS_BACKEND = 'sentry.metrics.dogstatsd.DogStatsdMetricsBackend'

--- a/src/docs/services/metrics.mdx
+++ b/src/docs/services/metrics.mdx
@@ -24,7 +24,7 @@ Datadog will require you to install the `datadog` package into your Sentry envir
 $ pip install datadog
 ```
 
-<Break/>
+In your `sentry.conf.py`:
 
 ```python
 SENTRY_METRICS_BACKEND = 'sentry.metrics.datadog.DatadogMetricsBackend'
@@ -47,7 +47,7 @@ You must also install the `datadog` Python package into your Sentry environment:
 $ pip install datadog
 ```
 
-</Break>
+In your `sentry.conf.py`:
 
 ```python
 SENTRY_METRICS_BACKEND = 'sentry.metrics.dogstatsd.DogStatsdMetricsBackend'


### PR DESCRIPTION
Our doc builder folds consecutive codeblocks into one codeblock with tabs. This does not make a lot of sense here.