### PR TITLE
feat: Move more development handbook content over

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -41,7 +41,6 @@ const Sidebar = () => (
         <NavLink to="https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md">
           Code of Conduct
         </NavLink>
-        <NavLink to="/environment/">Development Environment</NavLink>
         <NavLink to="/docs/">Documentation Guide</NavLink>
         <NavLink to="/translations/">Translations</NavLink>
         <NavLink to="/code-review/">Code Review</NavLink>
@@ -52,16 +51,28 @@ const Sidebar = () => (
         className="sidebar-title d-flex align-items-center mb-0"
         data-sidebar-link
       >
-        <h6>Understand</h6>
+        <h6>Development</h6>
+      </div>
+      <ul className="list-unstyled" data-sidebar-tree>
+        <NavLink to="/environment/">Development Environment</NavLink>
+        <NavLink to="/continuous-integration/">Continuous Integration</NavLink>
+        <NavLink to="/python-dependencies/">Python Dependencies</NavLink>
+        <NavLink to="/database-migrations/">Database Migrations</NavLink>
+        <NavLink to="/testing/">Testing Tips</NavLink>
+      </ul>
+    </li>
+    <li className="mb-3" data-sidebar-branch>
+      <div
+        className="sidebar-title d-flex align-items-center mb-0"
+        data-sidebar-link
+      >
+        <h6>Application</h6>
       </div>
       <ul className="list-unstyled" data-sidebar-tree>
         <NavLink to="/sentry-vs-getsentry/">sentry vs getsentry</NavLink>
         <NavLink to="/config/">Configuration</NavLink>
         <NavLink to="/feature-flags/">Feature Flags</NavLink>
-        <NavLink to="/python-dependencies/">Python Dependencies</NavLink>
-        <NavLink to="/database-migrations/">Database Migrations</NavLink>
         <NavLink to="/serializers/">Serializers</NavLink>
-        <NavLink to="/testing/">Testing Tips</NavLink>
       </ul>
     </li>
     <li className="mb-3" data-frontend-branch>
@@ -118,7 +129,7 @@ const Sidebar = () => (
         <NavLink to="/sdk/overview/">Overview</NavLink>
         <NavLink to="/sdk/unified-api/" title="Unified API">
           <NavLink to="/sdk/unified-api/tracing">
-          Guideline for AM support
+            Guideline for AM support
           </NavLink>
         </NavLink>
         <NavLink to="/sdk/features/">Expected Features</NavLink>

--- a/src/docs/continuous-integration.mdx
+++ b/src/docs/continuous-integration.mdx
@@ -1,0 +1,76 @@
+---
+title: "Continuous Integration"
+---
+
+Sentry uses a variety of continuous integration services to help ensure we don't
+accidentally break the application.
+
+## Travis CI
+
+Travis CI is our primary CI system and runs our tests on every pull request and
+on merges to master. It is required that tests pass before changes can be
+merged.
+
+### Clearing Travis Cache
+
+The "Delete all repository caches" button does NOT work.
+
+Type the following into your browser devtools console on the [Travis cache page](https://travis-ci.org/getsentry/sentry/caches):
+
+```javascript
+Travis.__registry__._resolveCache['config:environment'].skipConfirmations = true; btns=document.getElementsByClassName("delete-cache-icon"); i=0; while (i<btns.length) { btns[i].click(); i++; }
+```
+
+Or this works too and is prettier:
+
+```javascript
+window.confirm = (m => true); Array.from(document.getElementsByClassName('delete-cache-icon')).map(e => e.click());
+```
+
+## GitHub Actions
+
+We use GitHub Actions to supplement front-end builds and apply automatic style
+fixes. We're also trialing it as a way to run acceptance tests.
+
+## Percy
+
+Percy checks the outputs of acceptance tests and reports on changes in rendered
+results. See the [testing chapter for more information](/testing#percy)
+
+## Freight
+
+Freight is how we deploy our applications to staging & production.
+
+### Reverting / Rolling Back After a Bad Deploy
+
+If you've deployed something bad, you'll need to do the following:
+
+- Deploy the most recently known good commit that succeeded ASAP. Keep an eye on
+  this as deploys MUST finish, otherwise it's possible some web machines will
+  still be stuck on the bad deploy's code.
+- Inform #team-engineering that you're rolling back a bad deploy, and that no
+  one should deploy getsentry master until the issue is resolved.
+- Fix the issue, and get it merged into master.
+- Deploy the fix, and verify that the issue has indeed been fixed.
+- Inform #team-engineering that it is safe to deploy getsentry again.
+
+## Troubleshooting CI
+
+**Problem:**
+
+`ContextualVersionConflict` while installing stuff in Travis CI.
+
+**Solution:**
+
+Purge the travis cache. How? See the FAQ.
+
+---
+
+**Problem:**
+
+When pushing your build to staging and you it fails the `Ensure test image` step on Travis.
+
+**Solution:**
+
+You probably forgot to push your branch on Sentry to GitHub.
+


### PR DESCRIPTION
* Add CI notes and troubleshooting sections over.
* Reorganize sidebar to have a 'development' section covering
  development life-cycle type information.
* Group application feature docs in 'Application' formerly 'understand'.