### PR TITLE
build: upgrade node to match node version in sentry (v10.16.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "volta": {
-    "node": "10.14.2",
+    "node": "10.16.3",
     "yarn": "1.16.0"
   }
 }


### PR DESCRIPTION
Not too keen on downloading another node version to develop, so bump node to match the version I already use for Sentry.

This doesn't break anything locally for me.

Right now, I don't know if this needs to be bumped elsewhere.