### PR TITLE
docs: Add missing make command

### DIFF
--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -200,7 +200,7 @@ did a `ls ~/code` you'd see something like:
 sentry/   getsentry/
 ```
 
-Next, run `make develop` and follow any additional instructions that come up.
+Next, run `make bootstrap` and `make develop` and follow any additional instructions that come up.
 Once you've completed installation you can create start the development server
 with
 


### PR DESCRIPTION
When setting up getsentry you need to run `make bootstrap` prior to  `make develop` you'll receive an error saying the getsentry database doesn't exist.