### PR TITLE
ref: some devenv doc clarifications

### DIFF
--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -201,16 +201,17 @@ sentry/   getsentry/
 ```
 
 Next, run `make bootstrap` and `make develop` and follow any additional instructions that come up.
-Once you've completed installation you can create start the development server
-with
+
+If all went well, then you can start the development server:
 
 ```bash
 getsentry devserver --workers
 ```
 
-Once you've booted the server you'll access the development environment
-via [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/), which will
-allow you to use the appropriate subdomains (app and www).
+Note that you **cannot** have both sentry and getsentry devserver running at the same time.
+
+After the server warms up for a little while, you should be able to access it
+at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/).
 
 You can set your local instance's org to use a business plan by running the
 following in getsentry:

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -178,9 +178,7 @@ If you would like to be able to run `devserver` outside of your root checkout, y
   Only Sentry employees have access to getsentry.
 </Alert>
 
-Now that you have sentry all set up, it's time to set up getsentry. Getsentry is
-the application we deploy to production and contains additional functionality
-only offered in our SaaS offering.
+Now that you have sentry all set up, it's time to set up Getsentry. For information on the distinction between the two, refer to <Link to="/sentry-vs-getsentry/">Sentry vs Getsentry</Link>.
 
 Let's start off by cloning the `getsentry` repository to be adjacent with your
 sentry repository:

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -198,7 +198,9 @@ did a `ls ~/code` you'd see something like:
 sentry/   getsentry/
 ```
 
-Next, run `make bootstrap` and `make develop` and follow any additional instructions that come up.
+Next, <Link to="#virtual-environment">create a virtual environment</Link> just like how you did with Sentry earlier.
+
+Then, run `make bootstrap` and follow any additional instructions that come up.
 
 If all went well, then you can start the development server:
 

--- a/src/docs/sentry-vs-getsentry.mdx
+++ b/src/docs/sentry-vs-getsentry.mdx
@@ -2,8 +2,8 @@
 title: "sentry vs getsentry"
 ---
 
-You'll find numerous references to both `sentry`, the public repository and core of Sentry, and `getsentry`, the proprietary and closed source components used for sentry.io.
+You'll find numerous references to both `sentry`, the public repository and core of Sentry, and `getsentry`, the proprietary and closed source components used for sentry.io. `getsentry` is the application we deploy to production and contains additional functionality only offered in our SaaS offering.
 
-In most cases, the systems operate very similarly with subtle differences. That is, you can often swap the `sentry` CLI for the `getsentry` CLI and they'll behave the same. In other cases we have attempted to call out differences in behavior.
+In most cases, the systems operate very similarly with subtle differences. That is, you can often swap the `sentry` CLI for the `getsentry` CLI and they'll behave the same. In other cases, we have attempted to call out differences in behavior.
 
 If you're not part of the Sentry team, you won't have access to develop on the `getsentry` codebase and you can ignore the related documentation.


### PR DESCRIPTION
@robinrendle Sorry, this is a bit late, but these are nonetheless the changes I said I would make.

Also, I changed instructions for getsentry to only use `make bootstrap` for 1st time setup because there is no reason for this part to be different than sentry setup which is also just `make bootstrap`. That actually doesn't currently work in getsentry, so I'm gonna make those changes: https://github.com/getsentry/getsentry/pull/4111. Which blocks this PR.

And, any opinions on automating virtualenv creation in `make bootstrap` since its a 1st time thing? That'd be some less manual steps.
