### PR TITLE
feat(frontend): Add File naming/structure section

### DIFF
--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -8,6 +8,25 @@ This guide covers how we write frontend code at Sentry, and is specifically focu
 
 The frontend codebase is currently located under `src/sentry/static/sentry/app` in sentry and `static/getsentry` in getsentry. (We intend to align to `static/sentry` in future.)
 
+## Folder & File structure
+
+### File Naming
+
+- Name a file meaningfully, based on the how the module's functions, or classes are used or the application section they are used in.
+- Unless necessary, don't use prefixes or suffixes (ie. `dataScrubbingEditModal`, `dataScrubbingAddModal`) instead favor names like `dataScrubbing/editModal`.
+
+### Using `index.(j|t)?(sx)`
+
+> Having an `index` file in a folder provides a way to implicitly import the main file without specifying it
+
+The use of an index file should comply with the following rules:
+
+- If the folder is created to group components that are used together, and there is an entrypoint component, that uses the components within the grouping (examples, avatar, idBadge). The entrypoint component should be the index file.
+
+- *Don't* use an `index.(j|t)?(sx)` file if the folder contains components used in other parts of the app regardless of the entrypoint file. (ie, actionCreators, panels)
+
+- *Don't* use an index file just to re-export. Prefer importing individual components instead.
+
 ## React
 
 ### Defining React components


### PR DESCRIPTION
According to the outcome of one of our TSC meetings (https://www.notion.so/sentry/93d1ddb057af4a4db67c9b741c5ab495?v=e97ab611c4b54951a6ca3e10e13be16e&p=99c691667f724ad080cb958103a36d54), I am updating this handbook by adding a section on using the index file in a component folder.

This PR also adds best practices when naming a file.