### PR TITLE
fix: event.logger attribute is optional

### DIFF
--- a/src/docs/sdk/event-payloads/index.mdx
+++ b/src/docs/sdk/event-payloads/index.mdx
@@ -48,21 +48,11 @@ import "./properties/event_id.mdx"
   }
   ```
 
-or: 
+or:
 
   ```json
   {
     "timestamp": 1304358096.0
-  }
-  ```
-
-`logger`
-
-: The name of the logger which created the record.
-
-  ```json
-  {
-    "logger": "my.logger.name"
   }
   ```
 
@@ -125,6 +115,16 @@ highly encouraged:
   -   `warning`
   -   `info`
   -   `debug`
+
+`logger`
+
+: The name of the logger which created the record.
+
+  ```json
+  {
+    "logger": "my.logger.name"
+  }
+  ```
 
 `transaction`
 


### PR DESCRIPTION
Depending on platform, the logger is not always available/known. It has been an optional attribute in practice, document it as such.