### PR TITLE
fix: sdk info is actually sdk

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -113,9 +113,9 @@ Envelopes can have a number of headers which are valid in all situations:
   the envelope has all the information necessary to be sent to sentry.  In this
   case the full DSN must be stored in this key.
 
-`sdk_info`
+`sdk`
 
-: *Object, recommended.* This can carry the same payload as the <Link to="/sdk/event-payloads/debugmeta/">`sdk_info` attribute</Link>
+: *Object, recommended.* This can carry the same payload as the <Link to="/sdk/event-payloads/sdk/">`sdk` interface</Link>
   of the `debug_meta` interface in the event payload but can be carried for all events.
   This means that SDK information can be carried for minidumps, session data and other submissions.
 

--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -116,7 +116,7 @@ Envelopes can have a number of headers which are valid in all situations:
 `sdk`
 
 : *Object, recommended.* This can carry the same payload as the <Link to="/sdk/event-payloads/sdk/">`sdk` interface</Link>
-  of the `debug_meta` interface in the event payload but can be carried for all events.
+  in the event payload but can be carried for all events.
   This means that SDK information can be carried for minidumps, session data and other submissions.
 
 ### Items


### PR DESCRIPTION
This is a change to how we want to deal with this sdk meta data.