### PR TITLE
ref(envelope): Update size limits for envelopes and attachments

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -96,7 +96,7 @@ Payload = { * } ;
   attributes.
 - **Items** comprise their own headers and a payload. There can be
   an arbitrary number of **Items** in an Envelope separated by a newline. An
-  implementation should consume Items until the file ends. 
+  implementation should consume Items until the file ends.
 - Envelopes should be terminated with a trailing newline. This newline is
   optional. After the final newline, no whitespace is allowed.
 - Envelopes may be empty, terminating immediately after the headers.
@@ -275,7 +275,7 @@ encoded in JSON.
   payload. Clients are required to generate an event identifier ahead of time
   and set it at least in the Envelope headers. If the identifier mismatches
   between the Envelope and payload, the Envelope header takes precedence.
-  
+
 `sent_at`
 
 : *String, recommended.* The timestamp when the event was sent from the SDK as
@@ -453,9 +453,9 @@ Event ingestion imposes limits on the size and number of Items in Envelopes.
 These limits are subject to future change and defined currently as:
 
 - *20MB* for a compressed Envelope request
-- *50MB* for a full Envelope after decompression
-- *50MB* for all attachments combined
-- *50MB* for each attachment Item
+- *100MB* for a full Envelope after decompression
+- *100MB* for all attachments combined
+- *100MB* for each attachment Item
 - *1MB* for event and transaction Items
 - *100 sessions* per Envelope
 


### PR DESCRIPTION
See https://github.com/getsentry/relay/pull/671