### PR TITLE
ref: environment docs polish

### DIFF
--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -150,11 +150,6 @@ Any time the `.envrc` configuration changes (including the first time) you will 
 
 ## Running the Development Server
 
-<Alert title="Tip!" level="info">
-  If you would like to import an example dataset, running `./bin/load-mocks`
-  will add a few example projects and teams to the main organization.
-</Alert>
-
 Once you’ve successfully stood up your datastore, you can now run the development server:
 
 ```bash

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -126,6 +126,28 @@ The `bootstrap` command does a few things you'll want to know about:
 
 Once this command has finished you'll have Sentry installed in development mode with all its required dependencies.
 
+## direnv
+
+We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
+
+You need to install it, and add the following snippet to the end of your startup script:
+
+```bash {filename: ~/.bashrc}
+eval "$(direnv hook bash)"
+```
+
+```bash {filename: ~/.zshrc} {tabTitle: Zsh}
+eval "$(direnv hook zsh)"
+```
+
+And after doing that, reload your shell:
+
+```bash
+exec "$SHELL"
+```
+
+Any time the `.envrc` configuration changes (including the first time) you will be prompted to run `direnv allow` before any of the configuration will run. This is for security purposes and you are encouraged to inspect the changes before running this command.
+
 ## Running the Development Server
 
 <Alert title="Tip!" level="info">
@@ -149,28 +171,6 @@ If you would like to be able to run `devserver` outside of your root checkout, y
   <em>and</em> port are required in order for DNS and some pages urls to be
   displayed correctly.
 </Alert>
-
-## direnv
-
-We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
-
-You need to install it, and add the following snippet to the end of your startup script:
-
-```bash {filename: ~/.bashrc}
-eval "$(direnv hook bash)"
-```
-
-```bash {filename: ~/.zshrc} {tabTitle: Zsh}
-eval "$(direnv hook zsh)"
-```
-
-And after doing that, reload your shell:
-
-```bash
-exec "$SHELL"
-```
-
-Any time the `.envrc` configuration changes (including the first time) you will be prompted to run `direnv allow` before any of the configuration will run. This is for security purposes and you are encouraged to inspect the changes before running this command.
 
 ## Setting up Getsentry
 

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -114,28 +114,6 @@ node -v
 
 Volta intercepts this and automatically downloads and installs the node version in sentry's `package.json`.
 
-## direnv
-
-We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
-
-You need to install it, and add the following snippet to the end of your startup script:
-
-```bash {filename: ~/.bashrc}
-eval "$(direnv hook bash)"
-```
-
-```bash {filename: ~/.zshrc} {tabTitle: Zsh}
-eval "$(direnv hook zsh)"
-```
-
-And after doing that, reload your shell:
-
-```bash
-exec "$SHELL"
-```
-
-Any time the `.envrc` configuration changes (including the first time) you will be prompted to run `direnv allow` before any of the configuration will run. This is for security purposes and you are encouraged to inspect the changes before running this command.
-
 ## Bootstrap Services
 
 The last step is to run `make bootstrap`. This will take a long time, as it bootstraps not only Sentry and its dependencies, but starts up related services, and runs database migrations.
@@ -171,6 +149,28 @@ If you would like to be able to run `devserver` outside of your root checkout, y
   <em>and</em> port are required in order for DNS and some pages urls to be
   displayed correctly.
 </Alert>
+
+## direnv
+
+We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
+
+You need to install it, and add the following snippet to the end of your startup script:
+
+```bash {filename: ~/.bashrc}
+eval "$(direnv hook bash)"
+```
+
+```bash {filename: ~/.zshrc} {tabTitle: Zsh}
+eval "$(direnv hook zsh)"
+```
+
+And after doing that, reload your shell:
+
+```bash
+exec "$SHELL"
+```
+
+Any time the `.envrc` configuration changes (including the first time) you will be prompted to run `direnv allow` before any of the configuration will run. This is for security purposes and you are encouraged to inspect the changes before running this command.
 
 ## Setting up Getsentry
 

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -116,7 +116,7 @@ Volta intercepts this and automatically downloads and installs the node version 
 
 ## Bootstrap Services
 
-Source your Python environment again (`source .venv/bin/activate`), then run `make bootstrap`. This will take a long time, as it bootstraps not only Sentry and its dependencies, but starts up related services, and runs database migrations.
+Source your virtual environment again (`source .venv/bin/activate`), then run `make bootstrap`. This will take a long time, as it bootstraps not only Sentry and its dependencies, but starts up related services, and runs database migrations.
 
 The `bootstrap` command does a few things you'll want to know about:
 
@@ -128,9 +128,9 @@ Once this command has finished you'll have Sentry installed in development mode 
 
 ## direnv
 
-We use [direnv](https://github.com/direnv/direnv) to automate configuration and constraints. It automatically sets some helpful environment variables for you, activates your virtual environment, and does some simple state checking to guide you towards the expected development environment.
+[direnv](https://github.com/direnv/direnv) _automatically activates your virtual environment_, sets some helpful environment variables for you, and performs some simple checks to make sure your environment is as expected (and tries its best to guide you if it isn't).
 
-You need to install it, and add the following snippet to the end of your startup script:
+First, you should be done bootstrapping. Then, run `brew install direnv` and add the following snippet to the end of your startup script:
 
 ```bash {filename: ~/.bashrc}
 eval "$(direnv hook bash)"

--- a/src/docs/environment.mdx
+++ b/src/docs/environment.mdx
@@ -116,7 +116,7 @@ Volta intercepts this and automatically downloads and installs the node version 
 
 ## Bootstrap Services
 
-The last step is to run `make bootstrap`. This will take a long time, as it bootstraps not only Sentry and its dependencies, but starts up related services, and runs database migrations.
+Source your Python environment again (`source .venv/bin/activate`), then run `make bootstrap`. This will take a long time, as it bootstraps not only Sentry and its dependencies, but starts up related services, and runs database migrations.
 
 The `bootstrap` command does a few things you'll want to know about:
 


### PR DESCRIPTION
Per feedback from helping @cameronmcefee set up from scratch.

Mainly:

- direnv moved to after bootstrap to reduce confusion since we have it check for a bootstrapped environment
  - PR to remove from sentry Brewfile so that it isn't installed in the beginning when `brew bundle` is run: https://github.com/getsentry/sentry/pull/20011
- added tip to manually source before bootstrap since prior steps involve reloading the shell
- bin/load-mocks is broken (has been for many months), so tip was removed (can be resurrected if someone fixes it lol)