### PR TITLE
feat(envelopes): Add a note on backwards compatibility

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -7,6 +7,13 @@ This document defines the Envelope and Item formats used by Sentry for data
 ingestion, forwarding, and offline storage. The target audience of this document
 is Sentry SDK developers and maintainers of the ingestion pipeline.
 
+<Alert title="Backward Compatibility" level="info">
+
+Envelopes require Relay, which has been introduced in **Sentry v20.6.0**.
+Earlier versions of Sentry do not support Envelopes.
+
+</Alert>
+
 *Envelopes* are a data format similar to HTTP form data, comprising common
 *Headers* and a set of *Items* with their own headers and payloads. Envelopes
 are optimized for fast parsing and human readability. They support a combination


### PR DESCRIPTION
Adds a note on the minimum onpremise version required to support envelopes.

---

![image](https://user-images.githubusercontent.com/1433023/88514788-f2248d00-cfea-11ea-8ee6-f86ef662dde1.png)
