### PR TITLE
fix(docs): Add to getsentry troubleshooting

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -209,10 +209,16 @@ Note that you **cannot** have both sentry and getsentry devserver running at the
 After the server warms up for a little while, you should be able to access it
 at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/).
 
+If you see `DoesNotExist: Subscription matching query does not exist` in your dev server,
+run the following in getsentry:
+```bash
+./bin/mock-subscription
+```
+
 You can set your local instance's org to use a business plan by running the
 following in getsentry:
 
-```go
+```bash
 ./bin/mock-subscription <org_slug> --plan mm2_a_500k
 ```
 
@@ -292,4 +298,25 @@ In your sentry virtualenv:
 ```shell
 pip uninstall uwsgi
 pip install --no-cache-dir uwsgi
+```
+
+---
+
+**Problem:** `DoesNotExist: Subscription matching query does not exist`
+
+**Solution:** In getsentry run the following to mock a subscription:
+
+```bash
+./bin/mock-subscription <org_slug>
+```
+
+---
+
+**Problem:** Something like `Error: No such container: sentry_postgres`
+
+**Solution:** Review the [bootstrap services](http://localhost:8000/environment/#bootstrap-services)
+section or spin up Docker services with:
+
+```bash
+sentry devservices up
 ```

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -314,7 +314,7 @@ pip install --no-cache-dir uwsgi
 
 **Problem:** Something like `Error: No such container: sentry_postgres`
 
-**Solution:** Review the [bootstrap services](http://localhost:8000/environment/#bootstrap-services)
+**Solution:** Review the [bootstrap services](/environment/#bootstrap-services)
 section or spin up Docker services with:
 
 ```bash


### PR DESCRIPTION
- adds `mock-subscription` to the getsentry setup docs and troubleshooting section since this is a common question
- updates to getsentry's Makefile are in [#4303](https://github.com/getsentry/getsentry/pull/4303), which adds `mock-subscription` to `make bootstrap` so it is run on initial setup, instead of only `make reset-db`