### PR TITLE
fix: Remove span.sampled from API docs

### DIFF
--- a/src/docs/sdk/event-payloads/properties/sampled.mdx
+++ b/src/docs/sdk/event-payloads/properties/sampled.mdx
@@ -1,9 +1,0 @@
-`sampled`
-
-: _Required_. Determines if the the Span should be sent, if `!== true` it will be sampled and therefore not sent.
-
-  ```json
-  {
-    "sampled": true
-  }
-  ```

--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -23,8 +23,6 @@ import "./properties/trace_id.mdx";
 
 import "./properties/transaction.mdx";
 
-import "./properties/sampled.mdx";
-
 import "./properties/op.mdx";
 
 import "./properties/description.mdx";
@@ -60,7 +58,6 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
 {
   "spans": [
     {
-      "sampled": true,
       "start_timestamp": 1588601261.481961,
       "description": "GET /sockjs-node/info",
       "tags": {
@@ -79,7 +76,6 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
       "span_id": "b01b9f6349558cd1"
     },
     {
-      "sampled": true,
       "start_timestamp": 1588601261.535386,
       "description": "Vue <App>",
       "timestamp": 1588601261.544196,


### PR DESCRIPTION
This was never a proper part of the protocol as understood and implemented in Relay.

The JS SDKs used to send this as a side-effect of how it serialized the internal span representation into JSON.