### PR TITLE
ref(onpremise): Point people to the latest release

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -200,7 +200,7 @@ const Sidebar = () => (
 
       <ul className="list-unstyled" data-sidebar-tree>
         <NavLink to="https://docs.sentry.io">User Documentation</NavLink>
-        <NavLink to="https://github.com/getsentry/onpremise">
+        <NavLink to="https://github.com/getsentry/onpremise/releases/latest">
           Self-Hosting Sentry
         </NavLink>
       </ul>


### PR DESCRIPTION
We used to point people to the homepage of on-premise, advocating for the nightly builds. With this patch, we point them to the latest release.

Rel: https://app.asana.com/0/1169344595888357/1190341230301201/f

/cc @PeloWriter