### PR TITLE
fix: Remove span.transaction from API docs

### DIFF
--- a/src/docs/sdk/event-payloads/properties/status.mdx
+++ b/src/docs/sdk/event-payloads/properties/status.mdx
@@ -1,7 +1,6 @@
 `status`
 
-: _Optional_. Describing the `status` of the Span. We use this property to determine if the [Transaction](/sdk/event-payloads/properties/transaction/)
-ended in an error or not.
+: _Optional_. Describes the `status` of the Span/Transaction.
 
 | State                        | Description                                                                                                  | HTTP status code equivalent |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------- |

--- a/src/docs/sdk/event-payloads/properties/transaction.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction.mdx
@@ -1,9 +1,0 @@
-`transaction`: 
-
-: _Recommended_. In case of a root span, this property is recommended. Set the `transaction` to give your tree of spans a dedicated name. If it's empty we fall back to `<unlabeled transaction>`.
-
-  ```json
-  {
-    "transaction": "/users/detail/:id"
-  }
-  ```

--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -21,8 +21,6 @@ import "./properties/parent_span_id.mdx";
 
 import "./properties/trace_id.mdx";
 
-import "./properties/transaction.mdx";
-
 import "./properties/op.mdx";
 
 import "./properties/description.mdx";


### PR DESCRIPTION
This was never a proper part of the protocol as understood and
implemented in Relay.

The transaction name is sent as a top-level field in the event payload,
it is not part of a span.