### PR TITLE
feat(onpremise): Add on-premise releases documentation

### DIFF
--- a/src/docs/onpremise/releases.mdx
+++ b/src/docs/onpremise/releases.mdx
@@ -1,0 +1,25 @@
+# On-Premise Versions & Releases
+
+![CalVer: YY.MM.MICRO](https://img.shields.io/badge/calver-YY.MM.MICRO-ad6caa.svg)
+
+Sentry on-premise follows a monthly release schedule using the [CalVer](https://calver.org/#scheme) versioning scheme. A new version is released on the [15th of each month](https://github.com/getsentry/onpremise/blob/704e4c3b5b7360080f79bcfbe26583e5a95ae675/.github/workflows/release.yml#L20-L24), and patch releases are done when needed in-between. You can find the [latest release](https://github.com/getsentry/onpremise/releases/latest) over at the [releases section of our onpremise repository](https://github.com/getsentry/onpremise/releases/).
+
+# Upgrading
+
+We strongly recommend upgrading by going through all the versions between your current version and the target version you are upgrading to. That means if you are on version 20.6.0 and want to upgrade to 20.8.0, the recommendation is for you to upgrade to 20.7.0 first and then upgrade to 20.8.0. Skipping versions *may* work, but there will be times that Sentry requires specific a version to be installed first, to ensure essential data migrations before moving forward.
+
+Upgrading is as simple as downloading the latest version of the onpremise repository and running `./install.sh` there. Refer to the <Link to="/onpremise/basics">on-premise basics page</Link> if you need more information about upgrades and configuration.
+
+# Nightly Builds
+
+We provide nightly builds from the [master branch of the onpremise repository](https://github.com/getsentry/onpremise/) for each new commit for [Sentry](https://github.com/getsentry/sentry), and all of the supporting projects:
+
+- [Snuba](https://github.com/getsentry/snuba)
+- [Relay](https://github.com/getsentry/relay)
+- [Symbolicator](https://github.com/getsentry/symbolicator)
+
+These builds are usually stable, but you may occasionally hit a broken version as these versions are not guaranteed to be deployed to [sentry.io](http://sentry.io/) first. There is also no guarantee that you will be able to do a clean upgrade to later versions without losing any data. **Use the nightly builds at your own risk.**
+
+# Why CalVer instead of SemVer?
+
+In short, this is to keep the on-premise version as close to the live version hosted at [sentry.io](http://sentry.io/). There are more details for the curious over at our [blog post announcing the switch](https://blog.sentry.io/2020/06/22/self-hosted-sentry-switching-to-calver).


### PR DESCRIPTION
This is a first pass for on-premise releases without any connection to the new document. We will be adding an on-premise homepage that links to this document.

See https://app.asana.com/0/1169344595888357/1190341230301205/f.
