### PR TITLE
feat: Add list of used ports in sentry dev env

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -106,9 +106,8 @@ const Sidebar = () => (
       </div>
 
       <ul className="list-unstyled" data-sidebar-tree>
-        <NavLink to="/services/devservices/">
-          Service Manager (devservices)
-        </NavLink>
+        <NavLink to="/services/devservices/">Service Manager (devservices)</NavLink>
+        <NavLink to="/services/ports/">Assigned ports</NavLink>
         <NavLink to="/services/queue/">Asynchronous Workers (celery)</NavLink>
         <NavLink to="/services/email/">Email</NavLink>
         <NavLink to="/services/nodestore/">Node Storage</NavLink>

--- a/src/docs/services/ports.mdx
+++ b/src/docs/services/ports.mdx
@@ -19,9 +19,9 @@ The following is a non-exhaustive list of ports used by Sentry services or any d
 | 5432 | Postgres                                   | <Link to="/services/devservices/">Devservice</Link> `postgres` (or perhaps installed via Homebrew in rustier setups)
 | 8000 | <Link to="/environment/">Sentry Dev</Link> | Sentry API + frontend. Webpack listens on this port.
 | 8001 | uWSGI                                      | Starts/stops with `sentry devserver`. Serves the Django app/API. Webpack on 8000 reverse-proxies to this server.
-| 3000 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
+| 7999 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
 | 8000 | [Develop docs][]                           | The website around this document. **Conflicts with Sentry Dev.**
-| 3000 | [User docs][]                              | User-facing documentation. **Conflicts with Relay.**
+| 3000 | [User docs][]                              | User-facing documentation. May conflict with Relay if Relay is run outside of devservices.
 | 9001 | Sentry Dev Styleguide server               | Bound when running `sentry devserver --styleguide`
 | 9000 | `sentry run web`                           | Legacy default port for `sentry run web`, changed to 9001 to avoid conflict with Clickhouse.
 | 9001 | `sentry run web`                           | Barebones frontend without webpack or Relay. <Link to="/environment/">Sentry Dev</Link> is likely better. **Conflicts with Sentry Dev Styleguide server.**

--- a/src/docs/services/ports.mdx
+++ b/src/docs/services/ports.mdx
@@ -1,0 +1,40 @@
+---
+title: "Assigned ports"
+---
+
+The following is a non-exhaustive list of ports used by Sentry services or any dependency of a Sentry service in development setups. It serves two purposes:
+
+* Finding out why a port is used on your work machine and which process to kill to make it free.
+* Finding out which ports are probably safe to assign to new services.
+
+<!-- This table line-wraps pooly, just edit this on a bigger monitor or lower your font size -->
+
+| Port | Service                                    | Description
+|:-----|:-------------------------------------------|:-----------
+| 9000 | Clickhouse                                 | <Link to="/services/devservices/">Devservice</Link> `clickhouse`. Database for Snuba.
+| 8123 | Clickhouse                                 |
+| 9009 | Clickhouse                                 | 
+| 3021 | Symbolicator                               | <Link to="/services/devservices/">Devservice</Link> `symbolicator`. For processing stacktraces.
+| 1218 | [Snuba][]                                  | <Link to="/services/devservices/">Devservice</Link> `snuba`. For searching events.
+| 9092 | Kafka                                      | <Link to="/services/devservices/">Devservice</Link> `kafka`. for relay-sentry communication and optionally for sentry-snuba communication
+| 6379 | Redis                                      | <Link to="/services/devservices/">Devservice</Link> `redis` (or perhaps installed via Homebrew in rustier setups), responsible for caches, relay projectconfigs and Celery queues
+| 5432 | Postgres                                   | <Link to="/services/devservices/">Devservice</Link> `postgres` (or perhaps installed via Homebrew in rustier setups)
+| 8000 | <Link to="/environment/">Sentry Dev</Link> | Sentry API + frontend. Webpack listens on this port.
+| 8001 | uWSGI                                      | Starts/stops with `sentry devserver`. Serves the Django app/API. Webpack on 8000 reverse-proxies to this server.
+| 3000 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
+| 8000 | [Develop docs][]                           | The website around this document. **Conflicts with Sentry Dev.**
+| 3000 | [User docs][]                              | User-facing documentation. **Conflicts with Relay.**
+| 9001 | Sentry Dev Styleguide server               | Bound when running `sentry devserver --styleguide`
+| 9000 | `sentry run web`                           | Legacy default port for `sentry run web`, changed to 9001 to avoid conflict with Clickhouse.
+| 9001 | `sentry run web`                           | Barebones frontend without webpack or Relay. <Link to="/environment/">Sentry Dev</Link> is likely better. **Conflicts with Sentry Dev Styleguide server.**
+| 8000 | [Relay][] mkdocs documentation             | At some point this is going to get merged into our existing docs repos. **Conflicts with Sentry Dev.**
+
+## Finding out what's running on your machine
+
+* Use `lsof -nP -i4 | grep LISTEN` to find occupied ports on macOS.
+* The Dashboard UI of Docker for Mac shows you running docker containers/devservices together with assigned ports and option to start/stop.
+
+[Relay]: https://getsentry.github.io/relay/
+[Snuba]: https://github.com/getsentry/snuba
+[Develop docs]: https://github.com/getsentry/develop/
+[User docs]: https://github.com/getsentry/sentry-docs/

--- a/src/docs/services/ports.mdx
+++ b/src/docs/services/ports.mdx
@@ -7,8 +7,6 @@ The following is a non-exhaustive list of ports used by Sentry services or any d
 * Finding out why a port is used on your work machine and which process to kill to make it free.
 * Finding out which ports are probably safe to assign to new services.
 
-<!-- This table line-wraps pooly, just edit this on a bigger monitor or lower your font size -->
-
 | Port | Service                                    | Description
 |:-----|:-------------------------------------------|:-----------
 | 9000 | Clickhouse                                 | <Link to="/services/devservices/">Devservice</Link> `clickhouse`. Database for Snuba.


### PR DESCRIPTION
Wanted this for a while, with obvious bias towards the services I work on:

* snuba devserver probably listens to more ports if ran outside of docker
* data-team has some services???