### PR TITLE
feat(onpremise): Add a landing page for on-premise

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -78,7 +78,18 @@ const Sidebar = () => (
         <NavLink to="/feature-flags/">Feature Flags</NavLink>
         <NavLink to="/serializers/">Serializers</NavLink>
       </ul>
-    </li>
+      <li className="mb-3" data-sidebar-branch>
+        <div
+          className="sidebar-title d-flex align-items-center mb-0"
+          data-sidebar-link
+        >
+          <h6>Self-Hosting</h6>
+        </div>
+        <ul className="list-unstyled" data-sidebar-tree>
+          <NavLink to="/onpremise/">Overview</NavLink>
+          <NavLink to="/onpremise/releases/">Versioning & Releases</NavLink>
+        </ul>
+      </li>
     <li className="mb-3" data-frontend-branch>
       <div
         className="sidebar-title d-flex align-items-center mb-0"
@@ -200,7 +211,7 @@ const Sidebar = () => (
 
       <ul className="list-unstyled" data-sidebar-tree>
         <NavLink to="https://docs.sentry.io">User Documentation</NavLink>
-        <NavLink to="/onpremise/">Self-Hosting Sentry</NavLink>
+        <NavLink to="https://forum.sentry.io">Community Forum</NavLink>
       </ul>
     </li>
     <li className="mb-3" data-sidebar-branch>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,17 +1,17 @@
-import { withPrefix } from "gatsby";
-import React from "react";
-import { useLocation } from "@reach/router";
+import {withPrefix} from 'gatsby';
+import React from 'react';
+import {useLocation} from '@reach/router';
 
-import SmartLink from "./smartLink";
+import SmartLink from './smartLink';
 
-const NavLink = ({ to, title, children, ...props }) => {
+const NavLink = ({to, title, children, ...props}) => {
   const location = useLocation();
 
-  let className = "toc-item";
+  let className = 'toc-item';
   if (location && location.pathname.indexOf(withPrefix(to)) === 0) {
-    className += " toc-active";
+    className += ' toc-active';
   }
-  className += props.className ? " " + props.className : "";
+  className += props.className ? ' ' + props.className : '';
 
   return (
     <li className={className} data-sidebar-branch>
@@ -106,7 +106,9 @@ const Sidebar = () => (
       </div>
 
       <ul className="list-unstyled" data-sidebar-tree>
-        <NavLink to="/services/devservices/">Service Manager (devservices)</NavLink>
+        <NavLink to="/services/devservices/">
+          Service Manager (devservices)
+        </NavLink>
         <NavLink to="/services/ports/">Assigned ports</NavLink>
         <NavLink to="/services/queue/">Asynchronous Workers (celery)</NavLink>
         <NavLink to="/services/email/">Email</NavLink>
@@ -186,7 +188,6 @@ const Sidebar = () => (
         <NavLink to="/integrations/github/">GitHub</NavLink>
         <NavLink to="/integrations/slack/">Slack</NavLink>
         <NavLink to="/integrations/vercel/">Vercel</NavLink>
-
       </ul>
     </li>
     <li className="mb-3" data-sidebar-branch>
@@ -199,9 +200,7 @@ const Sidebar = () => (
 
       <ul className="list-unstyled" data-sidebar-tree>
         <NavLink to="https://docs.sentry.io">User Documentation</NavLink>
-        <NavLink to="https://github.com/getsentry/onpremise/releases/latest">
-          Self-Hosting Sentry
-        </NavLink>
+        <NavLink to="/onpremise/">Self-Hosting Sentry</NavLink>
       </ul>
     </li>
     <li className="mb-3" data-sidebar-branch>

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -78,18 +78,19 @@ const Sidebar = () => (
         <NavLink to="/feature-flags/">Feature Flags</NavLink>
         <NavLink to="/serializers/">Serializers</NavLink>
       </ul>
-      <li className="mb-3" data-sidebar-branch>
-        <div
-          className="sidebar-title d-flex align-items-center mb-0"
-          data-sidebar-link
-        >
-          <h6>Self-Hosting</h6>
-        </div>
-        <ul className="list-unstyled" data-sidebar-tree>
-          <NavLink to="/onpremise/">Overview</NavLink>
-          <NavLink to="/onpremise/releases/">Versioning & Releases</NavLink>
-        </ul>
-      </li>
+    </li>
+    <li className="mb-3" data-sidebar-branch>
+      <div
+        className="sidebar-title d-flex align-items-center mb-0"
+        data-sidebar-link
+      >
+        <h6>Self-Hosting</h6>
+      </div>
+      <ul className="list-unstyled" data-sidebar-tree>
+        <NavLink to="/onpremise/">Overview</NavLink>
+        <NavLink to="/onpremise/releases/">Versioning & Releases</NavLink>
+      </ul>
+    </li>
     <li className="mb-3" data-frontend-branch>
       <div
         className="sidebar-title d-flex align-items-center mb-0"

--- a/src/docs/onpremise/index.mdx
+++ b/src/docs/onpremise/index.mdx
@@ -8,7 +8,7 @@ In addition to making its source code available publicly, Sentry offers and main
 
 Our recommendation is to download the [latest release of the on-premise repository](https://github.com/getsentry/onpremise/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker-compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
 
-# Configuration
+## Configuration
 
 You are very likely to want to change the default configuration for Sentry. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` even if we ship with a built-in SMTP server for basic stuff. GitHub and Slack integration settings also reside in this file. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
 

--- a/src/docs/onpremise/index.mdx
+++ b/src/docs/onpremise/index.mdx
@@ -4,7 +4,7 @@ title: 'Sentry On-Premise / Self-Hosting'
 
 In addition to making its source code available publicly, Sentry offers and maintains a minimal setup that works out-of-the-box for simple use cases. This repository also serves as a blueprint for how various Sentry services connect for a complete setup, which is useful for folks willing to maintain larger installations. For the sake of simplicity, we have chosen to use [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) for this, along with a bash-based install and upgrade script.
 
-# Getting Started
+## Getting Started
 
 Our recommendation is to download the [latest release of the on-premise repository](https://github.com/getsentry/onpremise/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker-compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
 
@@ -14,7 +14,7 @@ You are very likely to want to change the default configuration for Sentry. Most
 
 **Once you change your configuration, you'll need to restart all Sentry services by running `docker-compose restart web worker cron sentry-cleanup` (or just `docker-compose restart` to restart everything).**
 
-# Troubleshooting
+## Troubleshooting
 
 You can see the logs of each service by running `docker-compose logs <service_name>`. You can use the `-f` flag to "follow" the logs as they come in, and use the `-t` flag for timestamps. If you don't pass any service names, you will get the logs for all running services. See the [reference for the logs command](https://docs.docker.com/compose/reference/logs/) for more info.
 
@@ -22,13 +22,13 @@ If you get stuck, you can always visit our [community forum](https://forum.sent
 
 Sharing your install logs, service logs, and your Sentry version when [reporting an issue](https://github.com/getsentry/onpremise/issues/new/choose) or asking a question on the forums would save time and effort for both you and people trying to help you.
 
-# Productionalizing
+## Productionalizing
 
 We strongly recommend using a dedicated load balancer in front of your Sentry setup bound to a dedicated domain or subdomain. A dedicated load balancer that does SSL/TLS termination that also forwards the client IP address as Docker Compose internal network (as this is [close to impossible to get otherwise)](https://github.com/getsentry/onpremise/issues/554) would give you the best Sentry experience.
 
 Keep in mind that all this setup uses single-nodes for all services, including Kafka. For larger loads, you'd need a beefy machine with lots of RAM and disk storage. To scale up even further, you are very likely to use clusters with a more complex tool, such as Kubernetes. Due to on-premise installations' very custom nature, we do not offer any recommendations or guidance around scaling up. We do what works for us for our thousands of customers over at [sentry.io](https://sentry.io/) and would love to have you over when you feel your local install's maintenance becomes a burden instead of a joy.
 
-# Upgrading
+## Upgrading
 
 Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/onpremise/releases/">on-premise releases page</Link>.
 

--- a/src/docs/onpremise/index.mdx
+++ b/src/docs/onpremise/index.mdx
@@ -1,4 +1,6 @@
-# On-Premise Basics
+---
+title: 'Sentry On-Premise / Self-Hosting'
+---
 
 In addition to making its source code available publicly, Sentry offers and maintains a minimal setup that works out-of-the-box for simple use cases. This repository also serves as a blueprint for how various Sentry services connect for a complete setup, which is useful for folks willing to maintain larger installations. For the sake of simplicity, we have chosen to use [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) for this, along with a bash-based install and upgrade script.
 
@@ -27,6 +29,8 @@ We strongly recommend using a dedicated load balancer in front of your Sentry se
 Keep in mind that all this setup uses single-nodes for all services, including Kafka. For larger loads, you'd need a beefy machine with lots of RAM and disk storage. To scale up even further, you are very likely to use clusters with a more complex tool, such as Kubernetes. Due to on-premise installations' very custom nature, we do not offer any recommendations or guidance around scaling up. We do what works for us for our thousands of customers over at [sentry.io](https://sentry.io/) and would love to have you over when you feel your local install's maintenance becomes a burden instead of a joy.
 
 # Upgrading
+
+Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/onpremise/releases/">on-premise releases page</Link>.
 
 We recommend (and sometimes require) you to upgrade Sentry one version at a time. That means if you are running 20.6.0, instead of going directly to 20.8.0, first go through 20.7.0. Skipping versions would work most of the time, but there will be times that we require you to stop at specific versions to ensure essential data migrations along the way.
 

--- a/src/docs/onpremise/releases.mdx
+++ b/src/docs/onpremise/releases.mdx
@@ -1,16 +1,18 @@
-# On-Premise Versions & Releases
+---
+title: 'On-Premise Versions & Releases'
+---
 
 ![CalVer: YY.MM.MICRO](https://img.shields.io/badge/calver-YY.MM.MICRO-ad6caa.svg)
 
 Sentry on-premise follows a monthly release schedule using the [CalVer](https://calver.org/#scheme) versioning scheme. A new version is released on the [15th of each month](https://github.com/getsentry/onpremise/blob/704e4c3b5b7360080f79bcfbe26583e5a95ae675/.github/workflows/release.yml#L20-L24), and patch releases are done when needed in-between. You can find the [latest release](https://github.com/getsentry/onpremise/releases/latest) over at the [releases section of our onpremise repository](https://github.com/getsentry/onpremise/releases/).
 
-# Upgrading
+## Upgrading
 
 We strongly recommend upgrading by going through all the versions between your current version and the target version you are upgrading to. That means if you are on version 20.6.0 and want to upgrade to 20.8.0, the recommendation is for you to upgrade to 20.7.0 first and then upgrade to 20.8.0. Skipping versions *may* work, but there will be times that Sentry requires specific a version to be installed first, to ensure essential data migrations before moving forward.
 
 Upgrading is as simple as downloading the latest version of the onpremise repository and running `./install.sh` there. See the <Link to="/onpremise/">main on-premise page</Link> if you need more information about upgrades and configuration.
 
-# Nightly Builds
+## Nightly Builds
 
 We provide nightly builds from the [master branch of the onpremise repository](https://github.com/getsentry/onpremise/) for each new commit for [Sentry](https://github.com/getsentry/sentry), and all of the supporting projects:
 
@@ -20,6 +22,6 @@ We provide nightly builds from the [master branch of the onpremise repository](
 
 These builds are usually stable, but you may occasionally hit a broken version as these versions are not guaranteed to be deployed to [sentry.io](http://sentry.io/) first. There is also no guarantee that you will be able to do a clean upgrade to later versions without losing any data. **Use the nightly builds at your own risk.**
 
-# Why CalVer instead of SemVer?
+## Why CalVer instead of SemVer?
 
 In short, this is to keep the on-premise version as close to the live version hosted at [sentry.io](http://sentry.io/). There are more details for the curious over at our [blog post announcing the switch](https://blog.sentry.io/2020/06/22/self-hosted-sentry-switching-to-calver).

--- a/src/docs/onpremise/releases.mdx
+++ b/src/docs/onpremise/releases.mdx
@@ -8,7 +8,7 @@ Sentry on-premise follows a monthly release schedule using the [CalVer](https:/
 
 We strongly recommend upgrading by going through all the versions between your current version and the target version you are upgrading to. That means if you are on version 20.6.0 and want to upgrade to 20.8.0, the recommendation is for you to upgrade to 20.7.0 first and then upgrade to 20.8.0. Skipping versions *may* work, but there will be times that Sentry requires specific a version to be installed first, to ensure essential data migrations before moving forward.
 
-Upgrading is as simple as downloading the latest version of the onpremise repository and running `./install.sh` there. Refer to the <Link to="/onpremise/basics">on-premise basics page</Link> if you need more information about upgrades and configuration.
+Upgrading is as simple as downloading the latest version of the onpremise repository and running `./install.sh` there. See the <Link to="/onpremise/">main on-premise page</Link> if you need more information about upgrades and configuration.
 
 # Nightly Builds
 


### PR DESCRIPTION
This converts the onpremise/basics page into a landing page for on-premise.

See https://app.asana.com/0/1169344595888357/1191462835804799/f
