### PR TITLE
ref(services): Update/resolve relay port conflict

### DIFF
--- a/src/docs/services/ports.mdx
+++ b/src/docs/services/ports.mdx
@@ -20,7 +20,7 @@ The following is a non-exhaustive list of ports used by Sentry services or any d
 | 7899 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
 | 8000 | <Link to="/environment/">Sentry Dev</Link> | Sentry API + frontend. Webpack listens on this port and proxies API requests Django app
 | 8001 | uWSGI                                      | Starts/stops with `sentry devserver`. Serves the Django app/API. Webpack on 8000 reverse-proxies to this server.
-| 7999 | Sentry frontend prod proxy                 | **For testing local UI changes against a prod API
+| 7999 | Sentry frontend prod proxy                 | For testing local UI changes against a prod API
 | 8000 | [Develop docs][]                           | The website around this document. **Conflicts with Sentry Dev.**
 | 3000 | [User docs][]                              | User-facing documentation. May conflict with Relay if Relay is run outside of devservices.
 | 9001 | Sentry Dev Styleguide server               | Bound when running `sentry devserver --styleguide`

--- a/src/docs/services/ports.mdx
+++ b/src/docs/services/ports.mdx
@@ -17,16 +17,16 @@ The following is a non-exhaustive list of ports used by Sentry services or any d
 | 9092 | Kafka                                      | <Link to="/services/devservices/">Devservice</Link> `kafka`. for relay-sentry communication and optionally for sentry-snuba communication
 | 6379 | Redis                                      | <Link to="/services/devservices/">Devservice</Link> `redis` (or perhaps installed via Homebrew in rustier setups), responsible for caches, relay projectconfigs and Celery queues
 | 5432 | Postgres                                   | <Link to="/services/devservices/">Devservice</Link> `postgres` (or perhaps installed via Homebrew in rustier setups)
-| 8000 | <Link to="/environment/">Sentry Dev</Link> | Sentry API + frontend. Webpack listens on this port.
+| 7899 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
+| 8000 | <Link to="/environment/">Sentry Dev</Link> | Sentry API + frontend. Webpack listens on this port and proxies API requests Django app
 | 8001 | uWSGI                                      | Starts/stops with `sentry devserver`. Serves the Django app/API. Webpack on 8000 reverse-proxies to this server.
-| 7999 | [Relay][]                                  | <Link to="/services/devservices/">Devservice</Link> `relay`. Serves APIs for SDKs to send events to (aka event ingestion). Webpack on 8000 reverse-proxies to this server. Starts/stops with `sentry devserver`.
+| 7999 | Sentry frontend prod proxy                 | **For testing local UI changes against a prod API
 | 8000 | [Develop docs][]                           | The website around this document. **Conflicts with Sentry Dev.**
 | 3000 | [User docs][]                              | User-facing documentation. May conflict with Relay if Relay is run outside of devservices.
 | 9001 | Sentry Dev Styleguide server               | Bound when running `sentry devserver --styleguide`
 | 9000 | `sentry run web`                           | Legacy default port for `sentry run web`, changed to 9001 to avoid conflict with Clickhouse.
 | 9001 | `sentry run web`                           | Barebones frontend without webpack or Relay. <Link to="/environment/">Sentry Dev</Link> is likely better. **Conflicts with Sentry Dev Styleguide server.**
 | 8000 | [Relay][] mkdocs documentation             | At some point this is going to get merged into our existing docs repos. **Conflicts with Sentry Dev.**
-| 7999 | Sentry frontend prod proxy                 | **Conflicts with Relay.**
 
 ## Finding out what's running on your machine
 


### PR DESCRIPTION
This updates and resolves the relay port conflict. See https://github.com/getsentry/sentry/pull/20668