### PR TITLE
fix(envelopes): Require filename item headers

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -354,6 +354,10 @@ file. It is always associated to an event or transaction.
 
 **Additional Item Headers:**
 
+`filename`
+
+: **String, required.**  The name of the uploaded file without a path component.
+
 `attachment_type`
 
 : *String, optional.* The special type of this attachment. Possible values are:
@@ -373,10 +377,6 @@ file. It is always associated to an event or transaction.
 
 : *String, optional.* The content type of the attachment payload. Defaults to
   `application/octet-stream`.
-
-`filename`
-
-: *String, optional.* The name of the uploaded file without a path component.
 
 ### Session
 


### PR DESCRIPTION
The filename for attachment items is required, as the attachment can otherwise
not be persisted properly. This was enforced in the Minidump multipart upload
endpoint, but not when ingesting Envelopes.

There will be an additional fix in Relay to default the name if it is missing,
but it is required, regardless.

---

![image](https://user-images.githubusercontent.com/1433023/92936581-8ab38700-f44a-11ea-8afc-ab45fdc34e09.png)
