### PR TITLE
feat(devenv): Describe Rust requirements

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -19,11 +19,26 @@ You're going to be working out of this repository for the remainder of the setup
 
 You'll need to first install Xcode cli tools. (If you try running `git` or `make`, you'll get an xcrun error. Run `xcode-select --install` and follow the instructions.
 
-Once you have Xcode installed, install [Homebrew](http://brew.sh), and then run `brew bundle --verbose` to install the various system packages as listed in sentry's `Brewfile`. 
+Once you have Xcode installed, install [Homebrew](http://brew.sh), and then run `brew bundle --verbose` to install the various system packages as listed in sentry's `Brewfile`.
 
 One thing that requires manual attention is `docker`, which should have just been installed. Open up Spotlight, search for "Docker" and start it. You should soon see the docker icon in your macOS menubar. Docker will automatically run on system restarts, so this should be the only time you do this.
 
 You can verify that Docker is running by running `docker ps` in your terminal. If it doesn't error with something like `Error response from daemon: dial unix docker.raw.sock: connect: connection refused`, you're good to continue.
+
+## Build Toolchain
+
+Sentry depends on [Python Wheels](https://pythonwheels.com/), packages containing binary extension modules. We distribute these wheels for the following platforms:
+
+- Linux compatible with [PEP-513](https://www.python.org/dev/peps/pep-0513/) (`manylinux1`)
+- macOS 10.15.0 or newer
+
+If your development machine does not run one of the above systems, you need to install the Rust toolchain. Follow the instructions at [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install) to install the compiler and related tools. Once installed, the Sentry setup will automatically use Rust to build all binary modules without additional configuration.
+
+We generally track the latest stable Rust version, which updates every six weeks. Therefore, ensure to keep your Rust toolchain up to date by occasionally running:
+
+```bash
+rustup update stable
+```
 
 ## Python
 
@@ -37,7 +52,7 @@ If you're using bash, make sure your `~/.bash_profile` contains the following:
 
 ```bash {filename: ~/.bash_profile}
 source ~/.bashrc
-````
+```
 
 Configure your shell to load pyenv:
 


### PR DESCRIPTION
With moving to GHA, our wheels can only build on 10.15+, which means older systems (and Windows) need a Rust compiler.