### PR TITLE
Add: note about stack frame order

### DIFF
--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -24,6 +24,11 @@ follow this rule of thumb:
 : **Required**. A non-empty list of stack frames (see below). The list is
   ordered from caller to callee, or oldest to youngest. The last frame is the
   one creating the exception.
+  <Note>
+  <markdown>
+  Note: The stack frame order lists the oldest frame to the most recent (where the exception happened).
+  </markdown>
+  </Note>
 
 `registers`
 

--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -24,10 +24,11 @@ follow this rule of thumb:
 : **Required**. A non-empty list of stack frames (see below). The list is
   ordered from caller to callee, or oldest to youngest. The last frame is the
   one creating the exception.
+  
   <Note>
-  <markdown>
-  Note: The stack frame order lists the oldest frame to the most recent (where the exception happened).
-  </markdown>
+    <markdown>
+      Note: The stack frame order lists the oldest frame to the most recent (where the exception happened).
+    </markdown>
   </Note>
 
 `registers`


### PR DESCRIPTION
Customers are writing in about the stack frame order and an added note might help with that communication. There's another sentence about stack framer order in the introductory paragraph, but perhaps that gets overlooked. 