### PR TITLE
fix(typos): Fix typo and off-by-one error on code samples

### DIFF
--- a/src/docs/docs-components.mdx
+++ b/src/docs/docs-components.mdx
@@ -9,7 +9,7 @@ MDX setups.  To see how they are used have a look at the source of this page.
 ## Code Tabs
 
 Sibling code blocks are automatically merged into a block with tabs to switch
-between them.  To prevent two adjacent code blocks to merge separate them with
+between them.  To prevent two adjacent code blocks from merging, separate them with
 the `<Break/>` component.
 
 Example of two code blocks merged:
@@ -77,6 +77,7 @@ Code without title:
 nolang all alone
 ```
 
+```
 ```
 
 No language combined with Python:


### PR DESCRIPTION
We missed closing one of the code blocks.