### PR TITLE
fix: Change Message.formatted to optional

### DIFF
--- a/src/docs/sdk/event-payloads/message.mdx
+++ b/src/docs/sdk/event-payloads/message.mdx
@@ -11,7 +11,7 @@ help to group similar messages into the same issue.
 
 `formatted`
 
-: **Required**. The fully formatted message. If missing, Sentry will try to
+: _Optional_. The fully formatted message. If missing, Sentry will try to
   interpolate the message.
   
   It must not exceed 8192 characters. Longer messages will be truncated.
@@ -24,7 +24,7 @@ help to group similar messages into the same issue.
 
 `params`
 
-: _Optional_: A list of formatting parameters, preferably strings. Non-strings
+: _Optional_. A list of formatting parameters, preferably strings. Non-strings
   will be coerced to strings.
 
 


### PR DESCRIPTION
The formatted attribute of the Message for the EventPayload is not required. The comment states
that if it is missing, Sentry will try to interpolate the message. Furthermore, Sentry accepts an empty
formatted attribute.