### PR TITLE
fix: Add info on Message.formatted

### DIFF
--- a/src/docs/sdk/event-payloads/message.mdx
+++ b/src/docs/sdk/event-payloads/message.mdx
@@ -15,7 +15,7 @@ help to group similar messages into the same issue.
   interpolate the message.
   
   It must not exceed 8192 characters. Longer messages will be truncated. Sentry
-  aslo accepts a message where this is not set to support legacy SDKs.
+  also accepts a message where this is not set to support legacy SDKs.
 
 `message`
 

--- a/src/docs/sdk/event-payloads/message.mdx
+++ b/src/docs/sdk/event-payloads/message.mdx
@@ -14,7 +14,8 @@ help to group similar messages into the same issue.
 : **Required**. The fully formatted message. If missing, Sentry will try to
   interpolate the message.
   
-  It must not exceed 8192 characters. Longer messages will be truncated.
+  It must not exceed 8192 characters. Longer messages will be truncated. Sentry
+  aslo accepts a message where this is not set to support legacy SDKs.
 
 `message`
 


### PR DESCRIPTION
Add info that Sentry accepts events where message.formatted is empty to support
legacy SDKs.