### PR TITLE
fix(api-docs): Update sentry-docs SHA location

### DIFF
--- a/src/docs/docs/api.mdx
+++ b/src/docs/docs/api.mdx
@@ -73,7 +73,7 @@ We use [Open API Spec 3](https://swagger.io/docs/specification/about/) to write 
 Once you make changes to an endpoint and merge the change into Sentry, a Github Action will update the schema in [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) with a build version. To make your changes go live:
 
 1. Get the latest SHA from [sentry-api-schema](https://github.com/getsentry/sentry-api-schema/commits/main).
-2. Go to sentry-docs and update the SHA ([https://github.com/getsentry/sentry-docs/blob/bf5a9463df40bf6e99685f14451c6e1313898b36/src/gatsby/config.ts#L187](https://github.com/getsentry/sentry-docs/blob/bf5a9463df40bf6e99685f14451c6e1313898b36/src/gatsby/config.ts#L187)).
+2. Go to sentry-docs and update the SHA ([https://github.com/getsentry/sentry-docs/blob/9e62a559fba15ecc0f08f3f10336df518eaf9ee0/src/gatsby/utils/resolveOpenAPI.ts#L21](https://github.com/getsentry/sentry-docs/blob/9e62a559fba15ecc0f08f3f10336df518eaf9ee0/src/gatsby/utils/resolveOpenAPI.ts#L21)).
 
 ### Requesting an API to be public
 


### PR DESCRIPTION
We've changed the location of where the SHA is put. So, update the docs.