### PR TITLE
feat(GitLab): Add on prem user docs

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -212,6 +212,7 @@ const Sidebar = () => (
         <NavLink to="/integrations/slack/">Slack</NavLink>
         <NavLink to="/integrations/vercel/">Vercel</NavLink>
         <NavLink to="/integrations/msteams/">Microsoft Teams</NavLink>
+        <NavLink to="/integrations/gitlab/">GitLab</NavLink>
       </ul>
     </li>
     <li className="mb-3" data-sidebar-branch>

--- a/src/docs/integrations/gitlab.mdx
+++ b/src/docs/integrations/gitlab.mdx
@@ -1,0 +1,19 @@
+---
+title: "GitLab Integration"
+---
+
+## Create a GitLab App
+
+To use the GitLab integration you'll need to create an OAuth app in GitLab. To start, visit [Applications](https://gitlab.com/oauth/applications/). 
+
+When configuring the app, use the following values:
+
+| Setting                         | Value                                         |
+| ------------------------------- | --------------------------------------------- |
+| Name                            | Sentry                                        |
+| Redirect URI                    | `{YOUR_DOMAIN}/extensions/gitlab/setup/`      |
+| Scopes                          | api                                           |
+
+Take note of your application ID and secret as you'll need it in the next step. 
+
+Follow our [documentation on installing and configuring the GitLab integration](https://docs.sentry.io/workflow/integrations/gitlab/) to use the integration. 

--- a/src/docs/integrations/gitlab.mdx
+++ b/src/docs/integrations/gitlab.mdx
@@ -16,4 +16,4 @@ When configuring the app, use the following values:
 
 Take note of your application ID and secret as you'll need it in the next step. 
 
-Follow our [documentation on installing and configuring the GitLab integration](https://docs.sentry.io/workflow/integrations/gitlab/) to use the integration. 
+Follow our [documentation on installing and configuring the GitLab integration](https://docs.sentry.io/workflow/integrations/gitlab/) to finish installation and use the integration. 

--- a/src/docs/integrations/index.mdx
+++ b/src/docs/integrations/index.mdx
@@ -8,3 +8,4 @@ TODO: Describe the difference between integration/plugin generations.
 - [Slack](/integrations/slack/)
 - [Vercel](/integrations/vercel/)
 - [Microsoft Teams](/integrations/msteams/)
+- [GitLab](/integrations/gitlab/)


### PR DESCRIPTION
This PR adds GitLab setup instructions - however it's the same as installing GitLab on SaaS so I just followed the format for creating the app as we have for other local integrations and then link to the setup docs on SaaS. 

![Screen Shot 2020-10-19 at 5 28 44 PM](https://user-images.githubusercontent.com/29959063/96525735-9a37a400-1230-11eb-9ac8-116ab864ec4a.png)
