### PR TITLE
feat(envelope): Change user report to user feedback

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -400,14 +400,37 @@ update to an existing session for Release Health.
 
 *None*
 
-### UserReport
+### User Feedback
 
-Item type `"user_report"`. This Item contains a user report JSON payload.
+User Feedback was called User Report in the beginning. Therefore the envelope item type is `"user_report"`. 
+The item contains a user feedback / user report JSON payload:
+```json
+{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","email":"john@me.com","name":"John Me","comments":"It broke."}\n
+```
+
+**Attributes**
+
+`event_id`
+
+: **UUID String, required.** The identifier of the event or transaction.
+
+
+`email`
+
+: *String, recommended.* The email of the user.
+
+`name`
+
+: *String, recommended.* The name of the user.
+
+`comments`
+
+: *String, recommended.* Comments of the user about what happened. 
 
 **Constraints:**
 
 - This Item may occur once per Envelope.
-- User Reports can be ingested separately from their events. We recommended to
+- User Feedbacks / Reports can be ingested separately from their events. We recommended to
   send them in the same Envelope.
 
 **Envelope Headers:**


### PR DESCRIPTION
The user facing wording of user report is now user feedback on Sentry. When implementing
user feedback on SDKs you have to impliclictly know that user feedback was once called user
report. Therefore UserReport is now renamed to User Feedback for the envelopes so devs can
find it quickly. Furthermore, information about the JSON of the envelope item is added.