### PR TITLE
Fix length header with UTF8 content

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -193,7 +193,7 @@ payload which is included in `length`:
 
 ```
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}\n
-{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}\n
+{"type":"attachment","length":13,"content_type":"text/plain","filename":"hello.txt"}\n
 \xef\xbb\xbfHello\r\n\n
 {"type":"event","length":41,"content_type":"application/json","filename":"application.log"}\n
 {"message":"hello world","level":"error"}\n
@@ -206,7 +206,7 @@ payload which is included in `length`:
 
 ```
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}\n
-{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}\n
+{"type":"attachment","length":14,"content_type":"text/plain","filename":"hello.txt"}\n
 \xef\xbb\xbfHello\r\n\n
 {"type":"event","length":41,"content_type":"application/json","filename":"application.log"}\n
 {"message":"hello world","level":"error"}

--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -193,7 +193,7 @@ payload which is included in `length`:
 
 ```
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}\n
-{"type":"attachment","length":13,"content_type":"text/plain","filename":"hello.txt"}\n
+{"type":"attachment","length":14,"content_type":"text/plain","filename":"hello.txt"}\n
 \xef\xbb\xbfHello\r\n\n
 {"type":"event","length":41,"content_type":"application/json","filename":"application.log"}\n
 {"message":"hello world","level":"error"}\n


### PR DESCRIPTION
"\xef\xbb\xbfHello\r\n\n" has length of 11 as a string (or 10 if you don't count the last \n), but is actually 14 (or 13) bytes in UTF8