### PR TITLE
fix: Fix the wording on the `synthetic` flag

### DIFF
--- a/src/docs/sdk/event-payloads/exception.mdx
+++ b/src/docs/sdk/event-payloads/exception.mdx
@@ -82,14 +82,14 @@ with error parameters.
 
 `synthetic`
 
-: An optional falg indicating that this error is synthetic.  Synthetic errors
-are errors that carry little meaning by themselves because for instance they
-are created at a central place (for instance a crash handler) and are all
-called the same "Error", "Segfault" etc.  When the flag is set then Sentry will
+: An optional flag indicating that this error is synthetic. Synthetic errors
+are errors that carry little meaning by themselves. This may be because they
+are created at a central place (like a crash handler), and are all
+called the same: `Error`, `Segfault` etc. When the flag is set, Sentry will then
 try to use other information (top in-app frame function) rather than exception
-type and value in the UI for the primary event display.  For instance this is
-to be set for all "segfaults" for instance as otherwise every single error
-group would look very similar.
+type and value in the UI for the primary event display. This flag should be set
+for all "segfaults" for instance as every single error group would look very
+similar otherwise.
 
 `meta`
 


### PR DESCRIPTION
Cleared up the wording a bit while fixing the glaring typo 😀 