### PR TITLE
feat(bitbucket) Add on prem user docs

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -250,6 +250,7 @@ export default () => {
           <SidebarLink to="/integrations/vercel/">Vercel</SidebarLink>
           <SidebarLink to="/integrations/msteams/">Microsoft Teams</SidebarLink>
           <SidebarLink to="/integrations/gitlab/">GitLab</SidebarLink>
+          <SidebarLink to="/integrations/bitbucket/">Bitbucket</SidebarLink>
         </ul>
       </li>
       <li className="mb-3" data-sidebar-branch>

--- a/src/docs/integrations/bitbucket.mdx
+++ b/src/docs/integrations/bitbucket.mdx
@@ -4,7 +4,7 @@ title: "Bitbucket Integration"
 
 Ensure [developer mode](https://support.atlassian.com/bitbucket-cloud/docs/enable-bitbucket-cloud-development-mode/) is enabled in your Atlassian account.
 
-Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the subdomain option on port 8000.
+Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the [subdomain option](https://ngrok.com/docs#http-subdomain).
 
 In Sentry navigate to **Settings > Integrations > Bitbucket**. Click "Add Installation". 
 

--- a/src/docs/integrations/bitbucket.mdx
+++ b/src/docs/integrations/bitbucket.mdx
@@ -1,0 +1,13 @@
+---
+title: "Bitbucket Integration"
+---
+
+Ensure [developer mode](https://support.atlassian.com/bitbucket-cloud/docs/enable-bitbucket-cloud-development-mode/) is enabled in your Atlassian account.
+
+Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the subdomain option on port 8000.
+
+In Sentry navigate to **Settings > Integrations > Bitbucket**. Click "Add Installation". 
+
+In the resulting modal, select your Bitbucket workspace and then click "Install from URL". Paste in the app descriptor as `https://{YOUR_SUBDOMAIN}.ngrok.io/extensions/bitbucket/descriptor/`
+
+Follow our [documentation on configuring the Bitbucket integration](https://docs.sentry.io/product/integrations/bitbucket/#configure) to use the integration. 

--- a/src/docs/integrations/bitbucket.mdx
+++ b/src/docs/integrations/bitbucket.mdx
@@ -4,7 +4,9 @@ title: "Bitbucket Integration"
 
 Ensure [developer mode](https://support.atlassian.com/bitbucket-cloud/docs/enable-bitbucket-cloud-development-mode/) is enabled in your Atlassian account.
 
-Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the [subdomain option](https://ngrok.com/docs#http-subdomain).
+Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the [subdomain option](https://ngrok.com/docs#http-subdomain), for example: 
+
+`./ngrok http -subdomain={YOUR_SUBDOMAIN} 8000`
 
 In Sentry navigate to **Settings > Integrations > Bitbucket**. Click "Add Installation". 
 

--- a/src/docs/integrations/index.mdx
+++ b/src/docs/integrations/index.mdx
@@ -9,3 +9,4 @@ TODO: Describe the difference between integration/plugin generations.
 - [Vercel](/integrations/vercel/)
 - [Microsoft Teams](/integrations/msteams/)
 - [GitLab](/integrations/gitlab/)
+- [Bitbucket](/integrations/bitbucket/)


### PR DESCRIPTION
Add instructions for how to use Bitbucket when running Sentry on prem. 

![Screen Shot 2020-11-02 at 3 24 54 PM](https://user-images.githubusercontent.com/29959063/97930165-a129e080-1d1f-11eb-990b-383fc6f19bb8.png)
