### PR TITLE
call sentryTrace instead of Tracecontext

### DIFF
--- a/src/docs/sdk/unified-api/tracing.mdx
+++ b/src/docs/sdk/unified-api/tracing.mdx
@@ -62,8 +62,8 @@ tree as well as the unit of reporting to Sentry.
   - When a `Span` is created, set the `startTimestamp` to the current time
   - `SpanContext` is the attribute collection for a `Span` (Can be an implementation detail)
   - `Span` should have a method `startChild` which creates a new span with the current span's id as the new span's `parentSpanId` and the current span's `sampled` value copied over to the new span's `sampled` property
-  - `Span` should have a method called `toTraceparent` which returns a string `sentry-trace` that could be sent as a header
-  - Similar `SpanContext` should have a static method called `fromTraceparent` which prefills a `SpanContext` with data received from a `sentry-trace` string
+  - `Span` should have a method called `toSentryTrace` which returns a string `sentry-trace` that could be sent as a header
+  - Similar `SpanContext` should have a static method called `fromSentryTrace` which prefills a `SpanContext` with data received from a `sentry-trace` string
 
 - `Transaction` Interface
 


### PR DESCRIPTION
This document says:

> To avoid confusion with the W3C `traceparent` header (to which our header is similar but not identical), we call it simply `sentry-trace`.
No version is being defined in the header.

To avoid further confusion, let's name the function that parses/creates `sentry-trace`:
`toSentryTrace` and `fromSentryTrace`.