### PR TITLE
feat: Update documentation about Storybook

### DIFF
--- a/src/docs/frontend/storybook.mdx
+++ b/src/docs/frontend/storybook.mdx
@@ -20,16 +20,4 @@ getsentry/sentry repository.
 
 ## Is it deployed somewhere?
 
-Sentry’s Storybook is built as a Travis job and deployed to a private Google
-Cloud Storage bucket. If your git branch has been tested by Travis, is also has
-had its Storybook uploaded.
-
-You can find all uploaded branches here: [http://storybook.getsentry.net/branches/](http://storybook.getsentry.net/branches/)
-
-For convenience, you will be redirected to the master branch when
-visiting [http://storybook.getsentry.net/](http://storybook.getsentry.net/)
-
-One thing to keep in mind: branch names are preprocessed before assets uploading
-in order to get rid of slashes and other special characters. For example,
-branch `feature/hello#,123` will be deployed
-to [http://storybook.getsentry.net/branches/feature-hello123](http://storybook.getsentry.net/branches/feature-hello123)
+[Sentry’s Storybook](https://storybook.sentry.dev/) is built and deployed using [Vercel](https://vercel.com/). Each Pull Request will have its own deployment and each push to the main branch will be deployed to [https://storybook.sentry.dev](https://storybook.sentry.dev).


### PR DESCRIPTION
We have removed the GCS bucket where it was previously deployed and have migrated to Vercel.