### PR TITLE
Update overview.mdx

### DIFF
--- a/src/docs/sdk/overview.mdx
+++ b/src/docs/sdk/overview.mdx
@@ -126,7 +126,6 @@ You should parse the following settings:
 
 -   URI = `https://sentry.example.com`
 -   Public Key = `public`
--   Secret Key = `secret`
 -   Project ID = `1`
 
 The resulting POST request for a plain JSON payload would then transmit to:


### PR DESCRIPTION
Removed `Secret Key` from L129, as it was absent in the example dsn above