### PR TITLE
ref(navigation): made Environment first item in nav

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -53,12 +53,12 @@ export default () => {
           <h6>Development</h6>
         </div>
         <ul className="list-unstyled" data-sidebar-tree>
-          <SidebarLink to="/workflow/">Workflow</SidebarLink>
           <SidebarLink to="/environment/" title="Environment">
             <Children
               tree={tree.find(n => n.name === "environment").children}
             />
           </SidebarLink>
+          <SidebarLink to="/workflow/">Workflow</SidebarLink>
           <SidebarLink to="/continuous-integration/">
             Continuous Integration
           </SidebarLink>


### PR DESCRIPTION
I just had to setup my local env and was confused as to why `Workflow` is the first item in this list — it should be `Environment` because it’s more important when getting started. And generally less confusing.

## Before

<img width="261" alt="Screen Shot 2020-11-08 at 7 28 29 PM" src="https://user-images.githubusercontent.com/1900676/98507295-2460a000-2212-11eb-98d7-10dfcc075d94.png">


## After
![Screen Shot 2020-11-08 at 10 21 35 PM](https://user-images.githubusercontent.com/1900676/98507311-2c204480-2212-11eb-82fb-174a9f6603d0.png)
