### PR TITLE
feat(azure devops): Add on prem user docs

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -245,12 +245,13 @@ export default () => {
 
         <ul className="list-unstyled" data-sidebar-tree>
           <SidebarLink to="/integrations/">Overview</SidebarLink>
+          <SidebarLink to="/integrations/azuredevops/">Azure DevOps</SidebarLink>
+          <SidebarLink to="/integrations/bitbucket/">Bitbucket</SidebarLink>
           <SidebarLink to="/integrations/github/">GitHub</SidebarLink>
+          <SidebarLink to="/integrations/gitlab/">GitLab</SidebarLink>
+          <SidebarLink to="/integrations/msteams/">Microsoft Teams</SidebarLink>
           <SidebarLink to="/integrations/slack/">Slack</SidebarLink>
           <SidebarLink to="/integrations/vercel/">Vercel</SidebarLink>
-          <SidebarLink to="/integrations/msteams/">Microsoft Teams</SidebarLink>
-          <SidebarLink to="/integrations/gitlab/">GitLab</SidebarLink>
-          <SidebarLink to="/integrations/bitbucket/">Bitbucket</SidebarLink>
         </ul>
       </li>
       <li className="mb-3" data-sidebar-branch>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -244,6 +244,7 @@ export default () => {
         </div>
 
         <ul className="list-unstyled" data-sidebar-tree>
+          {/* this list is alphabetized */}
           <SidebarLink to="/integrations/">Overview</SidebarLink>
           <SidebarLink to="/integrations/azuredevops/">Azure DevOps</SidebarLink>
           <SidebarLink to="/integrations/bitbucket/">Bitbucket</SidebarLink>

--- a/src/docs/integrations/azuredevops.mdx
+++ b/src/docs/integrations/azuredevops.mdx
@@ -1,0 +1,26 @@
+---
+title: "Azure DevOps Integration"
+---
+
+## Create an Azure application
+
+Log into your Azure DevOps account, creating one if needed. Ensure you have a project set up.
+
+To use the Azure DevOps integration you'll need to create an application. To start, visit [this page](https://app.vsaex.visualstudio.com/app/register) to register the app. 
+
+When configuring the app, use the following values:
+
+| Setting                         | Value                                                                                              |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Authorization callback URL      | https://yourname.ngrok.io/extensions/vsts/setup/                                                   |
+| Authorized Scopes               | Code (read), Work Items (read and write), Service Endpoints (read, query and manage), Graph (read) |
+
+Take note of your App ID and Client Secret (the long one you have to click to show) and add those to `config.yml` like this:
+
+```yml
+# Azure DevOps #
+vsts.client-id: your-app-id
+vsts.client-secret: your-client-secret
+```
+
+Follow our [documentation on installing and configuring the Azure DevOps integration](https://docs.sentry.io/product/integrations/azure-devops/) to finish installation and use the integration. 

--- a/src/docs/integrations/index.mdx
+++ b/src/docs/integrations/index.mdx
@@ -4,9 +4,10 @@ title: Integrations
 
 TODO: Describe the difference between integration/plugin generations.
 
+- [Azure DevOps](/integrations/azuredevops/)
+- [Bitbucket](/integrations/bitbucket/)
 - [GitHub](/integrations/github/)
+- [GitLab](/integrations/gitlab/)
+- [Microsoft Teams](/integrations/msteams/)
 - [Slack](/integrations/slack/)
 - [Vercel](/integrations/vercel/)
-- [Microsoft Teams](/integrations/msteams/)
-- [GitLab](/integrations/gitlab/)
-- [Bitbucket](/integrations/bitbucket/)


### PR DESCRIPTION
Add instructions for installing Azure DevOps in an on prem instance of Sentry. Also alphabetize the sidebar and index page. 

![Screen Shot 2020-11-09 at 12 45 24 PM](https://user-images.githubusercontent.com/29959063/98594518-a0e29580-2289-11eb-868b-6570cadaf0a1.png)
