### PR TITLE
fix(integrations): Change URL prefix to be consistent across integrations

### DIFF
--- a/src/docs/integrations/azuredevops.mdx
+++ b/src/docs/integrations/azuredevops.mdx
@@ -12,7 +12,7 @@ When configuring the app, use the following values:
 
 | Setting                         | Value                                                                                              |
 | ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Authorization callback URL      | {YOUR_DOMAIN}/extensions/vsts/setup/                                                   |
+| Authorization callback URL      | `{YOUR_DOMAIN}/extensions/vsts/setup/`                                                             |
 | Authorized Scopes               | Code (read), Work Items (read and write), Service Endpoints (read, query and manage), Graph (read) |
 
 Take note of your App ID and Client Secret (the long one you have to click to show) and add those to `config.yml` like this:

--- a/src/docs/integrations/azuredevops.mdx
+++ b/src/docs/integrations/azuredevops.mdx
@@ -6,13 +6,13 @@ title: "Azure DevOps Integration"
 
 Log into your Azure DevOps account, creating one if needed. Ensure you have a project set up.
 
-To use the Azure DevOps integration you'll need to create an application. To start, visit [this page](https://app.vsaex.visualstudio.com/app/register) to register the app. 
+To use the Azure DevOps integration you'll need to create an application. To start, visit [this page](https://app.vsaex.visualstudio.com/app/register) to register the app.
 
 When configuring the app, use the following values:
 
 | Setting                         | Value                                                                                              |
 | ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Authorization callback URL      | https://yourname.ngrok.io/extensions/vsts/setup/                                                   |
+| Authorization callback URL      | {YOUR_DOMAIN}/extensions/vsts/setup/                                                   |
 | Authorized Scopes               | Code (read), Work Items (read and write), Service Endpoints (read, query and manage), Graph (read) |
 
 Take note of your App ID and Client Secret (the long one you have to click to show) and add those to `config.yml` like this:
@@ -23,4 +23,4 @@ vsts.client-id: your-app-id
 vsts.client-secret: your-client-secret
 ```
 
-Follow our [documentation on installing and configuring the Azure DevOps integration](https://docs.sentry.io/product/integrations/azure-devops/) to finish installation and use the integration. 
+Follow our [documentation on installing and configuring the Azure DevOps integration](https://docs.sentry.io/product/integrations/azure-devops/) to finish installation and use the integration.

--- a/src/docs/integrations/bitbucket.mdx
+++ b/src/docs/integrations/bitbucket.mdx
@@ -4,12 +4,8 @@ title: "Bitbucket Integration"
 
 Ensure [developer mode](https://support.atlassian.com/bitbucket-cloud/docs/enable-bitbucket-cloud-development-mode/) is enabled in your Atlassian account.
 
-Start an [ngrok](https://ngrok.com/) tunnel (or equivalent) using the [subdomain option](https://ngrok.com/docs#http-subdomain), for example: 
+In Sentry navigate to **Settings > Integrations > Bitbucket**. Click "Add Installation".
 
-`./ngrok http -subdomain={YOUR_SUBDOMAIN} 8000`
+In the resulting modal, select your Bitbucket workspace and then click "Install from URL". Paste in the app descriptor as `{YOUR_DOMAIN}/extensions/bitbucket/descriptor/`
 
-In Sentry navigate to **Settings > Integrations > Bitbucket**. Click "Add Installation". 
-
-In the resulting modal, select your Bitbucket workspace and then click "Install from URL". Paste in the app descriptor as `https://{YOUR_SUBDOMAIN}.ngrok.io/extensions/bitbucket/descriptor/`
-
-Follow our [documentation on configuring the Bitbucket integration](https://docs.sentry.io/product/integrations/bitbucket/#configure) to use the integration. 
+Follow our [documentation on configuring the Bitbucket integration](https://docs.sentry.io/product/integrations/bitbucket/#configure) to use the integration.

--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -16,10 +16,10 @@ When configuring the app, use the following values:
 
 | Setting                         | Value                                     |
 | ------------------------------- | ----------------------------------------- |
-| Homepage URL                    | `${urlPrefix}`                            |
-| User authorization callback URL | `${urlPrefix}/auth/sso/`                  |
-| Setup URL (optional)            | `${urlPrefix}/extensions/github/setup/`   |
-| Webhook URL                     | `${urlPrefix}/extensions/github/webhook/` |
+| Homepage URL                    | `${YOUR_DOMAIN}`                            |
+| User authorization callback URL | `${YOUR_DOMAIN}/auth/sso/`                  |
+| Setup URL (optional)            | `${YOUR_DOMAIN}/extensions/github/setup/`   |
+| Webhook URL                     | `${YOUR_DOMAIN}/extensions/github/webhook/` |
 
 When prompted for permissions, choose the following:
 

--- a/src/docs/integrations/slack/index.mdx
+++ b/src/docs/integrations/slack/index.mdx
@@ -41,8 +41,8 @@ Now that you’ve created your app and updated your Sentry config, you can navig
 Click __Enable Interactive Components__ and you’ll be able to enter your Request URL (this is the location of your self-hosted Sentry) and Options Load URL:
 
 ```
-Request URL: https://your-sentry-server.com/extensions/slack/action/
-Options Load URL: https://your-sentry-server.com/extensions/slack/options-load/
+Request URL: {YOUR_DOMAIN}/extensions/slack/action/
+Options Load URL: {YOUR_DOMAIN}/extensions/slack/options-load/
 ```
 
 Click __Enable Interactive Components__ and Slack will confirm if the HTTP request to the URL you entered succeeds or fails.

--- a/src/docs/integrations/slack/index.mdx
+++ b/src/docs/integrations/slack/index.mdx
@@ -51,10 +51,10 @@ Navigate to __OAuth & Permissions__ to configure the Redirect URLs.
 
 ![OAuth](./oauth.png)
 
-Click __Add a new Redirect URL__, enter the URL, and click __Add__. The URL will look like:
+Click __Add a new Redirect URL__, enter the URL, and click __Add__. Set the URL to:
 
 ```
-https://your-sentry-server.com/extensions/slack/setup/
+{YOUR_DOMAIN}/extensions/slack/setup/
 ```
 
 Click __Save URLs__.
@@ -67,7 +67,7 @@ Click __Save Changes__.
 
 _Note: You have the option to set Restrict API Token Usage on this page if you want to ensure your Slack is the only one talking to your Sentry instance._
 
-Navigate to __Event Subscription__ and toggle “On”. Here you will enter another Request URL in the following format: `https://your-sentry-server.com/extensions/slack/event/`
+Navigate to __Event Subscription__ and toggle “On”. Here you will enter another Request URL: `{YOUR_DOMAIN}/extensions/slack/event/`
 
 You’ll see “Verified” when you’ve entered the correct URL.
 


### PR DESCRIPTION
We use `{YOUR_DOMAIN}` in most of our integration docs, so, keep the rest of the integration docs consistent with that terminology.

Also, removing references to ngrok cause these docs can be used as on prem docs too (in addition to development docs), which shouldn't be on ngrok.