### PR TITLE
Add docs on geolocation

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -102,11 +102,12 @@ export default () => {
         </div>
         <ul className="list-unstyled" data-sidebar-tree>
           <SidebarLink to="/self-hosted/">Overview</SidebarLink>
+          <SidebarLink to="/self-hosted/email/">Email</SidebarLink>
+          <SidebarLink to="/self-hosted/geolocation/">Geolocation</SidebarLink>
           <SidebarLink to="/self-hosted/sso/">Single Sign-On (SSO)</SidebarLink>
           <SidebarLink to="/self-hosted/releases/">
             Versioning & Releases
           </SidebarLink>
-          <SidebarLink to="/self-hosted/email/">Email</SidebarLink>
           <SidebarLink to="/self-hosted/support/">Support</SidebarLink>
         </ul>
       </li>

--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -1,0 +1,26 @@
+---
+title: 'Self-Hosted Geolocation'
+---
+
+Sentry can use [MaxMind's free GeoLite2 database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, as well as for the session history of users logging into your Sentry installation. Our on-premise offering bundles MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for initially downloading and periodically updating this dataset. To enable this functionality, you should sign up for [a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials via a [`docker-compose.override.yml`](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) file, like so:
+
+```yaml
+version: '3.4'
+services:
+  geoipupdate:
+    environment:
+      GEOIPUPDATE_ACCOUNT_ID: 012345
+      GEOIPUPDATE_LICENSE_KEY: foobar
+```
+
+By default, `onpremise` is configured to refresh the GeoLite2 database when the `geoipupdate` service first starts, and weekly thereafter. You can change the update frequency with an additional override:
+
+```yaml
+version: '3.4'
+services:
+  geoipupdate:
+    environment:
+      GEOIPUPDATE_ACCOUNT_ID: 012345
+      GEOIPUPDATE_LICENSE_KEY: foobar
+      GEOIPUPDATE_FREQUENCY: 24 # hours
+```

--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -2,17 +2,16 @@
 title: 'Self-Hosted Geolocation'
 ---
 
-Sentry can use [MaxMind's free GeoLite2 database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, as well as for the session history of users logging into your Sentry installation. Our self-hosted offering bundles MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for initially downloading and periodically updating this dataset. To enable this functionality, you should [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials via environment variables.
+Sentry can use [MaxMind's free `GeoLite2-City` database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, and for the session history of users logging into your Sentry installation. We bundle MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for this purpose. To enable IP address geolocation, [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials by placing your MaxMind configuration file at `geoip/GeoIP.conf`.
 
-```shell
-export GEOIPUPDATE_ACCOUNT_ID="012345"
-export GEOIPUPDATE_LICENSE_KEY="foobar"
+```
+AccountID 012345
+LicenseKey foobarbazbuz
+EditionIDs GeoLite2-City
 ```
 
-By default, self-hosted instances are configured to refresh the GeoLite2 database when the `geoipupdate` service first starts, and weekly thereafter. You can change the update frequency with an additional override:
+With this configuration file in place, subsequent runs of Sentry's `install.sh` will refresh the IP address geolocation database, and the next time you restart your self-hosted Sentry instance (the `relay` and `web` services, in particular), you should start seeing the latest data. Here's how to confirm that it's working:
 
-```shell
-export GEOIPUPDATE_ACCOUNT_ID="012345"
-export GEOIPUPDATE_LICENSE_KEY="foobar"
-export GEOIPUPDATE_FREQUENCY="24" # hours
-```
+1. For the `relay` service: Dashboards > Errors by Country should have some purple on it.
+
+1. For the `web` service: User Settings > Security > Session History should show country code and region (e.g., "US (CA)") underneath the IP addresses in the table.

--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -15,3 +15,20 @@ With this configuration file in place, subsequent runs of Sentry's `install.sh` 
 1. For the `relay` service: Dashboards > Errors by Country should have some purple on it.
 
 1. For the `web` service: User Settings > Security > Session History should show country code and region (e.g., "US (CA)") underneath the IP addresses in the table.
+
+## Upgrading?
+
+The services that consume the `GeoLite2-City.mmdb` file need to know where to find it. New installs will have this set automatically, but if you are upgrading you will need to manually set the following before restarting Sentry.
+
+In `relay/config.yml` ([example](https://github.com/getsentry/onpremise/blob/master/relay/config.example.yml)):
+
+```yaml
+processing:
+  geoip_path: "/geoip/GeoLite2-City.mmdb"
+```
+
+In `sentry/sentry.conf.py` ([example](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py)):
+
+```py
+GEOIP_PATH_MMDB = '/geoip/GeoLite2-City.mmdb'
+```

--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -2,7 +2,7 @@
 title: 'Self-Hosted Geolocation'
 ---
 
-Sentry can use [MaxMind's free `GeoLite2-City` database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, and for the session history of users logging into your Sentry installation. We bundle MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for this purpose. To enable IP address geolocation, [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials by placing your MaxMind configuration file at `geoip/GeoIP.conf`.
+Sentry can use [MaxMind's free `GeoLite2-City` database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end user's IP address is known and for the session history of users logging into your Sentry installation. We bundle MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for this purpose. To enable IP address geolocation, [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), then tell Sentry about your credentials by placing your MaxMind configuration file at `geoip/GeoIP.conf`.
 
 ```
 AccountID 012345
@@ -10,11 +10,11 @@ LicenseKey foobarbazbuz
 EditionIDs GeoLite2-City
 ```
 
-With this configuration file in place, subsequent runs of Sentry's `install.sh` will refresh the IP address geolocation database, and the next time you restart your self-hosted Sentry instance (the `relay` and `web` services, in particular), you should start seeing the latest data. Here's how to confirm that it's working:
+With this configuration file in place, subsequent runs of Sentry's `install.sh` will refresh the IP address geolocation database. The next time you restart your self-hosted Sentry instance (the `relay` and `web` services, in particular), you should start seeing the latest data. Here's how to confirm that it's working:
 
-1. For the `relay` service: Dashboards > Errors by Country should have some purple on it.
+1. For the `relay` service: **Dashboards > Errors by Country** should have some purple on it.
 
-1. For the `web` service: User Settings > Security > Session History should show country code and region (e.g., "US (CA)") underneath the IP addresses in the table.
+1. For the `web` service: **User Settings > Security > Session History** should display country code and region (for example, "US (CA)") underneath the IP addresses in the table.
 
 ## Upgrading?
 

--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -2,25 +2,17 @@
 title: 'Self-Hosted Geolocation'
 ---
 
-Sentry can use [MaxMind's free GeoLite2 database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, as well as for the session history of users logging into your Sentry installation. Our on-premise offering bundles MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for initially downloading and periodically updating this dataset. To enable this functionality, you should sign up for [a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials via a [`docker-compose.override.yml`](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) file, like so:
+Sentry can use [MaxMind's free GeoLite2 database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end-user's IP address is known, as well as for the session history of users logging into your Sentry installation. Our self-hosted offering bundles MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for initially downloading and periodically updating this dataset. To enable this functionality, you should [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), and then tell Sentry about your credentials via environment variables.
 
-```yaml
-version: '3.4'
-services:
-  geoipupdate:
-    environment:
-      GEOIPUPDATE_ACCOUNT_ID: 012345
-      GEOIPUPDATE_LICENSE_KEY: foobar
+```shell
+export GEOIPUPDATE_ACCOUNT_ID="012345"
+export GEOIPUPDATE_LICENSE_KEY="foobar"
 ```
 
-By default, `onpremise` is configured to refresh the GeoLite2 database when the `geoipupdate` service first starts, and weekly thereafter. You can change the update frequency with an additional override:
+By default, self-hosted instances are configured to refresh the GeoLite2 database when the `geoipupdate` service first starts, and weekly thereafter. You can change the update frequency with an additional override:
 
-```yaml
-version: '3.4'
-services:
-  geoipupdate:
-    environment:
-      GEOIPUPDATE_ACCOUNT_ID: 012345
-      GEOIPUPDATE_LICENSE_KEY: foobar
-      GEOIPUPDATE_FREQUENCY: 24 # hours
+```shell
+export GEOIPUPDATE_ACCOUNT_ID="012345"
+export GEOIPUPDATE_LICENSE_KEY="foobar"
+export GEOIPUPDATE_FREQUENCY="24" # hours
 ```

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -16,7 +16,7 @@ You are very likely to want to change the default configuration for Sentry. Here
 
 1. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
 
-1. You can also use [`docker-compose.override.yml`](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) to override [our `docker-compose.yml`](https://github.com/getsentry/onpremise/blob/master/docker-compose.yml). This is especially helpful for the few places where we depend on environment variables, such as <Link to="/self-hosted/geolocation/">geolocation</Link>.
+1. There are a few places where we depend on environment variables, such as <Link to="/self-hosted/geolocation/">geolocation</Link>.
 
 <Alert title="Note" level="info">
   Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -16,7 +16,7 @@ You are very likely to want to change the default configuration for Sentry. Here
 
 1. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
 
-1. There are a few places where we depend on environment variables. The keys are defined in [.env](https://github.com/getsentry/onpremise/blob/master/sentry/.env), though if you need to override any of them we expect you to use some other means of setting environment variables dependent on your system.
+1. There are a few places where we depend on environment variables. The keys are defined in [.env](https://github.com/getsentry/onpremise/blob/master/.env), though if you need to override any of them we expect you to use some other means of setting environment variables dependent on your system.
 
 1. <Link to="/self-hosted/geolocation/">Geolocation</Link> uses a custom configuration file to conform to the underlying technology.
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,13 +10,15 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 ## Configuration
 
-You are very likely to want to change the default configuration for Sentry. Here are the three main facilities available to you:
+You are very likely to want to change the default configuration for Sentry. Here are the main facilities available to you:
 
 1. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
 
 1. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
 
-1. There are a few places where we depend on environment variables, such as <Link to="/self-hosted/geolocation/">geolocation</Link>.
+1. There are a few places where we depend on environment variables. The keys are defined in [.env](https://github.com/getsentry/onpremise/blob/master/sentry/.env), though if you need to override any of them we expect you to use some other means of setting environment variables dependent on your system.
+
+1. <Link to="/self-hosted/geolocation/">Geolocation</Link> uses a custom configuration file to conform to the underlying technology.
 
 <Alert title="Note" level="info">
   Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,27 +10,9 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 ## Configuration
 
-You very likely will want to adjust the default configuration for Sentry. These main facilities are available for that purpose:
+You are very likely to want to change the default configuration for Sentry. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` even if we ship with a built-in SMTP server for basic stuff. GitHub and Slack integration settings also reside in this file. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
 
-1. `sentry/config.yml` which contains most, if not all, configuration options to adjust. This file is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. 
-
-The file itself documents the most common configuration options as code comments. You can find more about configuring Sentry at [the configuration section of our developer documentation](/config/). Typically, you'll need to change `system.url-prefix` (we prompt you to do this at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
-
-1. [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py), which contains more advanced configuration.
-
-1. Environment variables, the keys for which are defined in [.env](https://github.com/getsentry/onpremise/blob/master/.env). If you need to override any of them, we expect you to use some other means of setting environment variables dependent on your system.
-
-1. [Geolocation](/self-hosted/geolocation/) uses a custom configuration file to conform to the underlying technology.
-
-<Alert title="Note" level="info">
-  Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).
-</Alert>
-
-Here is further information on specific configuration topics:
-
-- [Email](/self-hosted/email/)
-- [Geolocation](/self-hosted/geolocation/)
-- [Single Sign-On (SSO)](/self-hosted/sso/)
+**Once you change your configuration, you'll need to restart all Sentry services by running `docker-compose restart web worker cron sentry-cleanup` (or just `docker-compose restart` to restart everything).**
 
 ## Troubleshooting
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -12,11 +12,13 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 You very likely will want to adjust the default configuration for Sentry. These main facilities are available for that purpose:
 
-1. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
+1. `sentry/config.yml` which contains most, if not all, configuration options to adjust. This file is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. 
 
-1. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
+The file itself documents the most common configuration options as code comments. You can find more about configuring Sentry at [the configuration section of our developer documentation](/config/). Typically, you'll need to change `system.url-prefix` (we prompt you to do this at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
 
-1. There are a few places where we depend on environment variables. The keys are defined in [.env](https://github.com/getsentry/onpremise/blob/master/.env), though if you need to override any of them we expect you to use some other means of setting environment variables dependent on your system.
+1. [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py), which contains more advanced configuration.
+
+1. Environment variables, the keys for which are defined in [.env](https://github.com/getsentry/onpremise/blob/master/.env). If you need to override any of them, we expect you to use some other means of setting environment variables dependent on your system.
 
 1. [Geolocation](/self-hosted/geolocation/) uses a custom configuration file to conform to the underlying technology.
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,7 +10,7 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 ## Configuration
 
-You are very likely to want to change the default configuration for Sentry. Here are the main facilities available to you for this purpose:
+You very likely will want to adjust the default configuration for Sentry. These main facilities are available for that purpose:
 
 1. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,9 +10,23 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 ## Configuration
 
-You are very likely to want to change the default configuration for Sentry. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` even if we ship with a built-in SMTP server for basic stuff. GitHub and Slack integration settings also reside in this file. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
+You are very likely to want to change the default configuration for Sentry. Here are the three main facilities available to you:
 
-**Once you change your configuration, you'll need to restart all Sentry services by running `docker-compose restart web worker cron sentry-cleanup` (or just `docker-compose restart` to restart everything).**
+1. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
+
+1. For more advanced things, you can have a look at [`sentry/sentry.conf.example.py`](https://github.com/getsentry/onpremise/blob/master/sentry/sentry.conf.example.py).
+
+1. You can also use [`docker-compose.override.yml`](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) to override [our `docker-compose.yml`](https://github.com/getsentry/onpremise/blob/master/docker-compose.yml). This is especially helpful for the few places where we depend on environment variables, such as <Link to="/self-hosted/geolocation/">geolocation</Link>.
+
+<Alert title="Note" level="info">
+  Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).
+</Alert>
+
+Here is further information on specific configuration topics:
+
+- <Link to="/self-hosted/email/">Email</Link>
+- <Link to="/self-hosted/geolocation/">Geolocation</Link>
+- <Link to="/self-hosted/sso/">Single Sign-On (SSO)</Link>
 
 ## Troubleshooting
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,7 +10,7 @@ Our recommendation is to download the [latest release of the onpremise reposito
 
 ## Configuration
 
-You are very likely to want to change the default configuration for Sentry. Here are the main facilities available to you:
+You are very likely to want to change the default configuration for Sentry. Here are the main facilities available to you for this purpose:
 
 1. Most, if not all, configuration options that you'd like to tweak are in `sentry/config.yml`, which is generated from [`sentry/config.example.yml`](https://github.com/getsentry/onpremise/blob/master/sentry/config.example.yml) at the time of installation. The file itself documents the most common configuration options as code comments, and you can find more about configuring Sentry over at <Link to="/config/">the configuration section of our developer documentation</Link>. You would likely need to change `system.url-prefix` (this is also prompted at the welcome screen, right after the installation) and settings starting with `mail.` (though we do ship with a basic SMTP server).  GitHub and Slack integration settings also reside in this file.
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -18,7 +18,7 @@ You very likely will want to adjust the default configuration for Sentry. These 
 
 1. There are a few places where we depend on environment variables. The keys are defined in [.env](https://github.com/getsentry/onpremise/blob/master/.env), though if you need to override any of them we expect you to use some other means of setting environment variables dependent on your system.
 
-1. <Link to="/self-hosted/geolocation/">Geolocation</Link> uses a custom configuration file to conform to the underlying technology.
+1. [Geolocation](/self-hosted/geolocation/) uses a custom configuration file to conform to the underlying technology.
 
 <Alert title="Note" level="info">
   Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).
@@ -26,9 +26,9 @@ You very likely will want to adjust the default configuration for Sentry. These 
 
 Here is further information on specific configuration topics:
 
-- <Link to="/self-hosted/email/">Email</Link>
-- <Link to="/self-hosted/geolocation/">Geolocation</Link>
-- <Link to="/self-hosted/sso/">Single Sign-On (SSO)</Link>
+- [Email](/self-hosted/email/)
+- [Geolocation](/self-hosted/geolocation/)
+- [Single Sign-On (SSO)](/self-hosted/sso/)
 
 ## Troubleshooting
 

--- a/src/docs/self-hosted/sso.mdx
+++ b/src/docs/self-hosted/sso.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Single Sign-On (SSO)'
+title: 'Self-Hosted Single Sign-On (SSO)'
 ---
 
 SSO in Sentry is handled in one of two ways:


### PR DESCRIPTION
Goes with https://github.com/getsentry/onpremise/pull/766.

Closes #220.

Don't merge until https://github.com/getsentry/onpremise/pull/766 is merged **and released**, hopefully will be in 20.12.0.