### PR TITLE
fix(integrations): Update Create a GitHub App Docs

### DIFF
--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -34,8 +34,8 @@ When prompted for permissions, choose the following:
 You'll be given various credentials, configure them in `config.yml`:
 
 ```yml
-# App ID
-github-app.id: "GITHUB_APP_ID"
+# App ID (an integer)
+github-app.id: GITHUB_APP_ID
 # App Name
 github-app.name: "GITHUB_APP_NAME"
 # Client ID


### PR DESCRIPTION
I got a parsing error when I put 
```
github-app.id: "92475"
``` 
in my `~/.sentry/config.yml` and tried to sun Sentry. I think a reminder in the docs would help other users creating and installing GitHub apps.