### PR TITLE
fix(typos): Tiny edits on inclusive language page

### DIFF
--- a/src/docs/inclusion.mdx
+++ b/src/docs/inclusion.mdx
@@ -7,14 +7,14 @@ backgrounds and we try to avoid language that has been identified as hurtful
 or insensitive.  This applies not only to the documentation but also to the
 product itself and internal APIs.
 
-What constitutes as inclusive language will always be an evolving topic and
-because Sentry is a product with history it is likely, that we will always carry
+What constitutes inclusive language will always be an evolving topic, and
+because Sentry is a product with history, it is likely that we will always carry
 something in the codebase that is hard to get rid of.
 
 As such this document largely determines what should be done for new code, but
 not necessarily for existing code.
 
-## Phased Out Terms
+## Phased-Out Terms
 
 We have identified some terms that we no longer want to use going forward but
 that might still exist in parts of the codebase.
@@ -51,8 +51,8 @@ grandfathered:
 master:
 
 : Master in isolation is acceptable if the origin of the term can exclude the
-  associated meaning of "slave".  This for instance is the case when this is
-  referred to as a "master copy", a "master degree" etc.  For the git branch
+  associated meaning of "slave".  This for instance is the case when
+  referring to as a "master copy", a "masters degree" etc.  For the git branch
   name please see below.
 
 
@@ -60,13 +60,13 @@ master:
 
 We are okay keeping the term "master" for existing repositories but it is
 generally recommended to change the default branch name to "main" going forward
-on new repositories.  The term "master" in isolation is acceptable in general
-however the history of the branch name in git comes from bitkeeper where this
+on new repositories.  While the term "master" in isolation is generally acceptable,
+the history of the branch name in git comes from bitkeeper where this
 terminology referred to master and slave repositories.  At present changing the
 default branch on existing repositories has negative consequences for users
 that have already cloned the repositories so these should not be changed.
 
-To reconfigure git to use a different default repo for `git init` a template
+To reconfigure git to use a different default branch name for `git init` a template
 can be configured.  Put the following into your `~/.gitconfig`:
 
 ```ini {tabTitle: Git Config}
@@ -85,8 +85,8 @@ From this moment onwards future repositories will use the default branch name "m
 
 ## Changing Code
 
-If you identified code or comments that uses problematic language you are free
-to change it.  However please be advised that some uses of problematic language
+If you identify code or comments that use problematic language, you are free
+to change them.  However please be advised that some uses of problematic language
 haven't been phased out because they are backward-incompatible changes and
 require a lot more work.  Specifically, for instance, the rate-limiting code in
 Sentry uses the terms "whitelist" for persisted data and for consistency the


### PR DESCRIPTION
Primarily this was to fix subject/verb agreement in the last paragraph, but I couldn't help smoothing a few other tiny language bumps along the way.