### PR TITLE
environment: No need to install virtualenv

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -113,8 +113,7 @@ If it worked, running `which python` should result in something like `/Users/you
 You're now ready to create a Python virtual environment. Run:
 
 ```bash
-python -m pip install virtualenv
-python -m virtualenv .venv
+python -m venv .venv
 ```
 
 And activate the virtual environment:


### PR DESCRIPTION
Python 3 does not require installing the `virtualenv` package since it is included
by default as a module.