### PR TITLE
fix: Specify valid content types

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -375,8 +375,7 @@ file. It is always associated to an event or transaction.
 
 `content_type`
 
-: *String, optional.* The content type of the attachment payload. Defaults to
-  `application/octet-stream`.
+: *String, optional.* The content type of the attachment payload. Any [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml) may be used; the default is `application/octet-stream`.
 
 ### Session
 


### PR DESCRIPTION
Specify that any valid MIME type can be used as a content type. Brought up in here https://github.com/getsentry/sentry-docs/pull/2826#issuecomment-755500370.