### PR TITLE
feat(docs): Add local dev setup for API docs

### DIFF
--- a/src/docs/docs/api.mdx
+++ b/src/docs/docs/api.mdx
@@ -73,7 +73,7 @@ We use [Open API Spec 3](https://swagger.io/docs/specification/about/) to write 
 ### Local development
 
 In `sentry`:
-1. Run `yarn run watch-api-docs`. This command will build a file `tests/apidocs/openapi-derefed.json`.
+1. Run `yarn run watch-api-docs`. This command will watch API docs files and continuously build an intermediate asset `tests/apidocs/openapi-derefed.json`.
 2. Copy the full path to `tests/apidocs/openapi-derefed.json`.
 
 In `sentry-docs`:

--- a/src/docs/docs/api.mdx
+++ b/src/docs/docs/api.mdx
@@ -70,6 +70,17 @@ If your answers are Yes, No and Yes, you're in business - make the API public.
 
 We use [Open API Spec 3](https://swagger.io/docs/specification/about/) to write our API documentation. You can find that content here: [https://github.com/getsentry/sentry/tree/master/api-docs.](https://github.com/getsentry/sentry/tree/master/api-docs) You can find the tests here: [https://github.com/getsentry/sentry/tree/master/tests/apidocs](https://github.com/getsentry/sentry/tree/master/tests/apidocs).
 
+### Local development
+
+In `sentry`:
+1. Run `yarn run watch-api-docs`. This command will build a file `tests/apidocs/openapi-derefed.json`.
+2. Copy the full path to `tests/apidocs/openapi-derefed.json`.
+
+In `sentry-docs`:
+1. Run `OPENAPI_LOCAL_PATH=COPIED_FULL_PATH DISABLE_THUMBNAILS=1 yarn start` and substitute `COPIED_FULL_PATH` with the copied path to your local openapi-derefed.json
+
+### Build process
+
 Once you make changes to an endpoint and merge the change into Sentry, a series of Github Actions will be triggered to make your changes automatically go live:
 
 1. The `openapi / deref_json` Github Action in [sentry](https://github.com/getsentry/Sentry) will update the schema in [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) with the OpenAPI build artifact.


### PR DESCRIPTION
## Objective:
We want to include steps on how to setup the local dev environment to update the API docs in `sentry-docs`.