### PR TITLE
fix: AddToTransaction link to transaction

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -119,8 +119,8 @@ The overload that takes a `path` should consider:
 * If reading the attachment fails, the SDK should not drop the whole envelope, but just the attachment's envelope item.
 * If the SDK is in debug mode log (`debug=true`) out errors to make debugging easier.
 
-If the SDK supports [transactions]((/sdk/envelopes/#transaction)), the attachments should offer a flag `addToTransactions`,
-that specifies if the attachment is added to transactions or not. The default should be `false`.
+If the SDK supports [transactions](/sdk/envelopes/#transaction), the attachments should offer a flag `addToTransactions`,
+that specifies if SDK adds the attachment to every transaction or not. The default should be `false`.
 
 Use the implementations of [Java](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/Attachment.java),
 [Objective-C](https://github.com/getsentry/sentry-cocoa/blob/master/Sources/Sentry/SentryAttachment.m), or


### PR DESCRIPTION
The link to transaction was broken. It is fixed now. I also changed the passive
voice to an active.