### PR TITLE
Fix: context name not required when raw_description is given

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -25,7 +25,7 @@ For more details about sending additional data with your event, see the [full do
 ## Device Context
 
 Device context describes the device that caused the event. This is most
-appropriate for mobile applications. 
+appropriate for mobile applications.
 
 The `type` and default key is `"device"`.
 
@@ -147,7 +147,7 @@ The `type` and default key is `"os"`.
 
 `name`
 
-: **Required**. The name of the operating system.
+: _Recommended_. The name of the operating system. It might be derived from `raw_description`. It is **required** if `raw_description` is not provided.
 
 `version`
 
@@ -211,7 +211,7 @@ The `type` and default key is `"runtime"`.
 
 `name`
 
-: **Required**. The name of the runtime.
+: _Recommended_. The name of the runtime. It might be derived from `raw_description`. It is **required** if `raw_description` is not provided.
 
 `version`
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/1590.