### PR TITLE
Environment: added instructions for fish shell

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -98,6 +98,10 @@ eval "$(pyenv init -)"
 eval "$(pyenv init -)"
 ```
 
+```bash {filename: ~/.config/fish/config.fish} {tabTitle: Fish}
+source (pyenv init - | psub)
+```
+
 
 Once that's done, your shell needs to be reloaded. You can either reload it in-place, or close your terminal and start it
 again and cd into sentry. To reload it, run:
@@ -158,6 +162,11 @@ export VOLTA_HOME="~/.volta"
 grep --silent "$VOLTA_HOME/bin" <<< $PATH || export PATH="$VOLTA_HOME/bin:$PATH"
 ```
 
+```bash {filename: ~/.config/fish/config.fish} {tabTitle: Fish}
+set -gx VOLTA_HOME "$HOME/.volta"
+set -gx PATH "$VOLTA_HOME/bin" $PATH
+```
+
 Now, if you try and run `volta`, you should see some help text, meaning volta is installed correctly. To install node,
 simply run:
 
@@ -197,6 +206,10 @@ eval "$(direnv hook bash)"
 
 ```bash {filename: ~/.zshrc} {tabTitle: Zsh}
 eval "$(direnv hook zsh)"
+```
+
+```bash {filename ~/.config/fish/config.fish} {tabTitle: Fish}
+direnv hook fish | source
 ```
 
 And after doing that, reload your shell:


### PR DESCRIPTION
I use the `fish` shell, so setting up the environment worked a little differently than for `bash` and `zsh`.