### PR TITLE
Added NSError to protocol

### DIFF
--- a/src/docs/sdk/event-payloads/exception.mdx
+++ b/src/docs/sdk/event-payloads/exception.mdx
@@ -160,6 +160,18 @@ descriptions.
 
 : Optional name of the exception constant in iOS / macOS.
 
+#### `ns_error`
+
+An `NSError` on Apple systems comprising of domain and code.
+
+`code`
+
+: Required numeric error code.
+
+`domain`
+
+: Required domain of the NSError as string.
+
 #### `errno`
 
 Error codes set by Linux system calls and some library functions as specified in


### PR DESCRIPTION
This adds `ns_error` to the mechanism protocol.

For more details see https://github.com/getsentry/sentry-cocoa/discussions/929