### PR TITLE
fix: Use official cask upgrade command

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -344,7 +344,7 @@ RetryException: Could not successfully execute <functools.partial object at 0x10
 **Solution:**
 
 ```bash
-brew cask upgrade chromedriver
+brew upgrade --cask chromedriver
 ```
 
 ---


### PR DESCRIPTION
Running `brew cask upgrade chromedriver` outputs the following:

```
Error: Calling `brew cask upgrade` is disabled! Use brew upgrade [--cask] instead.
```

Ref: https://stackoverflow.com/questions/31968664/upgrade-all-the-casks-installed-via-homebrew-cask

https://github.com/Homebrew/discussions/discussions/340