### PR TITLE
Account for external triagers

### DIFF
--- a/src/docs/processing-tickets.mdx
+++ b/src/docs/processing-tickets.mdx
@@ -36,6 +36,8 @@ Each Engineering team is responsible for monitoring issues assigned to their tea
 2. `Status: On Hold` — The ticket is actionable, but is not actively being worked.
 3. `Status: Accepted` — The ticket is actionable, and is actively being worked.
 
+External core contributors may participate in triage (this is common in SDK repos, for example), but the internal Sentry Engineering team that owns the repo is responsible for the SLA and for the final triage decision if there are disagreements.
+
 The Open Source Team maintains [a bot](https://github.com/getsentry/sentry/blob/master/.github/workflows/stale.yml) (installed on the same repos as the validation bot) that closes tickets (with a warning) after four weeks of inactivity unless they have the `Status: On Hold` or `Status: Accepted` label.
 
 ## 4. Resolve


### PR DESCRIPTION
This partially addresses https://github.com/getsentry/open.sentry.io/issues/1.