### PR TITLE
fix(breadcrumbs): Fix link, do other minor cleanup

### DIFF
--- a/src/docs/sdk/event-payloads/breadcrumbs.mdx
+++ b/src/docs/sdk/event-payloads/breadcrumbs.mdx
@@ -4,9 +4,9 @@ title: Breadcrumbs Interface
 
 Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an issue. These events are very similar to traditional logs but can record more rich structured data.
 
-This page provides technical information about a breadcrumb structure. You can read an overview of manual breadcrumb recording and customization on our [Breadcrumbs](https://docs.sentry.io/enriching-error-data/breadcrumbs/) sentry docs page.
+This page provides technical information about a breadcrumb structure. You can read an overview of manual breadcrumb recording and customization on our [Breadcrumbs](https://docs.sentry.io/platform-redirect/?next=/enriching-events/breadcrumbs/) Sentry docs page.
 
-An event may contain one or more `breadcrumbs` properties. The entries are ordered from oldest to newest. Consequently, the last entry in the list should be the last entry before the event occurred.
+An event may contain a `breadcrumbs` property with one entry, `values`, which is an array of breadcrumb objects. The entries are ordered from oldest to newest. Consequently, the last entry in the list should be the last entry before the event occurred.
 
 The following example illustrates the breadcrumbs part of the event payload and omits other attributes for simplicity.
 
@@ -42,17 +42,15 @@ A breadcrumb object contains the property `values`, which is an array of objects
 
 : The type of breadcrumb. By default, all breadcrumbs are recorded as `default`, which makes them appear as a Debug entry, but Sentry provides other types that influence how the breadcrumbs are rendered. For more information, see the [description of recognized breadcrumb types](#breadcrumb-types).
 
-By default, all breadcrumbs are recorded as `default`, which makes them appear as a Debug entry, but Sentry provides other types that influence how the breadcrumbs are rendered. For more information, see the [description of recognized breadcrumb types](#breadcrumb-types).
-
 `category` (optional)
 
 : A dotted string indicating what the crumb is or from where it comes. Typically it is a module name or a descriptive string. For instance, `ui.click` could be used to indicate that a click happened in the UI or flask could be used to indicate that the event originated in the Flask framework.
 
-_Internally we render some crumb’s color and icon based on the provided category. For more information, see the [description of recognized breadcrumb types](#breadcrumb-types)._
+_Internally we render some crumbs' color and icon based on the provided category. For more information, see the [description of recognized breadcrumb types](#breadcrumb-types)._
 
 `message` (optional)
 
-: Human readable message for the breadcrumb.
+: Human-readable message for the breadcrumb.
 
 If a message is provided, it is rendered as text with all whitespace preserved.
 
@@ -173,7 +171,7 @@ The HTTP status code of the response.
 
 `reason` (optional)
 
-A text that describes the status code.
+Text that describes the status code.
 
 ```json
 {


### PR DESCRIPTION
Fixes a link, removes an accidentally-duplicated paragraph, corrects a statement about multiple `breacrumbs` properties, and fixes a few small typos which jumped out at me in a quick skim.