### PR TITLE
feat: Add stack_start to stacktrace interface

### DIFF
--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -97,6 +97,14 @@ in this stack trace. For example, the frames that might power the framework’s
 web server of your app are probably not relevant. However, calls to the
 framework’s library once you start handling code likely are relevant.
 
+`stack_start`
+
+: Marks this frame as the bottom of a chained stack trace. Stack traces from
+asynchronous code consist of several sub traces that are chained together into
+one large list. This flag indicates the root function of a chained stack trace.
+Depending on the runtime and thread, this is either the `main` function or a
+thread base stub. This field should only be specified when `true`.
+
 `vars`
 
 : A mapping of variables which were available within this frame (usually


### PR DESCRIPTION
Was added with https://github.com/getsentry/relay/pull/981. Merge this once we deployed this.