### PR TITLE
fix: Session Aggregates Payload experimental status

### DIFF
--- a/src/docs/sdk/sessions.mdx
+++ b/src/docs/sdk/sessions.mdx
@@ -154,17 +154,6 @@ Ingest should force `errors` to 1 if not set or 0.
 
 ## Session Aggregates Payload
 
-<Alert title="Experimental Status" level="info">
-
-The `"sessions"` envelope item is still unfinished and considered experimental.
-It is currently only supported on the `sentry.io` installation and is subject
-to heavy usage-limits.
-
-Currently, the sum of all session counts must not exceed _100_. This limitation
-will be lifted in the future when this feature will become stable.
-
-</Alert>
-
 Especially for _request-mode_ sessions
 (<Link to="#sdk-considerations">see below</Link>), it is common to have
 thousands of requests, and thus sessions, per second.


### PR DESCRIPTION
Remove experimental status, since we already rely on the documented/implemented behavior in several SDKs for "request mode" session reporting.