### PR TITLE
Proposal: Culture Context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -375,3 +375,26 @@ The following example illustrates the contexts part of the <Link to="/sdk/event-
   }
 }
 ```
+
+## Current Culture Context
+
+Current Culture Context describes certain properties of the culture in which 
+the software is used.
+
+The `type` and default key is `"current culture"`.
+
+`calendar`
+
+: _Optional_. For example `GregorianCalendar`. Free form string. 
+
+`displayName`
+
+: _Optional_. Human readable name of the current culture. For example `English (United States)`
+
+`locale`
+
+: _Optional_. Two letter code of the current culture. For example `en-US`
+
+`24hourFormat`
+
+: _Optional_. boolean, either `true` or `false`.

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -395,6 +395,6 @@ The `type` and default key is `"current culture"`.
 
 : _Optional_. Two letter code of the current culture. For example `en-US`
 
-`24hourFormat`
+`is_24_hour_format`
 
 : _Optional_. boolean, either `true` or `false`.

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -376,7 +376,7 @@ The following example illustrates the contexts part of the <Link to="/sdk/event-
 }
 ```
 
-## Current Culture Context
+## Culture Context
 
 Current Culture Context describes certain properties of the culture in which 
 the software is used.

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -387,7 +387,7 @@ The `type` and default key is `"current culture"`.
 
 : _Optional_. For example `GregorianCalendar`. Free form string. 
 
-`displayName`
+`display_name`
 
 : _Optional_. Human readable name of the current culture. For example `English (United States)`
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -381,7 +381,7 @@ The following example illustrates the contexts part of the <Link to="/sdk/event-
 Current Culture Context describes certain properties of the culture in which 
 the software is used.
 
-The `type` and default key is `"current_culture"`.
+The `type` and default key is `"culture"`.
 
 `calendar`
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -389,7 +389,7 @@ The `type` and default key is `"culture"`.
 
 `display_name`
 
-: _Optional_. Human readable name of the current culture. For example `English (United States)`
+: _Optional_. Human readable name of the culture. For example `English (United States)`
 
 `locale`
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -378,7 +378,7 @@ The following example illustrates the contexts part of the <Link to="/sdk/event-
 
 ## Culture Context
 
-Current Culture Context describes certain properties of the culture in which 
+Culture Context describes certain properties of the culture in which 
 the software is used.
 
 The `type` and default key is `"culture"`.

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -381,7 +381,7 @@ The following example illustrates the contexts part of the <Link to="/sdk/event-
 Current Culture Context describes certain properties of the culture in which 
 the software is used.
 
-The `type` and default key is `"current culture"`.
+The `type` and default key is `"current_culture"`.
 
 `calendar`
 
@@ -393,8 +393,12 @@ The `type` and default key is `"current culture"`.
 
 `locale`
 
-: _Optional_. Two letter code of the current culture. For example `en-US`
+: _Optional_. The name identifier, usually following the RFC 4646. For example `en-US` or `pt-BR`.
 
 `is_24_hour_format`
 
 : _Optional_. boolean, either `true` or `false`.
+
+`timezone`
+
+: _Optional_. The timezone of the locale. For example, `Europe/Vienna`.


### PR DESCRIPTION
This PR is a proposal to add a `current culture` context to Contexts. 
It contains various kinds of information around the culture which is in use.

Who is using this (at least these are the ones I'm aware of):
- https://github.com/getsentry/sentry-dotnet
- This Draft PR is also adapting to it: https://github.com/getsentry/sentry-dart/pull/452

Where this also might be useful:
- Android
- iOS
- Desktop Linux
- Windows
- macOS
- Browser (?)

Additional relevant properties not yet included:
- decimal seperator
- units (weight, length, money)

Why do I want to have this information?
When my software supports multiple cultures/locales and I'm
- Parsing strings into numbers
- Calculating with units
- Displaying dates