### PR TITLE
Proposal: Darkmode field for OS context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -168,7 +168,7 @@ The `type` and default key is `"os"`.
 
 `brightness`
 
-: _Optional_. Either `light` or `dark`. Describes wether the OS runs in dark mode or not.
+: _Optional_. Either `light` or `dark`. Describes whether the OS runs in dark mode or not.
 
 `raw_description`
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -166,6 +166,10 @@ The `type` and default key is `"os"`.
 
 : _Optional_. A flag indicating whether the OS has been jailbroken or rooted.
 
+`brightness`
+
+: _Optional_. Either `light` or `dark`. Describes wether the OS runs in dark mode or not.
+
 `raw_description`
 
 : _Optional_. An unprocessed description string obtained by the operating

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -166,7 +166,7 @@ The `type` and default key is `"os"`.
 
 : _Optional_. A flag indicating whether the OS has been jailbroken or rooted.
 
-`brightness`
+`theme`
 
 : _Optional_. Either `light` or `dark`. Describes whether the OS runs in dark mode or not.
 


### PR DESCRIPTION
This PR proposed to add a `brightness` field to the OS context.

All major OSs (Windows, macOS, Linux (Ubuntu), Android, iOS) have implemented dark mode. 
Darkmode is a system wide option, thus I added this to the OS context.

I could imagine that it also makes sense as a field of the app.