### PR TITLE
feat: Exclude Sentry HTTP in client integrations

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -159,6 +159,8 @@ Ability to use an HTTP proxy. Often easy to implement using the existing HTTP cl
 
 ## HTTP Client Integrations
 
+Every HTTP client integration must exclude HTTP requests that match the configured DSN in the Options to exclude HTTP requests to Sentry.
+
 Add a breadcrumb for each outgoing HTTP request after the request finishes:
 
 - type: `http`


### PR DESCRIPTION
Add a comment to HTTP client integrations in expected SDK features to exclude
HTTP requests to Sentry.