### PR TITLE
fix: Add link to distributed tracing

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -169,6 +169,6 @@ If Performance Monitoring is both supported by the SDK and enabled in the client
 
 - operation: `http.client`
 - description: `$METHOD $url` (uppercase HTTP method), e.g. `GET https://sentry.io`
-- HTTP request must be enhanced with a [`sentry-trace` HTTP header](/sdk/performance/#header-sentry-trace)
+- HTTP requests must be enhanced with a [`sentry-trace` HTTP header](/sdk/performance/#header-sentry-trace) to support [distributed tracing](https://docs.sentry.io/platforms/java/performance/instrumentation/custom-instrumentation/#distributed-tracing
 - span status must match HTTP response status code ([see Span status to HTTP status code mapping](/sdk/event-payloads/span/))
 - when network error occurs, span status must be set to `internal_error`


### PR DESCRIPTION
Add link to distributed tracing for HTTP client integrations and
fix a typo.