### PR TITLE
Fix new issue links

### DIFF
--- a/src/docs/docs/api.mdx
+++ b/src/docs/docs/api.mdx
@@ -110,7 +110,7 @@ Once you make changes to an endpoint and merge the change into Sentry, a series 
 
 Want an endpoint to be public?
 
-Look at the [issues on sentry with the `Component: API` label](https://github.com/getsentry/sentry/issues?q=is%3Aopen+is%3Aissue+label%3A%22Component%3A+API%22). If a request has already been made to make the endpoint public, give it a thumbs up. If not, create a [feature request](https://github.com/getsentry/sentry/issues/new?template=feature_request.md) on Sentry and add the `Component: API` label.
+Look at the [issues on sentry with the `Component: API` label](https://github.com/getsentry/sentry/issues?q=is%3Aopen+is%3Aissue+label%3A%22Component%3A+API%22). If a request has already been made to make the endpoint public, give it a thumbs up. If not, create a [feature request](https://github.com/getsentry/sentry/issues/new?template=feature.yml) on Sentry and add the `Component: API` label.
 
 The team responsible for the endpoint will review the stability of the endpoint. If the endpoint will not have breaking changes in future, they can determine whether to make it public.
 


### PR DESCRIPTION
With the switch to GitHub issue forms (https://github.com/getsentry/sentry/pull/26898), these links have changed.

cf. https://github.com/getsentry/static-sites/pull/554 https://github.com/getsentry/sentry/pull/27153