### PR TITLE
ref: add status code to SDK http client integrations

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -165,7 +165,12 @@ Add a breadcrumb for each outgoing HTTP request after the request finishes:
 
 - type: `http`
 - category: `http`
-- data: `url`, `method` (uppercase HTTP method), `status_code`, optionally `request_body_size` and `response_body_size` (in bytes)
+- data (all fields are optional but recommended):
+  - `url` - The URL used in the HTTP request
+  - `method` - uppercase HTTP method, i.e: GET, HEAD
+  - `status_code` - Numeric status code such as `200` or `404`
+  - `request_body_size` Size in bytes
+  - `response_body_size` Size in bytes
 
 If Performance Monitoring is both supported by the SDK and enabled in the client application when the transaction is active a new `Span` must be created around the HTTP request:
 

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -165,7 +165,7 @@ Add a breadcrumb for each outgoing HTTP request after the request finishes:
 
 - type: `http`
 - category: `http`
-- data: `url`, `method` (uppercase HTTP method), optionally `request_body_size` and `response_body_size` (in bytes)
+- data: `url`, `method` (uppercase HTTP method), `status_code`, optionally `request_body_size` and `response_body_size` (in bytes)
 
 If Performance Monitoring is both supported by the SDK and enabled in the client application when the transaction is active a new `Span` must be created around the HTTP request:
 


### PR DESCRIPTION
Add an additional parameter to the HTTP Client Integrations breadcrumb.

The reason why is having a breadcrumb with more value, knowing the status code from an HTTP Request will help the use user to differentiate if the given request was "healthy" or errored. 

In addition, this is the current behavior from Sentry Angular (and by that, I'll assume the Javascript SDK also does the same)

* For reference, see the following discussion: https://github.com/getsentry/sentry-cocoa/issues/1197#issuecomment-877668159
* Sample event with status_code set: https://sentry.io/organizations/sentry-sdks/issues/2280281206/events/4cb980d3b4044b429ad876f9c9187a1e/?project=5428537
* Development documentation that contains the status_code for breadcrumbs: https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types