### PR TITLE
Use markdown front matter for page title

### DIFF
--- a/src/docs/sdk/research/performance/index.mdx
+++ b/src/docs/sdk/research/performance/index.mdx
@@ -1,4 +1,6 @@
-# Performance Monitoring: Sentry SDK API Evolution
+---
+title: "Performance Monitoring: Sentry SDK API Evolution"
+---
 
 The objective of this document is to contextualize the evolution of the Performance Monitoring features in Sentry SDKs. We start with a summary of how Performance Monitoring was added to Sentry and to SDKs, and, later, we discuss lessons learned in the form of identified issues and the initiatives to address those issues.
 


### PR DESCRIPTION
That's what we do instead of starting the document with an `<h1>` (`#` in markdown) because it makes the title available as metadata for the static site generation.