### PR TITLE
Add warning to Geolocation doc about PII

### DIFF
--- a/src/docs/self-hosted/geolocation.mdx
+++ b/src/docs/self-hosted/geolocation.mdx
@@ -2,7 +2,13 @@
 title: 'Self-Hosted Geolocation'
 ---
 
-Sentry can use [MaxMind's free `GeoLite2-City` database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end user's IP address is known and for the session history of users logging into your Sentry installation. We bundle MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for this purpose. To enable IP address geolocation, [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), then tell Sentry about your credentials by placing your MaxMind configuration file at `geoip/GeoIP.conf`.
+Sentry can use [MaxMind's free `GeoLite2-City` database](https://dev.maxmind.com/geoip/geoip2/geolite2/) to geolocate IP addresses, providing additional context for error events where the end user's IP address is known and for the session history of users logging into your Sentry installation. We bundle MaxMind's [`geoipupdate`](https://hub.docker.com/r/maxmindinc/geoipupdate) tool for this purpose.
+
+<Alert title="Warning" level="warning">
+In order to take advantage of server-side IP address geolocation, you must send IP addresses to Sentry in the first place. <a href="https://docs.sentry.io/platforms/python/data-management/sensitive-data/#personally-identifiable-information-pii">Newer SDKs do not do this by default</a>.
+</Alert>
+
+To enable server-side IP address geolocation, [sign up for a free MaxMind account](https://www.maxmind.com/en/geolite2/signup), then tell Sentry about your credentials by placing your MaxMind configuration file at `geoip/GeoIP.conf`.
 
 ```
 AccountID 012345
@@ -16,7 +22,7 @@ With this configuration file in place, subsequent runs of Sentry's `install.sh` 
 
 1. For the `web` service: **User Settings > Security > Session History** should display country code and region (for example, "US (CA)") underneath the IP addresses in the table.
 
-Note that it's normal to see the `sentry_onpremise_geoipupdate_1` container exit soon after startup, since updating the geolocation database is a one-off batch process and not a long-running job.
+It's normal to see the `sentry_onpremise_geoipupdate_1` container exit soon after startup, since updating the geolocation database is a one-off batch process and not a long-running job.
 
 ## Upgrading
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -50,7 +50,7 @@ Keep in mind that all this setup uses single-nodes for all services, including K
 
 Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/self-hosted/releases/">releases page</Link>.
 
-<Alert title="Warning" level="warn">
+<Alert title="Warning" level="warning">
   There are certain hard-stops you need to go through when upgrading from earlier versions. See the  <Link to="#hard-stops">hard-stops</Link> section below for a list.
 </Alert>
 


### PR DESCRIPTION
Newer SDKs don't send IP addresses by default, which breaks geolocation. Let's warn people about this.

https://forum.sentry.io/t/re-geolocation-doesnt-work-on-default-sentry/14651