### PR TITLE
Add troubleshooting section on Postgres disk space

### DIFF
--- a/src/docs/self-hosted/troubleshooting.mdx
+++ b/src/docs/self-hosted/troubleshooting.mdx
@@ -97,6 +97,23 @@ worker1:
 
 To see a more complete example, please see [a sample solution on our community forum](https://forum.sentry.io/t/how-to-clear-backlog-and-monitor-it/10715/14?u=byk).
 
+## Postgres
+
+Postgres is used for the primary datastore, as well as the [nodestore](https://develop.sentry.dev/services/nodestore/) which is used to store key/value data. The `node_nodestore` table can grow rapidly, especially when heavily utilising the Performance Monitoring feature as trace data is stored in this table.
+
+The `node_nodestore` table is cleaned up as part of the `cleanup` task, however Postgres may not get a chance to vacuum the table (especially under heavy load), so even the rows may be deleted, they're still taking up space on disk.
+
+You can use pg-repack which repacks a table live by creating a new table and copying data across, before dropping the old one. You'll want to run this after the clean up script, and note that as it creates a table, disk usage will spike before going back down.
+
+An example script below:
+
+```
+# Only keep the last 7 days of nodestore data. We heavily use performance monitoring.
+docker-compose exec -T sentry-cleanup sentry cleanup --days 7 -m nodestore -l debug
+# This ensures pg-repack exists before running as the container gets recreated on upgrades
+docker-compose exec -T postgres bash -c "apt update && apt install -y postgresql-9.6-repack && su postgres -c 'pg_repack -E info -t nodestore_node'"
+```
+
 ## Other
 
 If you are still stuck, you can always visit our [community forum](https://forum.sentry.io/) to search for existing topics or create a new topic and ask for help. Please keep in mind that we expect the community to help itself, but Sentry employees also try to monitor and answer forum questions when they have time.

--- a/src/docs/self-hosted/troubleshooting.mdx
+++ b/src/docs/self-hosted/troubleshooting.mdx
@@ -103,16 +103,15 @@ Postgres is used for the primary datastore, as well as the [nodestore](https://d
 
 The `node_nodestore` table is cleaned up as part of the `cleanup` task, however Postgres may not get a chance to vacuum the table (especially under heavy load), so even the rows may be deleted, they're still taking up space on disk.
 
-You can use pg-repack which repacks a table live by creating a new table and copying data across, before dropping the old one. You'll want to run this after the clean up script, and note that as it creates a table, disk usage will spike before going back down.
+You can use `pg-repack` which repacks a table live by creating a new table and copying data across, before dropping the old one. You'll want to run this after the clean up script, and note that as it creates a table, **disk usage will spike before going back down**.
 
 An example script below:
 
-```
+```shell
 # Only keep the last 7 days of nodestore data. We heavily use performance monitoring.
-docker-compose exec -T sentry-cleanup sentry cleanup --days 7 -m nodestore -l debug
+docker-compose run -T web cleanup --days 7 -m nodestore -l debug
 # This ensures pg-repack exists before running as the container gets recreated on upgrades
-docker-compose exec -T postgres bash -c "apt update && apt install -y postgresql-9.6-repack && su postgres -c 'pg_repack -E info -t nodestore_node'"
-```
+docker-compose run -T postgres bash -c "apt update && apt install -y --no-install-recommends postgresql-9.6-repack && su postgres -c 'pg_repack -E info -t nodestore_node'"
 
 ## Other
 

--- a/src/docs/self-hosted/troubleshooting.mdx
+++ b/src/docs/self-hosted/troubleshooting.mdx
@@ -112,6 +112,7 @@ An example script below:
 docker-compose run -T web cleanup --days 7 -m nodestore -l debug
 # This ensures pg-repack exists before running as the container gets recreated on upgrades
 docker-compose run -T postgres bash -c "apt update && apt install -y --no-install-recommends postgresql-9.6-repack && su postgres -c 'pg_repack -E info -t nodestore_node'"
+```
 
 ## Other
 


### PR DESCRIPTION
This PR adds a section to the Troubleshooting guide on dealing with Postgres disk space usage due to `nodestore` and what happens if Postgres fails to release disk space from deleted rows.

From https://github.com/getsentry/onpremise/issues/783#issuecomment-880448830