### PR TITLE
ref(perf): Add note about immutable SpanContext

### DIFF
--- a/src/docs/sdk/performance.mdx
+++ b/src/docs/sdk/performance.mdx
@@ -66,7 +66,7 @@ tree as well as the unit of reporting to Sentry.
 - `Span` Interface
 
   - When a `Span` is created, set the `startTimestamp` to the current time
-  - `SpanContext` is the attribute collection for a `Span` (Can be an implementation detail)
+  - `SpanContext` is the attribute collection for a `Span` (Can be an implementation detail). When possible `SpanContext` should be immutable.
   - `Span` should have a method `startChild` which creates a new span with the current span's id as the new span's `parentSpanId` and the current span's `sampled` value copied over to the new span's `sampled` property
   - `Span` should have a method called `toSentryTrace` which returns a string that could be sent as a header called `sentry-trace`.
   - `Span` should have a method called `iterHeaders` (adapt to platform's naming conventions) that returns an iterable or map of header names and values. This is a thin wrapper containing `return {"sentry-trace": toSentryTrace()}` right now. See `continueFromHeaders` as to why this exists and should be preferred when writing integrations.


### PR DESCRIPTION
After discussion with the team, it was decided that `SpanContext` should be immutable.

See: https://github.com/getsentry/sentry-cocoa/issues/1254