### PR TITLE
Specify 21.6.1 as stopper instead of 21.6.3

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -63,11 +63,11 @@ Before starting the upgrade, we shut down all the services and then run some dat
 Currently we have the following hard-stops that you need to go through:
 
 1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2`
-1. If you are coming from a version prior to `10.0.0`, you first need to upgrade to `21.6.3`
+1. If you are coming from a version prior to `10.0.0`, you first need to upgrade to `21.6.1`
 
 So if you are coming from `9.0.0` your path will be:
 ```
-9.0.0 -> 9.1.2 -> 21.6.3 -> latest
+9.0.0 -> 9.1.2 -> 21.6.1 -> latest
 ```
 
 If you are coming from `20.6.0`, you can directly go to latest:


### PR DESCRIPTION
I encountered this problem while upgrading. As fare as I understand the upgrade path `21.6.1` is the last version that still can migrate off `South`. See [21.6.1](https://github.com/getsentry/sentry/blob/21.6.1/src/sentry/runner/commands/upgrade.py) vs [21.6.2](https://github.com/getsentry/sentry/blob/21.6.2/src/sentry/runner/commands/upgrade.py). [e062636](https://github.com/getsentry/sentry/commit/e06263660e6ddf458a3c8c4d2014af5f14552a17) also mentions `21.6.1` as stopper in the changelog.