### PR TITLE
feat: Add different types of breadcrumbs

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -41,6 +41,8 @@ With deeper framework integration, the automatic recording of breadcrumbs is pos
 * System Events: low battery, low storage space, airplane mode started, memory warnings, device orientation changed, etc.
 * [Outgoing HTTP requests](/#http-client-integrations)
 
+Check out the [complete breadcrumb documentation](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types for more types).
+
 ## Event Sampling
 
 SDKs should allow the user to configure what percentage of events are actually sent to the server (the rest should be silently ignored). For example:

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -35,7 +35,11 @@ Manually record application events (into the current scope) during the
 lifecycle of an application. Implement a ring buffer so as not to grow
 indefinitely. The most recent breadcrumbs should be attached to events as they occur.
 
-With deeper framework integration, the automatic recording of some breadcrumbs is possible and recommended.
+With deeper framework integration, the automatic recording of breadcrumbs is possible and recommended, for example:
+
+* UI Events: button clicks, touch events, etc.
+* System Events: low battery, low storage space, airplane mode started, memory warnings, device orientation changed, etc.
+* [Outgoing HTTP requests](/#http-client-integrations)
 
 ## Event Sampling
 


### PR DESCRIPTION
In expected features, the breadcrumbs section doesn't mention which types of breadcrumbs. This is fixed now by adding a few examples.