### PR TITLE
fix: Update the docs to reflect that 21.6 is required

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -64,7 +64,7 @@ Before starting the upgrade, we shut down all the services and then run some dat
 Currently we have the following hard-stops that you need to go through:
 
 1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2`
-1. If you are coming from a version prior to `10.0.0`, you first need to upgrade to `21.6.3`
+1. If you are coming from a version prior to `21.6.0`, you first need to upgrade to `21.6.3`
 
 So if you are coming from `9.0.0` your path will be:
 ```
@@ -73,5 +73,5 @@ So if you are coming from `9.0.0` your path will be:
 
 If you are coming from an intermediate version such as `20.5.0`, you can directly go to latest:
 ```
-20.5.0 -> latest
+20.5.0 -> 21.6.3 -> latest
 ```


### PR DESCRIPTION
Because the squashed migrations were removed in 21.7 folks need to stop at 21.6 before going forward.