### PR TITLE
feat(api): Add API checklist and API concepts

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -37,9 +37,7 @@ export default () => {
           <SidebarLink to="https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md">
             Code of Conduct
           </SidebarLink>
-          <SidebarLink to="/docs/" title="Documentation Guide">
-            <SidebarLink to="/docs/api/">Making an API Public</SidebarLink>
-          </SidebarLink>
+          <SidebarLink to="/docs/">Documentation Guide</SidebarLink>
           <SidebarLink to="/inclusion/">Inclusive Language</SidebarLink>
           <SidebarLink to="/translations/">Translations</SidebarLink>
           <SidebarLink to="/code-review/">Code Review</SidebarLink>
@@ -87,6 +85,11 @@ export default () => {
           <SidebarLink to="/config/">Configuration</SidebarLink>
           <SidebarLink to="/feature-flags/">Feature Flags</SidebarLink>
           <SidebarLink to="/serializers/">Serializers</SidebarLink>
+          <SidebarLink to="/api/" title="API">
+            <Children
+              tree={tree.find(n => n.name === "api").children}
+            />
+          </SidebarLink>
           <SidebarLink to="/pii/" title="PII and Data Scrubbing">
             <SidebarLink to="/pii/types/">Rule Types</SidebarLink>
             <SidebarLink to="/pii/methods/">Redaction Methods</SidebarLink>

--- a/src/docs/api/checklist.mdx
+++ b/src/docs/api/checklist.mdx
@@ -1,0 +1,15 @@
+---
+title: "Public API Checklist"
+---
+
+Below is a checklist that developers should go through before making APIs public.
+
+1. APIs must return JSON. Exceptions to this rule are APIs where the user is specifically requesting for non JSON data. For example, requesting a CSV file or a debug file.
+1. The API should be available if requested with a bearer token from the integration platform.
+1. There are scopes that can be selected in the integration platform that enables or disables access to the resource exposed by the API.
+1. If the API call being made is resource intensive on Sentry's infrastructure, there is a rate limit in place which rate limits excessive calls.
+1. APIs returning a variable number of elements as a list should be paginated. They should be paginated using the link header standard.
+1. End user requests should not easily be able to trigger 5xx errors in our application by manipulating request data or sending invalid/malformed data.
+1. There are tests associated with the API which look for correctness. There should also be tests that check the response format to ensure the API does not deviate from its contract.
+1. The API should return the same format for a status code, irrespective of the input provided. The content can be different but the response format should be the same.
+1. When an API is only available when certain feature flags are enabled (perhaps through a pricing plan), the API should check for that. If a bearer token of an organization who does not have access to the feature is used, the API should return with a 403 Forbidden and an error explaining which feature flag is required.

--- a/src/docs/api/concepts.mdx
+++ b/src/docs/api/concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "API concepts"
+title: "API Concepts"
 ---
 In this document, we will be looking at API concepts that exist and should be followed by endpoints. We also describe why these concepts exist so that developers can use them at their own discretion.
 
@@ -13,7 +13,7 @@ To take an example, let's talk about the projects list endpoint. A project belon
 By default, here's what the project endpoint should look like
 
 ```json
-GET /api/0/projects/
+GET /api/0/projects/{project_slug}/
 {
   "id": 5,
   "name": "foo",
@@ -24,7 +24,7 @@ GET /api/0/projects/
 To display information about a bounded relationship, a user should be able to use the `expand` parameter. This is generally only true for 1:1 relationships.
 
 ```json
-GET /api/0/projects/?expand=organization
+GET /api/0/projects/{project_slug}/?expand=organization
 {
   "id": 5,
   "name": "foo",
@@ -62,7 +62,7 @@ Similar to expanding responses, an API endpoint can also collapse responses. Whe
 To take an example, let's look at the project list endpoints again. A project gets events and hence, has a `stats` component, which conveys information about how many events were received for the project. Let's say we made the stats part of the endpoint public, along with the rest of the projects list endpoint.
 
 ```json
-GET /api/0/projects/
+GET /api/0/projects/{project_slug}/
 {
   "id": 5,
   "name": "foo",
@@ -85,7 +85,7 @@ GET /api/0/projects/
 The `collapse` parameter can be passed to not return stats information.
 
 ```json
-GET /api/0/projects/?collapse=stats
+GET /api/0/projects/{project_slug}/?collapse=stats
 {
   "id": 5,
   "name": "foo",

--- a/src/docs/api/concepts.mdx
+++ b/src/docs/api/concepts.mdx
@@ -4,7 +4,9 @@ title: "API concepts"
 In this document, we will be looking at API concepts that exist and should be followed by endpoints. We also describe why these concepts exist so that developers can use them at their own discretion.
 
 ## Expanding responses
-In general, expose the fewest fields that will still make the API usable in the general scenario. Doing one SQL request per API request is a good rule of thumb. To return information on a bounded relationship, endpoints should rely on the `expand` parameter. To return an unbounded relationship, it should be another endpoint.
+Expanding responses allow us to include relational information on a resource without loading it by default.
+
+In general, endpoints should expose the fewest fields that will make the API usable in the general scenario. Doing one SQL request per API request is a good rule of thumb. To return information on a bounded relationship, endpoints should rely on the `expand` parameter. To return an unbounded relationship, it should be another endpoint.
 
 To take an example, let's talk about the projects list endpoint. A project belongs to an organizations but could be on multiple teams.
 

--- a/src/docs/api/concepts.mdx
+++ b/src/docs/api/concepts.mdx
@@ -40,7 +40,7 @@ GET /api/0/projects/{project_slug}/?expand=organization
 For unbounded relationships, make a separate query. This allows the query to be paginated and reduces the risk of having an arbitrarily large payload.
 
 ```json
-GET /api/0/projects/foo/teams
+GET /api/0/projects/{project_slug}/teams
 [
   {
     "id": 1,

--- a/src/docs/api/concepts.mdx
+++ b/src/docs/api/concepts.mdx
@@ -1,0 +1,94 @@
+---
+title: "API concepts"
+---
+In this document, we will be looking at API concepts that exist and should be followed by endpoints. We also describe why these concepts exist so that developers can use them at their own discretion.
+
+## Expanding responses
+In general, expose the fewest fields that will still make the API usable in the general scenario. Doing one SQL request per API request is a good rule of thumb. To return information on a bounded relationship, endpoints should rely on the `expand` parameter. To return an unbounded relationship, it should be another endpoint.
+
+To take an example, let's talk about the projects list endpoint. A project belongs to an organizations but could be on multiple teams.
+
+By default, here's what the project endpoint should look like
+
+```json
+GET /api/0/projects/
+{
+  "id": 5,
+  "name": "foo",
+  ...
+}
+```
+
+To display information about a bounded relationship, a user should be able to use the `expand` parameter. This is generally only true for 1:1 relationships.
+
+```json
+GET /api/0/projects/?expand=organization
+{
+  "id": 5,
+  "name": "foo",
+  "organization": {
+    "slug": "bar",
+    "isEarlyAdopter": false,
+    ...
+  }
+  ...
+}
+```
+
+For unbounded relationships, make a separate query. This allows the query to be paginated and reduces the risk of having an arbitrarily large payload.
+
+```json
+GET /api/0/projects/foo/teams
+[
+  {
+    "id": 1,
+		"name": "Team 1",
+		"slug": "team1",
+  },
+	{
+    "id": 2,
+		"name": "Team 2",
+		"slug": "team2",
+  }
+]
+
+```
+
+## Collapsing responses
+Similar to expanding responses, an API endpoint can also collapse responses. When the `collapse` parameter is passed, the API should not return attributes that have been collapsed.
+
+To take an example, let's look at the project list endpoints again. A project gets events and hence, has a `stats` component, which conveys information about how many events were received for the project. Let's say we made the stats part of the endpoint public, along with the rest of the projects list endpoint.
+
+```json
+GET /api/0/projects/
+{
+  "id": 5,
+  "name": "foo",
+  "stats": {
+      "24h": [
+          [
+              1629064800,
+              27
+          ],
+          [
+              1629068400,
+              24
+          ],
+          ...
+      ]
+  }
+}
+```
+
+The `collapse` parameter can be passed to not return stats information.
+
+```json
+GET /api/0/projects/?collapse=stats
+{
+  "id": 5,
+  "name": "foo",
+  ...
+}
+```
+
+This is typically only needed if the endpoint is already public and we do not want to introduce a breaking change. Remember, if the endpoint is public and we remove an attribute, it is a breaking change. If you are iterating on an undocumented endpoint, return the minimal set of attributes and rely on the `expand` parameter to get more detailed information.

--- a/src/docs/api/index.mdx
+++ b/src/docs/api/index.mdx
@@ -1,0 +1,8 @@
+---
+title: API
+---
+
+Welcome to the land of APIs! Here, we talk about all things API:
+- [API concepts](/api/concepts/)
+- [Making an API Public](/api/public/)
+- [Public API checklist](/api/checklist/)

--- a/src/docs/api/index.mdx
+++ b/src/docs/api/index.mdx
@@ -3,6 +3,6 @@ title: API
 ---
 
 Welcome to the land of APIs! Here, we talk about all things API:
-- [API concepts](/api/concepts/)
+- [API Concepts](/api/concepts/)
 - [Making an API Public](/api/public/)
 - [Public API checklist](/api/checklist/)

--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -60,16 +60,15 @@ Making an API public offers considerable benefits. A public API allows our custo
 
 As a guide, use these questions:
 
-1. Is the feature for which you're making the endpoint stable?
+1. Is the feature for which you're making the public endpoint stable?
 2. Will the API change substantially in the future?
-3. Does the API offer value to customers who are accessing it?
 
-If your answers are Yes, No and Yes, you're in business - make the API public.
+If your answers are Yes and No, you're in business - make the endpoint public. Head over to the [public API checklist](/api/checklist/) and ensure that your endpoint conforms to the checklist.
 
 ## How to make an endpoint public?
 
-We use [Open API Spec 3](https://swagger.io/docs/specification/about/) to write our API documentation. 
-You can find that content here: [https://github.com/getsentry/sentry/tree/master/api-docs.](https://github.com/getsentry/sentry/tree/master/api-docs) 
+We use [Open API Spec 3](https://swagger.io/docs/specification/about/) to write our API documentation.
+You can find that content here: [https://github.com/getsentry/sentry/tree/master/api-docs.](https://github.com/getsentry/sentry/tree/master/api-docs)
 You can find the tests here: [https://github.com/getsentry/sentry/tree/master/tests/apidocs](https://github.com/getsentry/sentry/tree/master/tests/apidocs).
 
 ### Local development


### PR DESCRIPTION
This PR does the following:
## Move API documentation instructions to it's own section in the sidebar
It is currently nested under "Documentation Guide" and it's not easily findable.

## Add a public API checklist
This has been moved from our internal wiki to the develop site. This was discussed and agreed upon during the last backend TSC. Since what was presented in backend TSC:
1. I've removed which status codes we respond with cause it was simply listing out the HTTP spec
2. Have not added guidelines on error objects - this is still something we should do but I do not want to block these guidelines while we figure that out
3. Made the list numbered

## Add API concepts
This has also been moved from our internal wiki. I've added `collapse` to the guidelines.

## Notes to the reviewer
Please click on the Vercel link to see what this will look like on production.