### PR TITLE
fix(self-hosted): Consolidate and fix upgrade docs

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -103,14 +103,16 @@ export default () => {
         </div>
         <ul className="list-unstyled" data-sidebar-tree>
           <SidebarLink to="/self-hosted/">Overview</SidebarLink>
-          <SidebarLink to="/self-hosted/custom-ca-roots/">Custom CA Roots</SidebarLink>
+          <SidebarLink to="/self-hosted/releases/">
+            Releases & Upgrading
+          </SidebarLink>
+          <SidebarLink to="/self-hosted/backup/">Backup & Restore</SidebarLink>
+          <SidebarLink to="/self-hosted/custom-ca-roots/">
+            Custom CA Roots
+          </SidebarLink>
           <SidebarLink to="/self-hosted/email/">Email</SidebarLink>
           <SidebarLink to="/self-hosted/geolocation/">Geolocation</SidebarLink>
           <SidebarLink to="/self-hosted/sso/">Single Sign-On (SSO)</SidebarLink>
-          <SidebarLink to="/self-hosted/backup/">Backup & Restore</SidebarLink>
-          <SidebarLink to="/self-hosted/releases/">
-            Versioning & Releases
-          </SidebarLink>
           <SidebarLink to="/self-hosted/troubleshooting/">
             Troubleshooting
           </SidebarLink>
@@ -170,9 +172,7 @@ export default () => {
           <SidebarLink to="/services/digests/">
             Notification Digests
           </SidebarLink>
-          <SidebarLink to="/services/relay/">
-            Relay
-          </SidebarLink>
+          <SidebarLink to="/services/relay/">Relay</SidebarLink>
           <SidebarLink to="https://github.com/getsentry/snuba">
             Snuba
           </SidebarLink>
@@ -243,7 +243,9 @@ export default () => {
             </SidebarLink>
           </SidebarLink>
           <SidebarLink to="/sdk/sessions/">Sessions</SidebarLink>
-          <SidebarLink to="/sdk/research/performance">Research: Performance Monitoring API</SidebarLink>
+          <SidebarLink to="/sdk/research/performance">
+            Research: Performance Monitoring API
+          </SidebarLink>
         </ul>
       </li>
       <li className="mb-3" data-sidebar-branch>

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -46,32 +46,3 @@ Here is further information on specific configuration topics related to self-hos
 We strongly recommend using a dedicated load balancer in front of your Sentry setup bound to a dedicated domain or subdomain. A dedicated load balancer that does SSL/TLS termination that also forwards the client IP address as Docker Compose internal network (as this is [close to impossible to get otherwise)](https://github.com/getsentry/onpremise/issues/554) would give you the best Sentry experience.
 
 Keep in mind that all this setup uses single-nodes for all services, including Kafka. For larger loads, you'd need a beefy machine with lots of RAM and disk storage. To scale up even further, you are very likely to use clusters with a more complex tool, such as Kubernetes. Due to self-hosted installations' very custom nature, we do not offer any recommendations or guidance around scaling up. We do what works for us for our thousands of customers over at [sentry.io](https://sentry.io/) and would love to have you over when you feel your local install's maintenance becomes a burden instead of a joy.
-
-## Upgrading
-
-Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/self-hosted/releases/">releases page</Link>.
-
-<Alert title="Warning" level="warning">
-  There are certain hard-stops you need to go through when upgrading from earlier versions. See the  <Link to="#hard-stops">hard-stops</Link> section below for a list.
-</Alert>
-
-To upgrade, all you need to do is download or check out the version of onpremise repository you want, replace your existing folder's contents with that, and then run `./install.sh`. **We may have some updated configuration, especially for new features, so always check the example config files under the [sentry directory](https://github.com/getsentry/onpremise/blob/master/sentry/) and see if you need to update your existing configuration**. We do our best to automate critical configuration updates, but you should always check your configs during upgrades.
-
-Before starting the upgrade, we shut down all the services and then run some data migrations, so expect to have some downtime. There is an *experimental* `--minimize-downtime` option to reduce the downtime during upgrades. Use this at your own risk and see [the pull request it was implemented in](https://github.com/getsentry/onpremise/issues/607) for more information.
-
-### Hard Stops
-
-Currently we have the following hard-stops that you need to go through:
-
-1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2`
-1. If you are coming from a version prior to `10.0.0`, you first need to upgrade to `21.6.3`
-
-So if you are coming from `9.0.0` your path will be:
-```
-9.0.0 -> 9.1.2 -> 21.6.3 -> latest
-```
-
-If you are coming from an intermediate version such as `20.5.0`, you can directly go to latest:
-```
-20.5.0 -> latest
-```

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Self-Hosted Versions & Releases'
+title: 'Self-Hosted Releases & Upgrading'
 ---
 
 ![CalVer: YY.MM.MICRO](https://img.shields.io/badge/calver-YY.MM.MICRO-ad6caa.svg)
 
-Self-hosted Sentry follows a monthly release schedule using the [CalVer](https://calver.org/#scheme) versioning scheme. A new version is released on the [15th of each month](https://github.com/getsentry/onpremise/blob/704e4c3b5b7360080f79bcfbe26583e5a95ae675/.github/workflows/release.yml#L20-L24), and follow-up releases are done when necessary in between. You can find the [latest release](https://github.com/getsentry/onpremise/releases/latest) over at the [releases section of our onpremise repository](https://github.com/getsentry/onpremise/releases/).
+Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io](https://sentry.io) as possible. We decided to follow a monthly release schedule using the [CalVer](https://calver.org/#scheme) versioning scheme. A new version is released on the [15th of each month](https://github.com/getsentry/onpremise/blob/704e4c3b5b7360080f79bcfbe26583e5a95ae675/.github/workflows/release.yml#L20-L24), and follow-up releases are done when necessary in between. You can find the [latest release](https://github.com/getsentry/onpremise/releases/latest) over at the [releases section of our onpremise repository](https://github.com/getsentry/onpremise/releases/).
 
 <Alert title="Why CalVer?" level="info">
   In short, this is to keep the self-hosted Sentry as close to the live version
@@ -18,9 +18,30 @@ Self-hosted Sentry follows a monthly release schedule using the [CalVer](https:
 
 ## Upgrading
 
-We strongly recommend upgrading by going through all the versions between your current version and the target version you are upgrading to. That means if you are on version `20.6.0` and want to upgrade to `20.8.0`, the recommendation is for you to upgrade to `20.7.0` first and then upgrade to `20.8.0`. Skipping versions *may* work, but there will be times that Sentry requires specific a version to be installed first, to ensure essential data migrations before moving forward.
+We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/self-hosted/releases/">releases page</Link>.
 
-Upgrading is as simple as downloading the latest version of the onpremise repository and running `./install.sh` there. See the <Link to="/self-hosted/">main page for self-hosted Sentry</Link> if you need more information about upgrades and configuration.
+<Alert title="Warning" level="warning">
+  There are certain hard-stops you need to go through when upgrading from earlier versions. See the  <Link to="#hard-stops">hard-stops</Link> section below for a list.
+</Alert>
+
+To upgrade, all you need to do is download or check out the version of onpremise repository you want, replace your existing folder's contents with that, and then run `./install.sh`. **We may have some updated configuration, especially for new features, so always check the example config files under the [sentry directory](https://github.com/getsentry/onpremise/blob/master/sentry/) and see if you need to update your existing configuration**. We do our best to automate critical configuration updates, but you should always check your configs during upgrades.
+
+Before starting the upgrade, we shut down all the services and then run some data migrations, so expect to have some downtime. There is an *experimental* `--minimize-downtime` option to reduce the downtime during upgrades. Use this at your own risk and see [the pull request it was implemented in](https://github.com/getsentry/onpremise/issues/607) for more information.
+
+### Hard Stops
+
+Currently we have the following hard-stops that you need to go through:
+
+1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2`:
+   ```
+   9.0.0 -> 9.1.2 -> 21.6.3 -> latest
+   ```
+1. If you are coming from a version prior to `21.6.3`, you first need to upgrade to `21.6.3`:
+   ```
+   20.5.0 -> 21.6.3 -> latest
+   ```
+
+Any other case (`21.6.3+`), you should be able to upgrade to the latest version directly.
 
 ## Nightly Builds
 

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -18,15 +18,15 @@ Sentry cuts regular releases for self-hosting to keep it as close to [sentry.io]
 
 ## Upgrading
 
-We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience. You can read more about our versioning strategy and philosophy over at the <Link to="/self-hosted/releases/">releases page</Link>.
-
-<Alert title="Warning" level="warning">
-  There are certain hard-stops you need to go through when upgrading from earlier versions. See the  <Link to="#hard-stops">hard-stops</Link> section below for a list.
-</Alert>
+We encourage everyone to regularly update their Sentry installations to get the best and the most recent Sentry experience.
 
 To upgrade, all you need to do is download or check out the version of onpremise repository you want, replace your existing folder's contents with that, and then run `./install.sh`. **We may have some updated configuration, especially for new features, so always check the example config files under the [sentry directory](https://github.com/getsentry/onpremise/blob/master/sentry/) and see if you need to update your existing configuration**. We do our best to automate critical configuration updates, but you should always check your configs during upgrades.
 
 Before starting the upgrade, we shut down all the services and then run some data migrations, so expect to have some downtime. There is an *experimental* `--minimize-downtime` option to reduce the downtime during upgrades. Use this at your own risk and see [the pull request it was implemented in](https://github.com/getsentry/onpremise/issues/607) for more information.
+
+<Alert title="Warning" level="warning">
+  There are certain hard-stops you need to go through when upgrading from earlier versions. Please read the <Link to="#hard-stops">hard-stops</Link> section below for a list.
+</Alert>
 
 ### Hard Stops
 


### PR DESCRIPTION
This PR does 3 things:

1. Fix the hard-stops section in upgrading to indicate the need for `21.6.3`.
2. Consolidate 'Upgrading' sections in the main overview and 'Versions & Releases' page under the renamed 'Releases & Upgrading' page
3. Reorder sidebar items for importance and relevance.

Refs getsentry/onpremise#1062.
