### PR TITLE
ref(selfhosted) Add missing hard stop

### DIFF
--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -38,11 +38,11 @@ Currently we have the following hard-stops that you need to go through:
 
 1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2`:
    ```
-   9.0.0 -> 9.1.2 -> 21.6.3 -> latest
+   9.0.0 -> 9.1.2 -> 21.5.0 -> 21.6.3 -> latest
    ```
 1. If you are coming from a version prior to `21.6.3`, you first need to upgrade to `21.6.3`:
    ```
-   20.5.0 -> 21.6.3 -> latest
+   20.6.0 -> 21.6.3 -> latest
    ```
 
 Any other case (`21.6.3+`), you should be able to upgrade to the latest version directly.


### PR DESCRIPTION
Users coming from sentry 9.x need to stop at 21.5.0 as it is the last release that contains south upgrade shims. They will also need to stop at 21.6.3 to run the last of the django migrations that were squashed.