### PR TITLE
ref(general): Simplify inclusion.mdx "Git Branch Naming"

### DIFF
--- a/src/docs/inclusion.mdx
+++ b/src/docs/inclusion.mdx
@@ -66,19 +66,10 @@ terminology referred to master and slave repositories.  At present changing the
 default branch on existing repositories has negative consequences for users
 that have already cloned the repositories so these should not be changed.
 
-To reconfigure git to use a different default branch name for `git init` a template
-can be configured.  Put the following into your `~/.gitconfig`:
-
-```ini {tabTitle: Git Config}
-[init]
-	templateDir = ~/.config/git/template/
-```
-
-And then create an appropriate template like this:
+As of Git 2.28, you can reconfigure git to use a different default branch name for `git init`:
 
 ```bash
-mkdir -p "$(git config --path --get init.templateDir)"
-echo "ref: refs/heads/main" > "$(git config --path --get init.templateDir)/HEAD"
+git config --global init.defaultBranch main
 ```
 
 From this moment onwards future repositories will use the default branch name "main" instead.


### PR DESCRIPTION
This PR simplifies the instructions for setting your default `git init` branch name to use the `init.defaultBranch` config option that was introduced in Git 2.28 (released last year, around July 2020).

See https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch for GitHub's 27th July 2020 blog post on the topic.

I opted to add the wording "As of Git 2.28" to the docs, in case anyone's got a client over a year out of date, and since Git won't produce any error if it comes across a config option it doesn't know about. (So it would silently appear to succeed if the user's on an older version)