### PR TITLE
fix(tracing): Small fixes to tracestate docs about third-party data

### DIFF
--- a/src/docs/sdk/performance/trace-context.mdx
+++ b/src/docs/sdk/performance/trace-context.mdx
@@ -72,7 +72,7 @@ Tracestate headers contain several vendor-specific opaque data. As per HTTP spec
 
 - Joined by comma:
   ```
-  tracestate: sentry=<data>, other=<data>
+  tracestate: sentry=<data>,other=<data>
   ```
 - Repetition:
   ```
@@ -119,7 +119,7 @@ ewogICJ0cmFjZV9pZCI6ICI3NzFhNDNhNDE5MjY0MmYwYjEzNmQ1MTU5YTUwMTcwMCIsCiAgInB1Ymxp
 Resulting in the header:
 
 ```
-tracestate: other=[omitted],sentry=ewogICJ0cmFjZV9pZCI6ICI3NzFhNDNhNDE5MjY0MmYwYjEzNmQ1MTU5YTUwMTcwMCIsCiAgInB1YmxpY19rZXkiOiAiNDlkMGY3Mzg2YWQ2NDU4NThhZTg1MDIwZTM5M2JlZjMiLAogICJyZWxlYXNlIjogIjEuMS4yMiIsCiAgImVudmlyb25tZW50IjogImRldiIsCiAgInVzZXIiOiB7CiAgICAic2VnbWVudCI6ICJ2aXAiLAogICAgImlkIjogIjdlZmE0OTc4ZGExNzc3MTNkZjA4OGY4NDZmOGM0ODRkIgogIH0KfQ
+tracestate: sentry=ewogICJ0cmFjZV9pZCI6ICI3NzFhNDNhNDE5MjY0MmYwYjEzNmQ1MTU5YTUwMTcwMCIsCiAgInB1YmxpY19rZXkiOiAiNDlkMGY3Mzg2YWQ2NDU4NThhZTg1MDIwZTM5M2JlZjMiLAogICJyZWxlYXNlIjogIjEuMS4yMiIsCiAgImVudmlyb25tZW50IjogImRldiIsCiAgInVzZXIiOiB7CiAgICAic2VnbWVudCI6ICJ2aXAiLAogICAgImlkIjogIjdlZmE0OTc4ZGExNzc3MTNkZjA4OGY4NDZmOGM0ODRkIgogIH0KfQ,other=[omitted]
 ```
 
 ## Implementation Guidelines

--- a/src/docs/sdk/performance/trace-context.mdx
+++ b/src/docs/sdk/performance/trace-context.mdx
@@ -8,7 +8,7 @@ This feature is under development and not required for all SDKs supporting Perfo
 
 </Alert>
 
-In order to sample traces we need to pass along the call chain a trace id together with the  necessary information for making a sampling decision, the so-called "trace context".
+In order to sample traces we need to pass along the call chain a trace id together with the necessary information for making a sampling decision, the so-called "trace context".
 
 ## Protocol
 
@@ -22,14 +22,14 @@ Regardless of the transport mechanism, the trace context is a JSON object with t
 
 - `trace_id` (string, required) - UUID V4 encoded as a hexadecimal sequence with no dashes (e.g. `771a43a4192642f0b136d5159a501700`) that is a sequence of 32 hexadecimal digits. This must match the trace id of the submitted transaction item.
 - `public_key` (string, required) - Public key from the DSN used by the SDK. It allows Sentry to sample traces spanning multiple projects, by resolving the same set of rules based on the starting project.
-- `release` (string, optional) - The release name as specified in client options, usually: `package@x.y.z+build`. *This should match the `release` attribute of the transaction event payload*.*
-- `environment` - The environment name as specified in client options, for example `staging`. *This should match the `environment` attribute of the transaction event payload*.*
+- `release` (string, optional) - The release name as specified in client options, usually: `package@x.y.z+build`. _This should match the `release` attribute of the transaction event payload_.\*
+- `environment` - The environment name as specified in client options, for example `staging`. _This should match the `environment` attribute of the transaction event payload_.\*
 - `user` (object, optional) - A subset of the scope's user context containing the following fields:
-    - `id` (string, optional) - The `id` attribute of the user context.
-    - `segment` (string, optional) - The value of a `segment` attribute in the user's data bag, if it exists. In the future, this field may be promoted to a proper attribute of the user context.
-- `transaction` (string, optional) - The transaction name set on the scope. *This should match the `transaction` attribute of the transaction event payload*.*
+  - `id` (string, optional) - The `id` attribute of the user context.
+  - `segment` (string, optional) - The value of a `segment` attribute in the user's data bag, if it exists. In the future, this field may be promoted to a proper attribute of the user context.
+- `transaction` (string, optional) - The transaction name set on the scope. _This should match the `transaction` attribute of the transaction event payload_.\*
 
-** See "Freezing the Context" for more information on consistency between the trace context and fields in the event payload.*
+\*_ See "Freezing the Context" for more information on consistency between the trace context and fields in the event payload._
 
 **Example:**
 
@@ -43,7 +43,7 @@ Regardless of the transport mechanism, the trace context is a JSON object with t
     "id": "7efa4978da177713df088f846f8c484d",
     "segment": "vip"
   },
-  "transaction": "/api/0/project_details",
+  "transaction": "/api/0/project_details"
 }
 ```
 
@@ -55,7 +55,7 @@ Here's an example of a minimal envelope header containing the trace context (Alt
 
 ```json
 {
-  "event_id":"12c2d058d58442709aa2eca08bf20986",
+  "event_id": "12c2d058d58442709aa2eca08bf20986",
   "trace": {
     "trace_id": "771a43a4192642f0b136d5159a501700",
     "public_key": "49d0f7386ad645858ae85020e393bef3"
@@ -95,7 +95,7 @@ By stripping trailing padding, default base64 parsers may detect an incomplete p
 
 </Alert>
 
-The following is an example :
+For example, the data
 
 ```json
 {
@@ -110,17 +110,19 @@ The following is an example :
 }
 ```
 
-Would encode as:
+would encode as
 
 ```
 ewogICJ0cmFjZV9pZCI6ICI3NzFhNDNhNDE5MjY0MmYwYjEzNmQ1MTU5YTUwMTcwMCIsCiAgInB1YmxpY19rZXkiOiAiNDlkMGY3Mzg2YWQ2NDU4NThhZTg1MDIwZTM5M2JlZjMiLAogICJyZWxlYXNlIjogIjEuMS4yMiIsCiAgImVudmlyb25tZW50IjogImRldiIsCiAgInVzZXIiOiB7CiAgICAic2VnbWVudCI6ICJ2aXAiLAogICAgImlkIjogIjdlZmE0OTc4ZGExNzc3MTNkZjA4OGY4NDZmOGM0ODRkIgogIH0KfQ
 ```
 
-Resulting in the header:
+and result in the header
 
 ```
-tracestate: sentry=ewogICJ0cmFjZV9pZCI6ICI3NzFhNDNhNDE5MjY0MmYwYjEzNmQ1MTU5YTUwMTcwMCIsCiAgInB1YmxpY19rZXkiOiAiNDlkMGY3Mzg2YWQ2NDU4NThhZTg1MDIwZTM5M2JlZjMiLAogICJyZWxlYXNlIjogIjEuMS4yMiIsCiAgImVudmlyb25tZW50IjogImRldiIsCiAgInVzZXIiOiB7CiAgICAic2VnbWVudCI6ICJ2aXAiLAogICAgImlkIjogIjdlZmE0OTc4ZGExNzc3MTNkZjA4OGY4NDZmOGM0ODRkIgogIH0KfQ,other=[omitted]
+tracestate: sentry=ewogIC...IH0KfQ,other=[omitted]
 ```
+
+(Note the third-party entry at the end of the header; new or modified entries are always added to the lefthand side, so we put the `sentry=` value there. Also note that though the encoded value has been elided for legibilty here, in a real header the full value would be used.)
 
 ## Implementation Guidelines
 
@@ -161,7 +163,7 @@ Specifically, this means even Envelopes without transactions can contain the `tr
 
 To ensure fully consistent trace contexts for all transactions in a trace, the trace context cannot be changed once it is sent over the wire, even if scope or options change afterwards. That is, once computed the trace context is no longer updated. Even if the app calls `setRelease`, the old release remains in the context.
 
-To compensate for lazy calls to functions like `setTransaction` and `setUser`, the trace context can be thought to be in two states: *NEW* and *SENT* . Initially, the context is in the *NEW* state and it is modifiable. Once sent for first time, it becomes *SENT* and can no longer change.
+To compensate for lazy calls to functions like `setTransaction` and `setUser`, the trace context can be thought to be in two states: _NEW_ and _SENT_ . Initially, the context is in the _NEW_ state and it is modifiable. Once sent for first time, it becomes _SENT_ and can no longer change.
 
 We recommend the trace context should be computed on-the-fly the first time it is needed in any of:
 
@@ -178,7 +180,7 @@ It is recommended that SDKs log modifications of attributes that would result in
 
 ### Incoming Contexts
 
-Same as for intercepting trace IDs from inbound HTTP requests, SDKs should read `tracestate` headers and assume the Sentry trace context, if specified. Such a context is immediately frozen in the *SENT* state and should no longer allow for modifications.
+Same as for intercepting trace IDs from inbound HTTP requests, SDKs should read `tracestate` headers and assume the Sentry trace context, if specified. Such a context is immediately frozen in the _SENT_ state and should no longer allow for modifications.
 
 ##
 
@@ -195,40 +197,41 @@ In short here's the function that converts a context into a base64 string that c
 ```jsx
 // Compact form
 function objToB64(obj) {
-    const utf16Json = JSON.stringify(obj)
-    const b64 = btoa(encodeURIComponent(utf16Json).replace(/%([0-9A-F]{2})/g,
-        function toSolidBytes(match, p1) {
-            return String.fromCharCode('0x' + p1);
-        }))
-    const len = b64.length
-    if (b64[len - 2] === '=')
-        return b64.substr(0, len - 2)
-    else if (b64[len - 1] === '=')
-        return b64.substr(0, len - 1)
-    return b64
+  const utf16Json = JSON.stringify(obj);
+  const b64 = btoa(
+    encodeURIComponent(utf16Json).replace(
+      /%([0-9A-F]{2})/g,
+      function toSolidBytes(match, p1) {
+        return String.fromCharCode("0x" + p1);
+      }
+    )
+  );
+  const len = b64.length;
+  if (b64[len - 2] === "=") return b64.substr(0, len - 2);
+  else if (b64[len - 1] === "=") return b64.substr(0, len - 1);
+  return b64;
 }
 
 // Commented
 function objToB64(obj) {
-    // object to JSON string
-    const utf16Json = JSON.stringify(obj)
-    // still utf16 string but with non ASCI escaped as UTF-8 numbers)
-    const encodedUtf8 =encodeURIComponent(utf16Json);
+  // object to JSON string
+  const utf16Json = JSON.stringify(obj);
+  // still utf16 string but with non ASCI escaped as UTF-8 numbers)
+  const encodedUtf8 = encodeURIComponent(utf16Json);
 
-    // replace the escaped code points with utf16
-    // in the first 256 code points (the most wierd part)
-    const b64 = btoa(endcodedUtf8.replace(/%([0-9A-F]{2})/g,
-        function toSolidBytes(match, p1) {
-            return String.fromCharCode('0x' + p1);
-        }))
+  // replace the escaped code points with utf16
+  // in the first 256 code points (the most wierd part)
+  const b64 = btoa(
+    endcodedUtf8.replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
+      return String.fromCharCode("0x" + p1);
+    })
+  );
 
-    // drop the '=' or '==' padding from base64
-    const len = b64.length
-    if (b64[len - 2] === '=')
-        return b64.substr(0, len - 2)
-    else if (b64[len - 1] === '=')
-        return b64.substr(0, len - 1)
-    return b64
+  // drop the '=' or '==' padding from base64
+  const len = b64.length;
+  if (b64[len - 2] === "=") return b64.substr(0, len - 2);
+  else if (b64[len - 1] === "=") return b64.substr(0, len - 1);
+  return b64;
 }
 // const test = {"x":"a-🙂-读写汉字 - 学中文"}
 // objToB64(test)
@@ -239,10 +242,15 @@ And here's the function that accepts a base64 string (with or without '=' paddin
 
 ```jsx
 function b64ToObj(b64) {
-    utf16 = decodeURIComponent(atob(b64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-    return JSON.parse(utf16)
+  utf16 = decodeURIComponent(
+    atob(b64)
+      .split("")
+      .map(function(c) {
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join("")
+  );
+  return JSON.parse(utf16);
 }
 
 // b64ToObj("eyJ4IjoiYS3wn5mCLeivu+WGmeaxieWtlyAtIOWtpuS4reaWhyJ9")


### PR DESCRIPTION
This fixes two problems with the docs on how to handle third-party `tracestate` data:

- In the "joined by comma" example in the Tracestate Headers section, there shouldn't be a space between the entries. See https://www.w3.org/TR/trace-context/#combined-header-value.

- In the last snippet in that same section, with an example header containing both sentry and third-party data, the order needs to be reversed, since whatever key-value pair you're adding or modifying should end up the leftmost one. See https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field.