### PR TITLE
Add status to span payload and reorder fields logically

### DIFF
--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -66,7 +66,8 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
         "type": "xhr",
         "method": "GET"
       },
-      "span_id": "b01b9f6349558cd1"
+      "span_id": "b01b9f6349558cd1",
+      "status": "ok"
     },
     {
       "start_timestamp": 1588601261.535386,
@@ -75,7 +76,8 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
       "parent_span_id": "9312d0d18bf51736",
       "trace_id": "1e57b752bc6e4544bbaa246cd1d05dee",
       "op": "update",
-      "span_id": "b980d4dec78d7344"
+      "span_id": "b980d4dec78d7344",
+      "status": "ok"
     }
   ]
 }

--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -51,33 +51,32 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
 {
   "spans": [
     {
-      "start_timestamp": 1588601261.481961,
+      "trace_id": "1e57b752bc6e4544bbaa246cd1d05dee",
+      "span_id": "b01b9f6349558cd1",
+      "parent_span_id": "b0e6f15b45c36b12",
+      "op": "http",
       "description": "GET /sockjs-node/info",
+      "status": "ok",
+      "start_timestamp": 1588601261.481961,
+      "timestamp": 1588601261.488901,
       "tags": {
         "http.status_code": "200"
       },
-      "timestamp": 1588601261.488901,
-      "parent_span_id": "b0e6f15b45c36b12",
-      "trace_id": "1e57b752bc6e4544bbaa246cd1d05dee",
-      "op": "http",
       "data": {
         "url": "http://localhost:8080/sockjs-node/info?t=1588601703755",
         "status_code": 200,
         "type": "xhr",
         "method": "GET"
-      },
-      "span_id": "b01b9f6349558cd1",
-      "status": "ok"
+      }
     },
     {
-      "start_timestamp": 1588601261.535386,
-      "description": "Vue <App>",
-      "timestamp": 1588601261.544196,
-      "parent_span_id": "9312d0d18bf51736",
       "trace_id": "1e57b752bc6e4544bbaa246cd1d05dee",
-      "op": "update",
       "span_id": "b980d4dec78d7344",
-      "status": "ok"
+      "parent_span_id": "9312d0d18bf51736",
+      "op": "update",
+      "description": "Vue <App>",
+      "start_timestamp": 1588601261.535386,
+      "timestamp": 1588601261.544196
     }
   ]
 }


### PR DESCRIPTION
Add status to the example as it is one of the possible fields.
Reorder fields in some logical way for readability, most important and required fields first.