### PR TITLE
Don't set lastEventId for transactions

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -184,10 +184,13 @@ keep track of it themselves.
   - This function returns a header (string) `sentry-trace`
   - The value should be the trace header string of the `Span` that is currently on the `Scope`
 
-- `Hub` → Introduce a method called `startTransaction`
+- Introduce a method called `startTransaction`
   - Takes the same two arguments as `Sentry.startTransaction`
   - Creates a new `Transaction` instance
   - Should implement sampling as described in more detail in the 'Sampling' section of this document
+
+- Modify the method called `captureEvent`
+  - Don't set `lastEventId` for transactions
 
 <!--
 NOTE: we may omit this as a deprecated API replaced by `startTransaction` and

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -189,7 +189,7 @@ keep track of it themselves.
   - Creates a new `Transaction` instance
   - Should implement sampling as described in more detail in the 'Sampling' section of this document
 
-- Modify the method called `captureEvent`
+- Modify the method called `captureEvent` or `captureTransaction`
   - Don't set `lastEventId` for transactions
 
 <!--


### PR DESCRIPTION
The `lastEventId` is often used for reporting a user feedback dialog or related use cases. We decided not to update `Hub.lastEventId` for transactions to keep that workflow working.

