### PR TITLE
add link to sentry-cli docs

### DIFF
--- a/src/docs/services/queue.mdx
+++ b/src/docs/services/queue.mdx
@@ -31,7 +31,7 @@ There's a few key differences we practice:
 
 ## Running a Worker
 
-Workers can be run by using the Sentry CLI.
+Workers can be run by using the [Sentry CLI](https://docs.sentry.io/product/cli/).
 
 ```bash
 $ sentry run worker


### PR DESCRIPTION
Adds link to https://docs.sentry.io/product/cli/