### PR TITLE
add info about Kafka tests in CI

### DIFF
--- a/src/docs/testing.mdx
+++ b/src/docs/testing.mdx
@@ -260,3 +260,7 @@ API response payloads. The `TestStubs` global includes all the fixture functions
 
 You should also use `MockApiClient.addMockResponse()` to set responses for API calls your components will make. Failing
 to mock an endpoint will result in tests failing.
+
+### Kafka Tests in CI
+
+The Snuba test suite (`.github/workflows/snuba-integration-test.yml`) is the only test suite that will actually have Kafka running in CI. If you have a test that needs Kafka running then those tests need to be nested under the Snuba test folder (`tests/snuba/`). If you don't, your tests will timeout and be cancelled in GH actions. 


### PR DESCRIPTION
It wasn't obvious that Kafka wasn't running in our generic backend tests.