### PR TITLE
fix(dev): Change info on how to start Docker

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -42,18 +42,15 @@ brew bundle --verbose
 
 ### Docker (Mac specific)
 
-On Mac, `docker` (which brew has already installed for you) needs some manual intervention. You
-can run this command to set it up automatically for you or you can follow the manual steps below:
+On Mac, `docker` (which brew has already installed for you under `/Applications/Docker.app`) needs some manual
+intervention. You can run this command to set it up automatically for you:
 
 ```shell
-SENTRY_NO_VENV_CHECK=1 ./scripts/do.sh init-docker
+open -g -a Docker.app
 ```
 
-#### Manual steps
-
-Open up Spotlight, search for "Docker" and start it. You should soon see the Docker icon in
-your macOS menubar. Docker will automatically run on system restarts, so this should be the
-only time you do this.
+You should soon see the Docker icon in your macOS menubar. Docker will automatically run on system restarts,
+so this should be the only time you do this.
 
 You can verify that Docker is running by running `docker ps` in your terminal.
 


### PR DESCRIPTION
In this [Sentry PR][PR], we remove the Docker initialization code since it broke
few months ago.

[PR]: https://github.com/getsentry/sentry/pull/28352