### PR TITLE
docs/unified-api: Fix wording issue

### DIFF
--- a/src/docs/sdk/unified-api/index.mdx
+++ b/src/docs/sdk/unified-api/index.mdx
@@ -94,7 +94,7 @@ It’s undefined what happens if you call `init` on anything but application sta
 
 A user has to call `init` once but it’s permissible to call this with a disabled DSN of sorts. Might for instance be no parameter passed etc.
 
-Additionally it also setups all default integrations.
+Additionally it also sets up all default integrations.
 
 - `capture_event(event)`: Takes an already assembled event and dispatches it to the currently active hub.  The event object can be a plain dictionary or a typed object whatever makes more sense in the SDK.  It should follow the native protocol as close as possible ignoring platform specific renames (case styles etc.).
 


### PR DESCRIPTION
I'm no native speaker, but "it also setups all default integrations" felt wrong when I just read it in the docs. This PR replaces it with:

> it also sets up all default integrations