### PR TITLE
docs/data-handling: Fix HTTP header name

### DIFF
--- a/src/docs/sdk/data-handling.mdx
+++ b/src/docs/sdk/data-handling.mdx
@@ -11,7 +11,7 @@ In older SDKs you might sometimes see elaborate constructs to allow the user to 
 
 - [_send-default-pii_](https://docs.sentry.io/error-reporting/configuration/#send-default-pii) is **disabled by default**, meaning that data that is naturally sensitive is not sent by default. That means, for example:
 
-  - When attaching HTTP requests to events, "raw" bodies (bodies which cannot be parsed as JSON or formdata) are removed, and known sensitive headers such as `Authentication` or `Cookies` are removed too.
+  - When attaching HTTP requests to events, "raw" bodies (bodies which cannot be parsed as JSON or formdata) are removed, and known sensitive headers such as `Authorization` or `Cookies` are removed too.
 
   - User-specific information (e.g. the current user ID according to the used webframework) is not sent at all.
 


### PR DESCRIPTION
I assume https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization was meant, since `Authentication` does not seems to be a standard HTTP header.