### PR TITLE
fix(env): Use $HOME instead of ~

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -166,12 +166,12 @@ This works because the volta installer conveniently made changes to your shell i
 startup script:
 
 ```shell {filename: ~/.bashrc} {tabTitle: Bash}
-export VOLTA_HOME="~/.volta"
+export VOLTA_HOME="$HOME/.volta"
 grep --silent "$VOLTA_HOME/bin" <<< $PATH || export PATH="$VOLTA_HOME/bin:$PATH"
 ```
 
 ```shell {filename: ~/.zshrc} {tabTitle: Zsh}
-export VOLTA_HOME="~/.volta"
+export VOLTA_HOME="$HOME/.volta"
 grep --silent "$VOLTA_HOME/bin" <<< $PATH || export PATH="$VOLTA_HOME/bin:$PATH"
 ```
 


### PR DESCRIPTION
With the introduction of pyright in pre-commit, using ~ for the home directory
is causing problems with a Popen call. Switching to $HOME to get around this.