### PR TITLE
feat(perf): Document span operations spec

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -205,6 +205,7 @@ export default () => {
           <SidebarLink to="/sdk/rate-limiting/">Rate Limiting</SidebarLink>
           <SidebarLink to="/sdk/performance/" title="Performance">
             <SidebarLink to="/sdk/performance/trace-context/">Trace Contexts</SidebarLink>
+            <SidebarLink to="/sdk/performance/span-operations/">Span Operations</SidebarLink>
           </SidebarLink>
           <SidebarLink to="/sdk/event-payloads/" title="Event Payloads">
             <SidebarLink to="/sdk/event-payloads/transaction/">

--- a/src/docs/sdk/event-payloads/properties/op.mdx
+++ b/src/docs/sdk/event-payloads/properties/op.mdx
@@ -6,6 +6,6 @@ For more details, see <Link to="/sdk/performance/span-operations/">Sentry's conv
 
   ```json
   {
-    "op": "sql.query"
+    "op": "db.query"
   }
   ```

--- a/src/docs/sdk/event-payloads/properties/op.mdx
+++ b/src/docs/sdk/event-payloads/properties/op.mdx
@@ -2,6 +2,8 @@
 
 : _Recommended_. Short code identifying the type of operation the span is measuring.
 
+For more details, see <Link to="/sdk/performance/span-operations/">Sentry's conventions around span operations</Link>.
+
   ```json
   {
     "op": "sql.query"

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -18,38 +18,40 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Browser
 
-| Op         | Usage           | Description                                                                                                         |
-| ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| pageload   |                 | A full page load of a web application                                                                               |
-| navigation |                 | Client-side browser history change in a web application                                                             |
-| resource   |                 | Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming) |
-|            | resource.script |                                                                                                                     |
-|            | resource.link   |                                                                                                                     |
-|            | resource.css    |                                                                                                                     |
-|            | resource.img    |                                                                                                                     |
-| browser    |                 | Usage of browser APIs or functionality                                                                              |
-|            | browser.paint   |                                                                                                                     |
-| mark       |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
-| measure    |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
-| user       |                 |                                                                                                                     |
-| animate    |                 |                                                                                                                     |
+| Category    | Usage           | Description                                                                                                         |
+| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| pageload    |                 | A full page load of a web application                                                                               |
+| navigation  |                 | Client-side browser history change in a web application                                                             |
+| resource    |                 | Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming) |
+|             | resource.script |                                                                                                                     |
+|             | resource.link   |                                                                                                                     |
+|             | resource.css    |                                                                                                                     |
+|             | resource.img    |                                                                                                                     |
+| browser     |                 | Usage of browser APIs or functionality                                                                              |
+|             | browser.paint   |                                                                                                                     |
+| mark        |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
+| measure     |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
+| interaction |                 | A user interaction                                                                                                  |
+| animate     |                 | An animation                                                                                                        |
+| render      |                 | Time it takes to render an element                                                                                  |
+| element     |                 | Operations related to [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components)                 |
 
 ### JS Frameworks
 
-| Op      | Usage        | Description                                    |
-| ------- | ------------ | ---------------------------------------------- |
-| react   |              | Spans related to [React](https://reactjs.org/) |
-|         | react.mount  |                                                |
-|         | react.render |                                                |
-| vue     |              |                                                |
-|         | vue.mount    |                                                |
-|         | vue.update   |                                                |
-| angular |              |                                                |
-| ember   |              |                                                |
+| Category | Usage        | Description                                      |
+| -------- | ------------ | ------------------------------------------------ |
+| react    |              | Spans related to [React](https://reactjs.org/)   |
+|          | react.mount  |                                                  |
+|          | react.render |                                                  |
+| vue      |              | Spans related to [Vue.js](https://vuejs.org/)    |
+|          | vue.mount    |                                                  |
+|          | vue.update   |                                                  |
+| angular  |              | Spans related to [Angular](https://angular.io/)  |
+| ember    |              | Spans related to [EmberJS](https://emberjs.com/) |
 
 ## Web Server
 
-| Op        | Usage           | Description |
+| Category  | Usage           | Description |
 | --------- | --------------- | ----------- |
 | http      |                 |             |
 |           | http.client     |             |
@@ -60,66 +62,69 @@ Having both a category and action is recommended. Operations should be lowercase
 |           | template.init   |             |
 |           | template.parse  |             |
 |           | template.render |             |
-| view      |                 |             |
+| render    |                 |             |
 |           | view.render     |             |
 | serialize |                 |             |
+| console   |                 |             |
 
 ## Web Frameworks
 
-| Op      | Usage             | Description |
-| ------- | ----------------- | ----------- |
-| django  |                   |             |
-|         | django.middleware |             |
-|         | django.view       |             |
-| express |                   |             |
-| rails   |                   |             |
-| rack    |                   |             |
-| console |                   |             |
+| Category | Usage             | Description |
+| -------- | ----------------- | ----------- |
+| django   |                   |             |
+|          | django.middleware |             |
+|          | django.view       |             |
+| express  |                   |             |
+| rails    |                   |             |
+| rack     |                   |             |
 
 ## Database
 
-| Op  | Usage            | Description                |
-| --- | ---------------- | -------------------------- |
-| db  |                  | An operation on a database |
-|     | db.connection    |                            |
-|     | db.transaction   |                            |
-|     | db.sql.query     |                            |
-|     | db.query         |                            |
-|     | db.query.compile |                            |
+| Category | Usage            | Description                |
+| -------- | ---------------- | -------------------------- |
+| db       |                  | An operation on a database |
+|          | db.connection    |                            |
+|          | db.transaction   |                            |
+|          | db.sql.query     |                            |
+|          | db.query         |                            |
+|          | db.query.compile |                            |
 
 ## Serverless (FAAS)
 
-| Op  | Usage       | Description |
-| --- | ----------- | ----------- |
-| aws |             |             |
-|     | aws.lambda  |             |
-|     | aws.request |             |
-| gcp |             |             |
+| Category | Usage            | Description |
+| -------- | ---------------- | ----------- |
+| faas     |                  |             |
+|          | faas.aws         |             |
+|          | faas.aws.lambda  |             |
+|          | faas.aws.request |             |
+|          | faas.gcp         |             |
 
 ## Mobile
 
-| Op         | Usage      | Description                         |
-| ---------- | ---------- | ----------------------------------- |
-| app        |            | Data about the mobile app           |
-|            | app.start  |                                     |
-| ui         |            | An operation on a mobile/desktop UI |
-|            | ui.load    |                                     |
-|            | ui.action  |                                     |
-| navigation |            | Navigating to another screen        |
-| file       |            | Operations on the file system       |
-|            | file.read  |                                     |
-|            | file.write |                                     |
+| Category   | Usage          | Description                         |
+| ---------- | -------------- | ----------------------------------- |
+| app        |                | Data about the mobile app           |
+|            | app.start      |                                     |
+|            | app.start.warm |                                     |
+|            | app.start.cold |                                     |
+| ui         |                | An operation on a mobile/desktop UI |
+|            | ui.load        |                                     |
+|            | ui.action      |                                     |
+| navigation |                | Navigating to another screen        |
+| file       |                | Operations on the file system       |
+|            | file.read      |                                     |
+|            | file.write     |                                     |
 
 ## Messages/Queues
 
-| Op     | Usage         | Description |
-| ------ | ------------- | ----------- |
-| topic  |               |             |
-|        | topic.send    |             |
-|        | topic.recieve |             |
-|        | topic.process |             |
-| queue  |               |             |
-|        | queue.process |             |
-| job    |               |             |
-|        | job.exec      |             |
-| celery |               |             |
+| Category | Usage         | Description |
+| -------- | ------------- | ----------- |
+| topic    |               |             |
+|          | topic.send    |             |
+|          | topic.recieve |             |
+|          | topic.process |             |
+| queue    |               |             |
+|          | queue.process |             |
+| job      |               |             |
+|          | job.exec      |             |
+| celery   |               |             |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -6,13 +6,7 @@ Span operations are a short code identifying the type of operation the span is m
 
 Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/README.md) as much as possible.
 
-Below is a table containing a list of span operations that are recommended to be used.
-
-Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.query`, where `db` is the category and `query` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
-
 It's important to keep categories consistent between SDKs and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations (`db`). The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
-
-Having both a category and action is recommended. Operations should be lowercased.
 
 # List of Operations
 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -10,11 +10,15 @@ Below is a table containing a list of span operations that are recommended to be
 
 Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.sql.query`, where `db` is the category, `sql` is the category identifier, and `query` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
 
-It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations. The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
+It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations (`db`). The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
+
+Due to use of categories in the Sentry product, span categories are expected to be low cardinality data. **Categories should not be auto-generated**. SDK developers should feel free to automatically generate the actions and identifiers for span operations.
 
 Having both a category and action is recommended. Operations should be lowercased.
 
 # List of Operations
+
+The following tables contain examples of operations used by the SDKs and Sentry product. The usage column in the table contains examples of using that operation category, but are not hard recommendations for operation usage. As long as categories stay consistent, SDK developers are free to choose actions and identifiers that best match the use case they are instrumenting.
 
 ## Browser
 
@@ -51,21 +55,22 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Web Server
 
-| Category  | Usage           | Description |
-| --------- | --------------- | ----------- |
-| http      |                 |             |
-|           | http.client     |             |
-|           | http.server     |             |
-| rpc       |                 |             |
-| grpc      |                 |             |
-| template  |                 |             |
-|           | template.init   |             |
-|           | template.parse  |             |
-|           | template.render |             |
-| render    |                 |             |
-|           | view.render     |             |
-| serialize |                 |             |
-| console   |                 |             |
+Web server related spans should aim to follow OpenTelemetry's [HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md) and [RPC](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md) semantic conventions when possible.
+
+| Category  | Usage           | Description                                                        |
+| --------- | --------------- | ------------------------------------------------------------------ |
+| http      |                 | Spans related to http operations                                   |
+|           | http.client     |                                                                    |
+|           | http.server     |                                                                    |
+| rpc       |                 | Spans related to remote procedure calls (RPC)                      |
+| grpc      |                 | Usage of the [gRPC framework](https://grpc.io/)                    |
+| template  |                 |                                                                    |
+|           | template.init   |                                                                    |
+|           | template.parse  |                                                                    |
+|           | template.render |                                                                    |
+| render    |                 | Rendering of a view                                                |
+| serialize |                 | Serialization of data                                              |
+| console   |                 | Accessing web servers through the command line (ex. Rails console) |
 
 ## Web Frameworks
 
@@ -80,6 +85,8 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Database
 
+Databased related spans are expected to follow OpenTelemetry's [Database](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md) semantic conventions when possible.
+
 | Category | Usage            | Description                |
 | -------- | ---------------- | -------------------------- |
 | db       |                  | An operation on a database |
@@ -91,13 +98,15 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Serverless (FAAS)
 
-| Category | Usage            | Description |
-| -------- | ---------------- | ----------- |
-| faas     |                  |             |
-|          | faas.aws         |             |
-|          | faas.aws.lambda  |             |
-|          | faas.aws.request |             |
-|          | faas.gcp         |             |
+Serverless related spans are expected to follow OpenTelemetry's [FaaS](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/faas.md) semantic conventions when possible.
+
+| Category | Usage            | Description                          |
+| -------- | ---------------- | ------------------------------------ |
+| faas     |                  | Invocations of a serverless function |
+|          | faas.aws         |                                      |
+|          | faas.aws.lambda  |                                      |
+|          | faas.aws.request |                                      |
+|          | faas.gcp         |                                      |
 
 ## Mobile
 
@@ -116,6 +125,8 @@ Having both a category and action is recommended. Operations should be lowercase
 |            | file.write     |                                     |
 
 ## Messages/Queues
+
+Messages/Queue spans are expected follow OpenTelemetry's [Messaging](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md) semantic conventions when possible.
 
 | Category | Usage         | Description |
 | -------- | ------------- | ----------- |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -2,7 +2,7 @@
 title: "Span Operations"
 ---
 
-Span operations are a short code identifying the type of operation the span is measuring.
+Span operations are a short code identifying the type of operation the span is measuring. Span operations are low cardinality attributes - they should be as general as possible while still being human readable and useful.
 
 Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md) as much as possible.
 
@@ -46,13 +46,26 @@ Having both a category and action is recommended. Operations should be lowercase
 | angular |              |                                                |
 | ember   |              |                                                |
 
-## HTTP
+## Web Server
 
 | Op   | Usage       | Description |
 | ---- | ----------- | ----------- |
 | http |             |             |
 |      | http.client |             |
 |      | http.server |             |
+| rpc  |             |             |
+| grpc |             |             |
+| view |             |             |
+|      | view.render |             |
+
+## Web Frameworks
+
+| Op      | Usage             | Description |
+| ------- | ----------------- | ----------- |
+| django  |                   |             |
+|         | django.middleware |             |
+| rails   |                   |             |
+| console |                   |             |
 
 ## Database
 
@@ -81,20 +94,48 @@ Having both a category and action is recommended. Operations should be lowercase
 |            | ui.action |                                     |
 | navigation |           | Navigating to another screen        |
 
+## Messages/Queues
 
-# Abhijeet's Notes (WIP)
+| Op     | Usage         | Description |
+| ------ | ------------- | ----------- |
+| topic  |               |             |
+|        | topic.send    |             |
+|        | topic.recieve |             |
+|        | topic.process |             |
+| queue  |               |             |
+|        | queue.process |             |
+| celery |               |             |
 
 ## List of Actions
 
+### Mobile/Desktop
+
+1. `app.init`
+
 ### User Interfaces
 
-1. `init` -> initialize the UI
-2. `load` -> load stuff in?
-    a. `pageload` -> browser specific loading a page
-3. `update` -> update something in the ui
-    a. `navigation` -> navigate to another screen/page without full restart/refresh
+`ui` can be replaced by specific framework name, ex. `react`
 
+1. `ui.init`: time it takes for UI to initialize
+2. `ui.load`: ui takes some loading action
+   a. `pageload`: browser specific loading a page (both init + load)
+3. `ui.mount`: when a UI component mounts on the screen
+4. `ui.update`: update something in the ui
+   a. `navigation`/`navigate`: navigate to another screen/page without full restart/refresh
+5. `ui.unmount`: when a UI component unmounts off the screen
+
+### Browser
+
+- `browser.mark` and `browser.measure` operations were previously referred to as `mark` and `measure`. Should we make this change?
 
 ### Web Servers
 
-- `browser.mark` and `browser.measure` operations were previously referred to as `mark` and `measure`. Should we make this change? 
+1. `http.server`
+
+### Messaging/Queues
+
+Match operation names from [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#operation-names).
+
+1. `send`
+2. `recieve`
+3. `process`

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -10,38 +10,45 @@ Below is a table containing a list of span operations that are recommended to be
 
 Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.redis.set`, where `db` is the category, `redis` is the category identifier, and `set` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
 
+It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations.
+
 Having both a category and action is recommended. Operations should be lowercased.
+
+# List of Operations
 
 ## Browser
 
-| Op         | Action          | Description                                                                                                |
-| ---------- | --------------- | ---------------------------------------------------------------------------------------------------------- |
-| pageload   |                 | A full page load of a web application                                                                      |
-| navigation |                 | Client-side browser history change in a web application                                                    |
-| resource   |                 |                                                                                                            |
-|            | resource.script |                                                                                                            |
-|            | resource.link   |                                                                                                            |
-|            | resource.css    |                                                                                                            |
-|            | resource.img    |                                                                                                            |
-| browser    |                 | Usage of browser APIs or functionality                                                                     |
-|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)       |
-|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) |
-|            | browser.paint   |                                                                                                            |
+| Op         | Usage           | Description                                                                                                         |
+| ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| pageload   |                 | A full page load of a web application                                                                               |
+| navigation |                 | Client-side browser history change in a web application                                                             |
+| resource   |                 | Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming) |
+|            | resource.script |                                                                                                                     |
+|            | resource.link   |                                                                                                                     |
+|            | resource.css    |                                                                                                                     |
+|            | resource.img    |                                                                                                                     |
+| browser    |                 | Usage of browser APIs or functionality                                                                              |
+|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
+|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
+|            | browser.paint   |                                                                                                                     |
+|            |                 |                                                                                                                     |
 
 ### JS Frameworks
 
-| Op      | Action       | Description                                    |
+| Op      | Usage        | Description                                    |
 | ------- | ------------ | ---------------------------------------------- |
 | react   |              | Spans related to [React](https://reactjs.org/) |
 |         | react.mount  |                                                |
 |         | react.render |                                                |
 | vue     |              |                                                |
+|         | vue.mount    |                                                |
+|         | vue.update   |                                                |
 | angular |              |                                                |
 | ember   |              |                                                |
 
 ## HTTP
 
-| Op   | Action      | Description |
+| Op   | Usage       | Description |
 | ---- | ----------- | ----------- |
 | http |             |             |
 |      | http.client |             |
@@ -49,15 +56,15 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Database
 
-| Op  | Action | Description |
-| --- | ------ | ----------- |
-| db  |        |             |
-|     |        |             |
-|     |        |             |
+| Op  | Usage | Description                |
+| --- | ----- | -------------------------- |
+| db  |       | An operation on a database |
+|     |       |                            |
+|     |       |                            |
 
 ## Serverless (FAAS)
 
-| Op  | Action     | Description |
+| Op  | Usage      | Description |
 | --- | ---------- | ----------- |
 | aws |            |             |
 |     | aws.lambda |             |
@@ -65,8 +72,28 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Mobile
 
-| Op  | Action    | Description |
-| --- | --------- | ----------- |
-| ui  |           |             |
-|     | ui.load   |             |
-|     | ui.action |             |
+| Op         | Usage     | Description                         |
+| ---------- | --------- | ----------------------------------- |
+| app        |           | Data about the a mobile app         |
+|            | app.start |                                     |
+| ui         |           | An operation on a mobile/desktop UI |
+|            | ui.load   |                                     |
+|            | ui.action |                                     |
+| navigation |           | Navigating to another screen        |
+
+# List of Actions (WIP)
+
+### User Interfaces
+
+1. `init` -> initialize the UI
+2. `load` -> load stuff in?
+    a. `pageload` -> browser specific loading a page
+3. `update` -> update something in the ui
+    a. `navigation` -> navigate to another screen/page without full restart/refresh
+
+
+### Web Servers
+
+# Abhijeet's Notes (WIP)
+
+- `browser.mark` and `browser.measure` operations were previously referred to as `mark` and `measure`. Should we make this change? 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -1,0 +1,72 @@
+---
+title: "Span Operations"
+---
+
+Span operations are a short code identifying the type of operation the span is measuring.
+
+Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md) as much as possible.
+
+Below is a table containing a list of span operations that are recommended to be used.
+
+Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.redis.set`, where `db` is the category, `redis` is the category identifier, and `set` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
+
+Having both a category and action is recommended. Operations should be lowercased.
+
+## Browser
+
+| Op         | Action          | Description                                                                                                |
+| ---------- | --------------- | ---------------------------------------------------------------------------------------------------------- |
+| pageload   |                 | A full page load of a web application                                                                      |
+| navigation |                 | Client-side browser history change in a web application                                                    |
+| resource   |                 |                                                                                                            |
+|            | resource.script |                                                                                                            |
+|            | resource.link   |                                                                                                            |
+|            | resource.css    |                                                                                                            |
+|            | resource.img    |                                                                                                            |
+| browser    |                 | Usage of browser APIs or functionality                                                                     |
+|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)       |
+|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) |
+|            | browser.paint   |                                                                                                            |
+
+### JS Frameworks
+
+| Op      | Action       | Description                                    |
+| ------- | ------------ | ---------------------------------------------- |
+| react   |              | Spans related to [React](https://reactjs.org/) |
+|         | react.mount  |                                                |
+|         | react.render |                                                |
+| vue     |              |                                                |
+| angular |              |                                                |
+| ember   |              |                                                |
+
+## HTTP
+
+| Op   | Action      | Description |
+| ---- | ----------- | ----------- |
+| http |             |             |
+|      | http.client |             |
+|      | http.server |             |
+
+## Database
+
+| Op  | Action | Description |
+| --- | ------ | ----------- |
+| db  |        |             |
+|     |        |             |
+|     |        |             |
+
+## Serverless (FAAS)
+
+| Op  | Action     | Description |
+| --- | ---------- | ----------- |
+| aws |            |             |
+|     | aws.lambda |             |
+|     |            |             |
+
+## Mobile
+
+| Op  | Action    | Description |
+| --- | --------- | ----------- |
+| ui  |           |             |
+|     | ui.load   |             |
+|     | ui.action |             |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -2,23 +2,23 @@
 title: "Span Operations"
 ---
 
-Span operations are a short code identifying the type of operation the span is measuring. Span operations are low cardinality attributes - they should be as general as possible while still being human readable and useful.
+Span operations are a short code identifying the type of operation the span is measuring. Span operations are low cardinality attributes - they should be as general as possible while still being human readable and useful. They should avoid including high cardinality data like ids and URLs.
 
-Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md) as much as possible.
+Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/README.md) as much as possible.
 
 Below is a table containing a list of span operations that are recommended to be used.
 
-Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.sql.query`, where `db` is the category, `sql` is the category identifier, and `query` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
+Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.query`, where `db` is the category and `query` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
 
-It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations (`db`). The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
-
-Due to use of categories in the Sentry product, span categories are expected to be low cardinality data. **Categories should not be auto-generated**. SDK developers should feel free to automatically generate the actions and identifiers for span operations.
+It's important to keep categories consistent between SDKs and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations (`db`). The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
 
 Having both a category and action is recommended. Operations should be lowercased.
 
 # List of Operations
 
 The following tables contain examples of operations used by the SDKs and Sentry product. The usage column in the table contains examples of using that operation category, but are not hard recommendations for operation usage. As long as categories stay consistent, SDK developers are free to choose actions and identifiers that best match the use case they are instrumenting.
+
+If a span operation is not provided, the value of `default` is used.
 
 ## Browser
 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -2,7 +2,7 @@
 title: "Span Operations"
 ---
 
-Span operations are a short code identifying the type of operation the span is measuring. Span operations are low cardinality attributes - they should be as general as possible while still being human readable and useful. They should avoid including high cardinality data like ids and URLs.
+Span operations are a short code identifying the type of operation the span is measuring. Span operations are low cardinality attributes - they should be as general as possible while still being human readable and useful. They should avoid including high cardinality data like IDs and URLs.
 
 Operations are expected to follow [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/README.md) as much as possible.
 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -8,9 +8,9 @@ Operations are expected to follow [OpenTelemetry's semantic conventions](https:/
 
 Below is a table containing a list of span operations that are recommended to be used.
 
-Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.redis.set`, where `db` is the category, `redis` is the category identifier, and `set` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
+Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers. For example, a redis database operation takes the form `db.sql.query`, where `db` is the category, `sql` is the category identifier, and `query` is the action. Another example is a mobile app rendering it's screen. It would have the operation `ui.load.hot`, where `ui` is the category, `load` is the action, and `hot` is the action identifier.
 
-It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations.
+It's important to keep categories consistent between sdks and integrations as they are used by Sentry in the [Operations Breakdown](https://docs.sentry.io/product/sentry-basics/tracing/event-detail/#operations-breakdown) feature. For example, both `db.init` and `db.query` will be categorized as database operations. The default operations breakdown config can be seen [here](https://github.com/getsentry/sentry/blob/809b7fe54c6f06cc1e4c503cf83ded896472a011/src/sentry/projectoptions/defaults.py#L74).
 
 Having both a category and action is recommended. Operations should be lowercased.
 
@@ -28,9 +28,9 @@ Having both a category and action is recommended. Operations should be lowercase
 |            | resource.css    |                                                                                                                     |
 |            | resource.img    |                                                                                                                     |
 | browser    |                 | Usage of browser APIs or functionality                                                                              |
-|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
-|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
 |            | browser.paint   |                                                                                                                     |
+| mark       |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
+| measure    |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
 |            |                 |                                                                                                                     |
 
 ### JS Frameworks
@@ -48,15 +48,20 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Web Server
 
-| Op   | Usage       | Description |
-| ---- | ----------- | ----------- |
-| http |             |             |
-|      | http.client |             |
-|      | http.server |             |
-| rpc  |             |             |
-| grpc |             |             |
-| view |             |             |
-|      | view.render |             |
+| Op       | Usage           | Description |
+| -------- | --------------- | ----------- |
+| http     |                 |             |
+|          | http.client     |             |
+|          | http.server     |             |
+| rpc      |                 |             |
+| grpc     |                 |             |
+| template |                 |             |
+|          | template.init   |             |
+|          | template.parse  |             |
+|          | template.render |             |
+| view     |                 |             |
+|          | view.render     |             |
+| serialize         |      |             |
 
 ## Web Frameworks
 
@@ -64,35 +69,45 @@ Having both a category and action is recommended. Operations should be lowercase
 | ------- | ----------------- | ----------- |
 | django  |                   |             |
 |         | django.middleware |             |
+|         | django.view       |             |
+| express |                   |             |
 | rails   |                   |             |
+| rack    |                   |             |
 | console |                   |             |
 
 ## Database
 
-| Op  | Usage | Description                |
-| --- | ----- | -------------------------- |
-| db  |       | An operation on a database |
-|     |       |                            |
-|     |       |                            |
+| Op  | Usage            | Description                |
+| --- | ---------------- | -------------------------- |
+| db  |                  | An operation on a database |
+|     | db.connection    |                            |
+|     | db.transaction   |                            |
+|     | db.sql.query     |                            |
+|     | db.query         |                            |
+|     | db.query.compile |                            |
 
 ## Serverless (FAAS)
 
-| Op  | Usage      | Description |
-| --- | ---------- | ----------- |
-| aws |            |             |
-|     | aws.lambda |             |
-|     |            |             |
+| Op  | Usage       | Description |
+| --- | ----------- | ----------- |
+| aws |             |             |
+|     | aws.lambda  |             |
+|     | aws.request |             |
+| gcp |             |             |
 
 ## Mobile
 
-| Op         | Usage     | Description                         |
-| ---------- | --------- | ----------------------------------- |
-| app        |           | Data about the a mobile app         |
-|            | app.start |                                     |
-| ui         |           | An operation on a mobile/desktop UI |
-|            | ui.load   |                                     |
-|            | ui.action |                                     |
-| navigation |           | Navigating to another screen        |
+| Op         | Usage      | Description                         |
+| ---------- | ---------- | ----------------------------------- |
+| app        |            | Data about the a mobile app         |
+|            | app.start  |                                     |
+| ui         |            | An operation on a mobile/desktop UI |
+|            | ui.load    |                                     |
+|            | ui.action  |                                     |
+| navigation |            | Navigating to another screen        |
+| file       |            | Operations on the file system       |
+|            | file.read  |                                     |
+|            | file.write |                                     |
 
 ## Messages/Queues
 
@@ -104,6 +119,8 @@ Having both a category and action is recommended. Operations should be lowercase
 |        | topic.process |             |
 | queue  |               |             |
 |        | queue.process |             |
+| job    |               |             |
+|        | job.exec      |             |
 | celery |               |             |
 
 ## List of Actions
@@ -114,15 +131,15 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ### User Interfaces
 
-`ui` can be replaced by specific framework name, ex. `react`
-
-1. `ui.init`: time it takes for UI to initialize
-2. `ui.load`: ui takes some loading action
+1. `init`: time it takes for UI to initialize
+2. `load`: ui takes some loading action
    a. `pageload`: browser specific loading a page (both init + load)
-3. `ui.mount`: when a UI component mounts on the screen
-4. `ui.update`: update something in the ui
+3. `mount`: when a UI component mounts on the screen
+4. `update`: update something in the ui
    a. `navigation`/`navigate`: navigate to another screen/page without full restart/refresh
-5. `ui.unmount`: when a UI component unmounts off the screen
+5. `unmount`: when a UI component unmounts off the screen
+
+For ex. `ui.init`.
 
 ### Browser
 
@@ -130,7 +147,9 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ### Web Servers
 
-1. `http.server`
+1. `server`
+2. `client`
+3. `middleware`
 
 ### Messaging/Queues
 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -27,8 +27,8 @@ If a span operation is not provided, the value of `default` is used.
 |            | resource.img    |                                                                                                                     |
 | browser    |                 | Usage of browser APIs or functionality                                                                              |
 |            | browser.paint   |                                                                                                                     |
-|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
-|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
+| mark       |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
+| measure    |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
 | ui         |                 |                                                                                                                     |
 |            | ui.animation    | An animation                                                                                                        |
 |            | ui.render       | Time it takes to render a UI element                                                                                |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -81,7 +81,10 @@ Having both a category and action is recommended. Operations should be lowercase
 |            | ui.action |                                     |
 | navigation |           | Navigating to another screen        |
 
-# List of Actions (WIP)
+
+# Abhijeet's Notes (WIP)
+
+## List of Actions
 
 ### User Interfaces
 
@@ -93,7 +96,5 @@ Having both a category and action is recommended. Operations should be lowercase
 
 
 ### Web Servers
-
-# Abhijeet's Notes (WIP)
 
 - `browser.mark` and `browser.measure` operations were previously referred to as `mark` and `measure`. Should we make this change? 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -31,7 +31,8 @@ Having both a category and action is recommended. Operations should be lowercase
 |            | browser.paint   |                                                                                                                     |
 | mark       |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
 | measure    |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
-|            |                 |                                                                                                                     |
+| user       |                 |                                                                                                                     |
+| animate    |                 |                                                                                                                     |
 
 ### JS Frameworks
 
@@ -48,20 +49,20 @@ Having both a category and action is recommended. Operations should be lowercase
 
 ## Web Server
 
-| Op       | Usage           | Description |
-| -------- | --------------- | ----------- |
-| http     |                 |             |
-|          | http.client     |             |
-|          | http.server     |             |
-| rpc      |                 |             |
-| grpc     |                 |             |
-| template |                 |             |
-|          | template.init   |             |
-|          | template.parse  |             |
-|          | template.render |             |
-| view     |                 |             |
-|          | view.render     |             |
-| serialize         |      |             |
+| Op        | Usage           | Description |
+| --------- | --------------- | ----------- |
+| http      |                 |             |
+|           | http.client     |             |
+|           | http.server     |             |
+| rpc       |                 |             |
+| grpc      |                 |             |
+| template  |                 |             |
+|           | template.init   |             |
+|           | template.parse  |             |
+|           | template.render |             |
+| view      |                 |             |
+|           | view.render     |             |
+| serialize |                 |             |
 
 ## Web Frameworks
 
@@ -99,7 +100,7 @@ Having both a category and action is recommended. Operations should be lowercase
 
 | Op         | Usage      | Description                         |
 | ---------- | ---------- | ----------------------------------- |
-| app        |            | Data about the a mobile app         |
+| app        |            | Data about the mobile app           |
 |            | app.start  |                                     |
 | ui         |            | An operation on a mobile/desktop UI |
 |            | ui.load    |                                     |
@@ -122,39 +123,3 @@ Having both a category and action is recommended. Operations should be lowercase
 | job    |               |             |
 |        | job.exec      |             |
 | celery |               |             |
-
-## List of Actions
-
-### Mobile/Desktop
-
-1. `app.init`
-
-### User Interfaces
-
-1. `init`: time it takes for UI to initialize
-2. `load`: ui takes some loading action
-   a. `pageload`: browser specific loading a page (both init + load)
-3. `mount`: when a UI component mounts on the screen
-4. `update`: update something in the ui
-   a. `navigation`/`navigate`: navigate to another screen/page without full restart/refresh
-5. `unmount`: when a UI component unmounts off the screen
-
-For ex. `ui.init`.
-
-### Browser
-
-- `browser.mark` and `browser.measure` operations were previously referred to as `mark` and `measure`. Should we make this change?
-
-### Web Servers
-
-1. `server`
-2. `client`
-3. `middleware`
-
-### Messaging/Queues
-
-Match operation names from [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#operation-names).
-
-1. `send`
-2. `recieve`
-3. `process`

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -22,36 +22,38 @@ If a span operation is not provided, the value of `default` is used.
 
 ## Browser
 
-| Category    | Usage           | Description                                                                                                         |
-| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| pageload    |                 | A full page load of a web application                                                                               |
-| navigation  |                 | Client-side browser history change in a web application                                                             |
-| resource    |                 | Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming) |
-|             | resource.script |                                                                                                                     |
-|             | resource.link   |                                                                                                                     |
-|             | resource.css    |                                                                                                                     |
-|             | resource.img    |                                                                                                                     |
-| browser     |                 | Usage of browser APIs or functionality                                                                              |
-|             | browser.paint   |                                                                                                                     |
-| mark        |                 | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
-| measure     |                 | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
-| interaction |                 | A user interaction                                                                                                  |
-| animate     |                 | An animation                                                                                                        |
-| render      |                 | Time it takes to render an element                                                                                  |
-| element     |                 | Operations related to [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components)                 |
+| Category   | Usage           | Description                                                                                                         |
+| ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| pageload   |                 | A full page load of a web application                                                                               |
+| navigation |                 | Client-side browser history change in a web application                                                             |
+| resource   |                 | Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming) |
+|            | resource.script |                                                                                                                     |
+|            | resource.link   |                                                                                                                     |
+|            | resource.css    |                                                                                                                     |
+|            | resource.img    |                                                                                                                     |
+| browser    |                 | Usage of browser APIs or functionality                                                                              |
+|            | browser.paint   |                                                                                                                     |
+|            | browser.mark    | Usage of [performance.mark() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)                |
+|            | browser.measure | Usage of [performance.measure() API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)          |
+| ui         |                 |                                                                                                                     |
+|            | ui.animation    | An animation                                                                                                        |
+|            | ui.render       | Time it takes to render a UI element                                                                                |
+|            | ui.update       | Time it takes to update a UI element                                                                                |
 
 ### JS Frameworks
 
-| Category | Usage        | Description                                      |
-| -------- | ------------ | ------------------------------------------------ |
-| react    |              | Spans related to [React](https://reactjs.org/)   |
-|          | react.mount  |                                                  |
-|          | react.render |                                                  |
-| vue      |              | Spans related to [Vue.js](https://vuejs.org/)    |
-|          | vue.mount    |                                                  |
-|          | vue.update   |                                                  |
-| angular  |              | Spans related to [Angular](https://angular.io/)  |
-| ember    |              | Spans related to [EmberJS](https://emberjs.com/) |
+JS Frameworks should be prepended with the `ui` category for operations related to UI components.
+
+| Category   | Usage           | Description                                                 |
+| ---------- | --------------- | ----------------------------------------------------------- |
+| ui.react   |                 | Spans related to [React](https://reactjs.org/) components   |
+|            | ui.react.mount  |                                                             |
+|            | ui.react.render |                                                             |
+| ui.vue     |                 | Spans related to [Vue.js](https://vuejs.org/) components    |
+|            | ui.vue.mount    |                                                             |
+|            | ui.vue.update   |                                                             |
+| ui.angular |                 | Spans related to [Angular](https://angular.io/) components  |
+| ui.ember   |                 | Spans related to [EmberJS](https://emberjs.com/) components |
 
 ## Web Server
 


### PR DESCRIPTION
Edit: Please note, the scope of this PR has changed since it's creation. After reading the PR description, please see: https://github.com/getsentry/develop/pull/452#issuecomment-983716185

This PR adds documentation around the span operations spec that we use.

# Background

Before reviewing, I would recommend reading through the `Introduction` of this document: [https://develop.sentry.dev/sdk/research/performance#introduction](https://develop.sentry.dev/sdk/research/performance#introduction)

`OpenTracing`, which we based our initial performance product off of, had a concept of operation name. We can see it being leveraged in this [early JS SDK PR](https://github.com/getsentry/sentry-javascript/pull/1918/files#diff-b7d385e8e3c69cd4ade2edd41436b21255dde1d851717dc5c22cc7623a911a37R61).

According to OpenTracing (which became OpenTelemetry btw): [https://opentracing.io/specification/](https://opentracing.io/specification/)

![https://user-images.githubusercontent.com/18689448/141842485-ae02281d-1d7d-4b0d-9e70-c95a5ee3b73f.png](https://user-images.githubusercontent.com/18689448/141842485-ae02281d-1d7d-4b0d-9e70-c95a5ee3b73f.png)

As we moved forward, we introduced [both the operation and description fields to spans](https://github.com/getsentry/sentry-python/pull/372/files#diff-771cb012ea65fcb826b77e2abb36b504fdf3407fbe8054857b05fe5a41ed5164R80). Now, these seem redundant (and in fact OpenTelemetry just has [span name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span)) - but if we use them correctly, they can be an advantage in our spec.

![image](https://user-images.githubusercontent.com/18689448/142429021-28cfaca9-a1f6-4bf0-a4c4-ee0cdb465649.png)

From the current usage of these attributes, span operation seems to typically be a low cardinality value, a short code that provides instant understanding to the user when they see a span. For example, `db` or `http`. Descriptions tend to be way more high cardinality, so a `db` operation would have the SQL query as it's description, while a `http` operation would have the resource URL as it's description.

Although these conventions were never codified or formally specced out, they seem to be providing a high degree of customer value. As such, when the span operations spec was created, it was heavily based on the existing conventions.

# What was done

Please read through `src/docs/sdk/performance/span-operations.mdx`.

In short, we introduce the ideas of categories and actions when defining span operations. Operations are expected to generally take the form: `CATEGORY.ACTION`, where the categories and actions can have optional identifiers.

# Next Steps

For now, this PR heavily focuses on defining the span operations. As a next step, we may start taking a look at [span descriptions](#463) or other metadata. Eventually, we want to establish a set of semantic conventions around performance monitoring, similar to OpenTelemetry's. In this case, we probably want to rely on OpenTelemetry's semantic conventions for backend focused use cases. For areas like desktop, mobile and browser (where OpenTelemetry lacks details), we should be more liberal in setting standards.

---

For #392.