### PR TITLE
docs(chartcuterie): Config to switch chartcuterie on

### DIFF
--- a/src/docs/services/chartcuterie.mdx
+++ b/src/docs/services/chartcuterie.mdx
@@ -95,8 +95,7 @@ your `config.yml`:
 
 ```yml
 # Enable charctuerie
-chart-rendering:
-  enabled: true
+chart-rendering.enabled: true
 ```
 
 Currently you need to manually build the configuration module in your development environment.


### PR DESCRIPTION
Updated the config to `chart-rendering.enabled: true`
since
```
chart-rendering:
  enabled: true
```
didn't register the config properly.