### PR TITLE
feat: Start react testing library guide

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -86,7 +86,7 @@ export default () => {
           <SidebarLink to="/feature-flags/">Feature Flags</SidebarLink>
           <SidebarLink to="/serializers/">Serializers</SidebarLink>
           <SidebarLink to="/api/" title="API">
-            <Children
+          <Children
               tree={tree.find(n => n.name === "api").children}
             />
           </SidebarLink>
@@ -139,6 +139,9 @@ export default () => {
             Typing DefaultProps
           </SidebarLink>
           <SidebarLink to="/frontend/using-hooks/">Using hooks</SidebarLink>
+          <SidebarLink to="/frontend/using-rtl/">
+            Using React Testing Library
+          </SidebarLink>
           <SidebarLink to="/frontend/migration-gridemotion/">
             Migration - grid-emotion
           </SidebarLink>
@@ -204,7 +207,7 @@ export default () => {
           <SidebarLink to="/sdk/envelopes/">Envelopes</SidebarLink>
           <SidebarLink to="/sdk/rate-limiting/">Rate Limiting</SidebarLink>
           <SidebarLink to="/sdk/performance/" title="Performance">
-            <SidebarLink to="/sdk/performance/trace-context/">Trace Contexts</SidebarLink>
+          <SidebarLink to="/sdk/performance/trace-context/">Trace Contexts</SidebarLink>
           </SidebarLink>
           <SidebarLink to="/sdk/event-payloads/" title="Event Payloads">
             <SidebarLink to="/sdk/event-payloads/transaction/">

--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -156,6 +156,10 @@ We are currently exploring alternatives to the `Reflux` library for future use.
 
 ## Testing
 
+<Alert level="info">
+  We are moving away from Enzyme in favor of React Testing Library. For RTL tips check out <Link to="/frontend/using-rtl/">this page</Link>.
+</Alert>
+
 Note: Your filename needs to be .spec.jsx or jest won’t run it!
 
 We have useful fixtures defined in [setup.js](https://github.com/getsentry/sentry/blob/master/tests/js/setup.js) Use these! If you are defining mock data in a repetitive way, it’s probably worth adding this this file. routerContext is a particularly useful one for providing the context object that most view are written to rely on.

--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -1,0 +1,148 @@
+---
+title: Using React Testing Library
+---
+
+We are in the process of converting our tests from Enzyme to React Testing Library.
+In this guide, you'll find tips to follow best practices and anticipate common pitfalls.
+
+We have two ESLint rules in place to help with this:
+
+- [eslint-plugin-jest-dom](https://github.com/testing-library/eslint-plugin-jest-dom)
+- [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library)
+
+We strive to write tests in such a way that closely resembles how our application is used.
+
+So rather than dealing with instances of rendered components, we query the DOM in the same way the user would.
+We find form elements by their label text (just like a user would), we find links and buttons from their text (like a user would).
+
+As a part of this goal, we avoid testing implementation details so refactors (changes to implementation but not functionality) don't break the tests.
+
+We are generally in favor of Use Case Coverage over Code Coverage.
+
+## Querying
+
+- use `getBy...` as much as possible
+- use `queryBy...` only when checking for non-existence
+- use `await findBy...` only when expecting an element to appear after but the change to the DOM might not happen immediately
+
+To ensure that the tests resemble how users interact with our code we recommend the following priority for querying:
+
+1. `getByRole` - This should be the go-to selector for almost everything. As a nice bonus with this selector, we make sure that our app is accessible. It will most likely be used together with the name option `getByRole('button', {name: /save/i})`. The name is usually the label of a form element or the text content of a button, or the value of the aria-label attribute. If unsure, use the [logRoles](https://testing-library.com/docs/dom-testing-library/api-accessibility/#logroles) feature or consult the [list of available roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#roles).
+2. `getByLabelText`/`getByPlaceholderText` - Users find form elements using label text, therefore this option is prefered when testing forms.
+3. `getByText` - Outside of forms, text content is the main way users find elements. This method can be used to find non-interactive elements (like divs, spans, and paragraphs).
+4. `getByTestId` - As this does not reflect how users interact with the app, it is only recommended for cases where you can't use any other selector
+
+If you still have trouble deciding which query to use, check out [testing-playground.com](https://testing-playground.com/) together with the `screen.logTestingPlaygroundURL()` and their browser extension.
+
+Do not forget, that you can drop `screen.debug()` anywhere in your test to see the current DOM.
+
+Read more about queries in the [official docs](https://testing-library.com/docs/queries/about/).
+
+## Tips
+
+Avoid destructuring query functions from render method, use `screen` instead ([examples](https://github.com/getsentry/sentry/pull/29312)).
+You won't have to keep the render call destructure up-to-date as you add/remove the queries you need. You only need to type `screen` and let your editor's autocomplete take care of the rest.
+
+```javascript
+import { mountWithTheme, screen } from "sentry-test/reactTestingLibrary";
+
+// ❌
+const { getByRole } = mountWithTheme(<Example />);
+const errorMessageNode = getByRole("alert");
+
+// ✅
+mountWithTheme(<Example />);
+const errorMessageNode = screen.getByRole("alert");
+```
+
+Avoid using `queryBy...` for anything except checking for non-existence ([examples](https://github.com/getsentry/sentry/pull/29517)).
+The `getBy...` and `findBy...` variants will throw a more helpful error message if no element is found.
+
+```javascript
+import { mountWithTheme, screen } from "sentry-test/reactTestingLibrary";
+
+// ❌
+mountWithTheme(<Example />);
+expect(screen.queryByRole("alert")).toBeInTheDocument();
+
+// ✅
+mountWithTheme(<Example />);
+expect(screen.getByRole("alert")).toBeInTheDocument();
+expect(screen.queryByRole("button")).not.toBeInTheDocument();
+```
+
+Avoid using `waitFor` for waiting on appearance, use `findBy...` instead ([examples](https://github.com/getsentry/sentry/pull/29544)).
+These two are basically equivalent, but the `findBy...` is simpler and the error message we get will be better.
+
+```javascript
+import {
+  mountWithTheme,
+  screen,
+  waitFor,
+} from "sentry-test/reactTestingLibrary";
+
+// ❌
+mountWithTheme(<Example />);
+await waitFor(() => {
+  expect(screen.getByRole("alert")).toBeInTheDocument();
+});
+
+// ✅
+mountWithTheme(<Example />);
+expect(await screen.findByRole("alert")).toBeInTheDocument();
+```
+
+Avoid using `waitFor` for waiting on disappearance, use `waitForElementToBeRemoved` instead ([examples](https://github.com/getsentry/sentry/pull/29547)).
+The latter is using MutationObserver which is more efficient than polling the DOM at regular intervals with waitFor.
+
+```javascript
+import {
+  mountWithTheme,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "sentry-test/reactTestingLibrary";
+
+// ❌
+mountWithTheme(<Example />);
+await waitFor(() =>
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+);
+
+// ✅
+mountWithTheme(<Example />);
+await waitForElementToBeRemoved(() => screen.getByRole("alert"));
+```
+
+Prefer using jest-dom assertions ([examples](https://github.com/getsentry/sentry/pull/29508)). The advantages of using these recommended assertions are better error messages, overall semantics, consistency, and uniformity.
+
+```javascript
+import { mountWithTheme, screen } from "sentry-test/reactTestingLibrary";
+
+// ❌
+mountWithTheme(<Example />);
+expect(screen.getByRole("alert")).toBeTruthy();
+expect(screen.getByRole("alert").textContent).toEqual("abc");
+expect(screen.queryByRole("button")).toBeFalsy();
+expect(screen.queryByRole("button")).toBeNull();
+
+// ✅
+mountWithTheme(<Example />);
+expect(screen.getByRole("alert")).toBeInTheDocument();
+expect(screen.getByRole("alert")).toHaveTextContent("abc");
+expect(screen.queryByRole("button")).not.toBeInTheDocument();
+```
+
+Prefer using case insensitive regex when searching by text. It will make the tests slightly more resilient to change.
+
+```javascript
+import { mountWithTheme, screen } from "sentry-test/reactTestingLibrary";
+
+// ❌
+mountWithTheme(<Example />);
+expect(screen.getByText("Hello World")).toBeInTheDocument();
+
+// ✅
+mountWithTheme(<Example />);
+expect(screen.getByText(/hello world/i)).toBeInTheDocument();
+```

--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -72,7 +72,7 @@ expect(screen.queryByRole("button")).not.toBeInTheDocument();
 ```
 
 Avoid using `waitFor` for waiting on appearance, use `findBy...` instead ([examples](https://github.com/getsentry/sentry/pull/29544)).
-These two are basically equivalent, but the `findBy...` is simpler and the error message we get will be better.
+These two are basically equivalent (`findBy...` even uses `waitFor` under the hood), but the `findBy...` is simpler and the error message we get will be better.
 
 ```javascript
 import {

--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -3,16 +3,16 @@ title: Using React Testing Library
 ---
 
 We are in the process of converting our tests from Enzyme to React Testing Library.
-In this guide, you'll find tips to follow best practices and anticipate common pitfalls.
+In this guide, you'll find tips to follow best practices and avoid common pitfalls.
 
 We have two ESLint rules in place to help with this:
 
 - [eslint-plugin-jest-dom](https://github.com/testing-library/eslint-plugin-jest-dom)
 - [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library)
 
-We strive to write tests in such a way that closely resembles how our application is used.
+We strive to write tests in a way that closely resembles how our application is used.
 
-So rather than dealing with instances of rendered components, we query the DOM in the same way the user would.
+Rather than dealing with instances of rendered components, we query the DOM in the same way the user would.
 We find form elements by their label text (just like a user would), we find links and buttons from their text (like a user would).
 
 As a part of this goal, we avoid testing implementation details so refactors (changes to implementation but not functionality) don't break the tests.
@@ -23,7 +23,7 @@ We are generally in favor of Use Case Coverage over Code Coverage.
 
 - use `getBy...` as much as possible
 - use `queryBy...` only when checking for non-existence
-- use `await findBy...` only when expecting an element to appear after but the change to the DOM might not happen immediately
+- use `await findBy...` only when expecting an element to appear after a change to the DOM that might not happen immediately
 
 To ensure that the tests resemble how users interact with our code we recommend the following priority for querying:
 
@@ -93,7 +93,7 @@ expect(await screen.findByRole("alert")).toBeInTheDocument();
 ```
 
 Avoid using `waitFor` for waiting on disappearance, use `waitForElementToBeRemoved` instead ([examples](https://github.com/getsentry/sentry/pull/29547)).
-The latter is using MutationObserver which is more efficient than polling the DOM at regular intervals with waitFor.
+The latter uses `MutationObserver` which is more efficient than polling the DOM at regular intervals with waitFor.
 
 ```javascript
 import {


### PR DESCRIPTION
A follow-up to the discussion of the October 7th frontend TSC.

I kicked it off with tips around querying+assertions and pitfalls around that.