### PR TITLE
ref(RTL): Add tip  with recommended library for testing user interactions

### DIFF
--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -146,3 +146,28 @@ expect(screen.getByText("Hello World")).toBeInTheDocument();
 mountWithTheme(<Example />);
 expect(screen.getByText(/hello world/i)).toBeInTheDocument();
 ```
+
+Use `@testing-library/user-event` over `fireEvent` where possible.
+`@testing-library/user-event` is a package that's built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely.
+
+```javascript
+// ❌
+import {
+  mountWithTheme,
+  screen,
+  fireEvent,
+} from "sentry-test/reactTestingLibrary";
+mountWithTheme(<Example />);
+fireEvent.change(screen.getByLabelText("Search by name"), {
+  target: { value: "sentry" },
+});
+
+// ✅
+import {
+  mountWithTheme,
+  screen,
+  userEvent,
+} from "sentry-test/reactTestingLibrary";
+mountWithTheme(<Example />);
+userEvent.type(screen.getByLabelText("Search by name"), "sentry");
+```

--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -148,7 +148,7 @@ expect(screen.getByText(/hello world/i)).toBeInTheDocument();
 ```
 
 Use `userEvent` over `fireEvent` where possible.
-`userEvent` comes from the package`@testing-library/user-event` which is built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely.
+`userEvent` comes from the package `@testing-library/user-event` which is built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely.
 
 ```javascript
 // ❌

--- a/src/docs/frontend/using-rtl.mdx
+++ b/src/docs/frontend/using-rtl.mdx
@@ -147,8 +147,8 @@ mountWithTheme(<Example />);
 expect(screen.getByText(/hello world/i)).toBeInTheDocument();
 ```
 
-Use `@testing-library/user-event` over `fireEvent` where possible.
-`@testing-library/user-event` is a package that's built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely.
+Use `userEvent` over `fireEvent` where possible.
+`userEvent` comes from the package`@testing-library/user-event` which is built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely.
 
 ```javascript
 // ❌


### PR DESCRIPTION
Add a new tip to the React Test Library doc, recommending using `userEvent` instead of `fireEvent` whenever possible.