### PR TITLE
docs(vercel): Update Vercel develop instructions

### DIFF
--- a/src/docs/integrations/vercel.mdx
+++ b/src/docs/integrations/vercel.mdx
@@ -4,15 +4,14 @@ title: "Vercel Integration"
 
 ## Create a Vercel App
 
-To use the Vercel integration you'll need to create your own integration in Vercel. To start, click "Create" in the [Integrations Developer Console](https://vercel.com/dashboard/integrations/console). 
+To use the Vercel integration you'll need to create your own integration in Vercel. To start, click "Create" in the [Integrations Developer Console](https://vercel.com/dashboard/integrations/console).
 
-When configuring the app, use the following values:
-
-| Setting                         | Value                                         |
-| ------------------------------- | --------------------------------------------- |
-| Redirect URL                    | `{YOUR_DOMAIN}/extensions/vercel/configure/`  |
-| UI Hook URL                     | `{YOUR_DOMAIN}/extensions/vercel/ui-hook/`    |
-| Delete Hook URL                 | `{YOUR_DOMAIN}/extensions/vercel/delete/`     |
+When configuring the app:
+* Set the `Redirect URL` to `{YOUR_DOMAIN}/extensions/vercel/configure/`
+* Set the `Webhook URL` to `{YOUR_DOMAIN}/extensions/vercel/delete/` and subscribe to the following events:
+  * Deployment Created
+  * Configuration Removed
+* Leave the `Configuration URL` empty
 
 Take note of your client ID, client secret, and integration URL slug (the value you entered in the URL Slug field. This will be used to construct the integration installation URL). Add those to `config.yml` like this:
 
@@ -23,4 +22,4 @@ vercel.client-secret: your-secret
 vercel.integration-slug: your-integration-slug
 ```
 
-Follow our [documentation on installing and configuring the Vercel integration](https://docs.sentry.io/workflow/integrations/vercel/) to use the integration. 
+Then, go to your integration in Vercel and click on `View in Marketplace`. Add the integration and then follow our [documentation on configuring the Vercel integration](https://docs.sentry.io/product/integrations/deployment/vercel/#configure) to use the integration.


### PR DESCRIPTION
We made some changes to the Vercel integration a few weeks back (see https://github.com/getsentry/sentry/pull/26162). This needs an update to our develop docs so that on prem users can use the integration. So, here are the updates.