### PR TITLE
fix: Description of language of device context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -147,7 +147,7 @@ The `type` and default key is `"device"`.
 
 `language`
 
-: _Optional_. The language of the device. For example, `en-US`.
+: _Optional_. The language of the device. For example, `en`.
 
 `processor_count`
 


### PR DESCRIPTION
The example of the language is actually a locale, instead, it should be a
language.