### PR TITLE
ref(msteams): Update documentation to use Developer Portal

### DIFF
--- a/src/docs/integrations/msteams/index.mdx
+++ b/src/docs/integrations/msteams/index.mdx
@@ -11,22 +11,22 @@ You will need to be a Microsoft Teams Administrator to perform some of the requi
 
 ## Create the Sentry App
 
-1. Visit the [Developer Portal](https://dev.teams.microsoft.com/apps)
-2. Click "Create your first app" or "New App" if you've made one before
-3. Enter "Sentry" as the name
+1. Visit the [Developer Portal](https://dev.teams.microsoft.com/apps).
+2. Click "Create your first app" (or "New App" if you've made one before).
+3. Enter "Sentry" as the name.
 4. Under "Basic Information" use the following values (the rest may be blank):
 
 | Setting                   | Value                       |
-| ------------------------------------------------------- |
-| Short description         | whatever                    |
-| Long description          | whatever but longer         |
+| ------------------------- | --------------------------- |
+| Short description         | enter anything              |
+| Long description          | enter anything              |
 | Developer or company name | Sentry                      |
 | Website                   | https://www.sentry.io       |
 | Privacy policy            | https://sentry.io/privacy/  |
 | Terms of use              | https://www.sentry.io/terms/|
 
 
-5. Hit "Save" at the bottom of the page
+5. Hit "Save" at the bottom of the page.
 6. On the left hand sidebar click "App features" >> "Bot" >> "Create a new bot". You may name this whatever you like.
 7. Enter the bot endpoint address as `{YOUR_DOMAIN}/extensions/msteams/webhook/` and hit save. Take note of your bot ID (shown in the URL).
 8. Go to "Client secrets" and create a secret. Copy the secret as we'll use it later on.
@@ -36,7 +36,7 @@ You will need to be a Microsoft Teams Administrator to perform some of the requi
 
 ## Set up config.yml
 
-Take the values from before and add them to the `config.yml` file as shown below
+Take the values from before and add them to the `config.yml` file as shown below:
 
 ```yml
 # Microsoft Teams #

--- a/src/docs/integrations/msteams/index.mdx
+++ b/src/docs/integrations/msteams/index.mdx
@@ -9,60 +9,45 @@ You will need to be a Microsoft Teams Administrator to perform some of the requi
 
 </Alert>
 
-## Allow Third-Party Apps
-
-Before you can create and install a custom Microsoft App, you will need to allow third party apps to be installed.
-
-1. Visit the [Teams admin page](https://admin.teams.microsoft.com/policies/manage-apps)
-2. Click the "Org-wide app settings" in the upper right hand corner
-3. Enable all the settings on the page as shown below
-
-![Third Party Apps](./3rd-party-apps.png)
-
 ## Create the Sentry App
 
-Now you will need to create a Microsoft Teams app for the Sentry integration.
+1. Visit the [Developer Portal](https://dev.teams.microsoft.com/apps)
+2. Click "Create your first app" or "New App" if you've made one before
+3. Enter "Sentry" as the name
+4. Under "Basic Information" use the following values (the rest may be blank):
 
-1. Visit your [Microsoft Teams page](https://teams.microsoft.com/)
-2. Install the "App Studio" app from the Teams Store
-![App Studio](./app-studio.png)
-3. Go to App Studio
-4. Click on the "Manifest Editor" tab
-5. Press "Crete new app"
-![Create New App](./create-new-app.png)
+| Setting                   | Value                       |
+| ------------------------------------------------------- |
+| Short description         | whatever                    |
+| Long description          | whatever but longer         |
+| Developer or company name | Sentry                      |
+| Website                   | https://www.sentry.io       |
+| Privacy policy            | https://sentry.io/privacy/  |
+| Terms of use              | https://www.sentry.io/terms/|
 
-## Fill out Manifest
-1. Fill out the form on the "App details page" (put whatever you want, it doesn't impact functionality)
-2. Click on the "Bots" tab on the sidebar
-3. Press "Set up"
-4. Fill out the form as shown below
-![Set Up Bot](./set-up-bot.png)
-5. Press "Generate new password" 
-6. Store the password somewhere as it will be used as the `msteams.client-secret` later
-7. Take note of the ID of your bot as shown below as that will be used the `msteams.client-id` later
-![Client ID](./client-id.png)
-8. Set the "Bot endpoint address" to `{YOUR_DOMAIN}/extensions/msteams/webhook/`
+
+5. Hit "Save" at the bottom of the page
+6. On the left hand sidebar click "App features" >> "Bot" >> "Create a new bot". You may name this whatever you like.
+7. Enter the bot endpoint address as `{YOUR_DOMAIN}/extensions/msteams/webhook/` and hit save. Take note of your bot ID (shown in the URL).
+8. Go to "Client secrets" and create a secret. Copy the secret as we'll use it later on.
+9. To go back click "Apps" >> {name of your app} >> "App features" >> "Bot" >> and then choose the bot you just created from the "Select an existing bot" dropdown and hit Save. 
+10. Click "Add a command" and call it anything you like. Select "Team" as the scope, Add it, and again hit Save. 
+
 
 ## Set up config.yml
 
-Take the values from above and add them to the `config.yml` file as shown below
+Take the values from before and add them to the `config.yml` file as shown below
 
 ```yml
 # Microsoft Teams #
-msteams.client-id: your-client-id
-msteams.client-secret: your-secret
+msteams.client-id: 'your-bot-client-id'
+msteams.client-secret: 'your-bot-secret'
 ```
 
 ## Installation
 
-If you left App Studio, go back and go to the "Manifest editor" tab and select your app
-
-1. Click on the "Test and distribute" tab on the left
-2. Fix any errors shown on the right side below "Description"
-![Errors](./errors.png)
-3. Press "Install"
-4. Press "Add to a team" in the popup that appears
-5. Pick the team(s) you want to install the app on
+1. At the top right of the screen click "Preview in Teams".
+2. Select "Add to a team" in the resulting popup, and choose the team(s) you want to install the app on.
 
 You should see a message in the General channel that says "Welcome to Sentry for Microsoft Teams". If you do not get this message, it means was something went wrong and you'll need to uninstall, fix the problem, and re-install it.
 

--- a/src/docs/integrations/msteams/index.mdx
+++ b/src/docs/integrations/msteams/index.mdx
@@ -11,8 +11,8 @@ You will need to be a Microsoft Teams Administrator to perform some of the requi
 
 ## Create the Sentry App
 
-1. Visit the [Developer Portal](https://dev.teams.microsoft.com/apps).
-2. Click "Create your first app" (or "New App" if you've made one before).
+1. Visit the [Developer Portal](https://dev.teams.microsoft.com/apps). Note: You may have to sign up for the [MS 365 Developer Program](https://developer.microsoft.com/en-us/microsoft-365/dev-program) if you're having trouble accessing this. 
+2. Click "New App".
 3. Enter "Sentry" as the name.
 4. Under "Basic Information" use the following values (the rest may be blank):
 
@@ -27,11 +27,11 @@ You will need to be a Microsoft Teams Administrator to perform some of the requi
 
 
 5. Hit "Save" at the bottom of the page.
-6. On the left hand sidebar click "App features" >> "Bot" >> "Create a new bot". You may name this whatever you like.
-7. Enter the bot endpoint address as `{YOUR_DOMAIN}/extensions/msteams/webhook/` and hit save. Take note of your bot ID (shown in the URL).
+6. On the left hand sidebar click "App features" >> "Bot" >> "Create a new bot" >> "New Bot". You may name this whatever you like.
+7. Enter the bot endpoint address as `{YOUR_DOMAIN}/extensions/msteams/webhook/` and hit save. Take note of your bot ID (shown in the URL e.g. https://dev.teams.microsoft.com/bots/{BOT-ID}/configure).
 8. Go to "Client secrets" and create a secret. Copy the secret as we'll use it later on.
-9. To go back click "Apps" >> {name of your app} >> "App features" >> "Bot" >> and then choose the bot you just created from the "Select an existing bot" dropdown and hit Save. 
-10. Click "Add a command" and call it anything you like. Select "Team" as the scope, Add it, and again hit Save. 
+9. To go back click "Apps" >> Sentry >> "App features" >> "Bot" >> and then choose the bot you just created from the "Select an existing bot" dropdown and hit Save. 
+10. Click "Add a command" and call it anything you like e.g. `/sentry`. Select "Team" as the scope, add it, and again hit Save. 
 
 
 ## Set up config.yml
@@ -52,6 +52,15 @@ msteams.client-secret: 'your-bot-secret'
 You should see a message in the General channel that says "Welcome to Sentry for Microsoft Teams". If you do not get this message, it means was something went wrong and you'll need to uninstall, fix the problem, and re-install it.
 
 Follow our [documentation on using the Microsoft Teams integration](https://docs.sentry.io/product/integrations/msteams/) to use the integration. 
+
+## Troubleshooting
+
+If you're having trouble with installation, try following these steps:
+1. Click "Publish to org" in the sidebar.
+2. Visit the [manage apps page](https://admin.teams.microsoft.com/policies/manage-apps), and find your app in the list by sorting by "Custom App".
+3. Click the title of your app, in this case "Sentry".
+4. Publish it to the org-wide app catalog. You should now see it under "Built for your org".
+
 
 
 ## Uninstallation


### PR DESCRIPTION
Microsoft has deprecated their App Studio in favor of a Developer Portal, and as such there is a new way to setup the MSTeams Sentry app. 