### PR TITLE
ref(gitlab): Update installation docs

### DIFF
--- a/src/docs/integrations/gitlab.mdx
+++ b/src/docs/integrations/gitlab.mdx
@@ -14,6 +14,8 @@ When configuring the app, use the following values:
 | Redirect URI                    | `{YOUR_DOMAIN}/extensions/gitlab/setup/`      |
 | Scopes                          | api                                           |
 
+Select 'Confidential' and 'Expire access tokens'.
+
 Take note of your application ID and secret as you'll need it in the next step. 
 
 Follow our [documentation on installing and configuring the GitLab integration](https://docs.sentry.io/workflow/integrations/gitlab/) to finish installation and use the integration. 


### PR DESCRIPTION
The GitLab app form has changed slightly, this PR updates the installation modal to reflect the new form.

sentry PR: https://github.com/getsentry/sentry/pull/31025