### PR TITLE
Fix direnv command in bash

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -218,7 +218,7 @@ First, you should be done bootstrapping. Then, run `brew install direnv` and add
 startup script:
 
 ```shell {filename: ~/.bashrc} {tabTitle: Bash}
-eval "\$(direnv hook bash)"
+eval "$(direnv hook bash)"
 ```
 
 ```shell {filename: ~/.zshrc} {tabTitle: Zsh}


### PR DESCRIPTION
Running as is was causing `(eval):1: command not found: _direnv_hook()`