### PR TITLE
Document alternative format for Exception/Breadcrumb/Thread payload item

### DIFF
--- a/src/docs/sdk/event-payloads/breadcrumbs.mdx
+++ b/src/docs/sdk/event-payloads/breadcrumbs.mdx
@@ -7,6 +7,7 @@ Sentry uses _breadcrumbs_ to create a trail of events that happened prior to an 
 This page provides technical information about a breadcrumb structure. You can read an overview of manual breadcrumb recording and customization on our [Breadcrumbs](https://docs.sentry.io/platform-redirect/?next=/enriching-events/breadcrumbs/) Sentry docs page.
 
 An event may contain a `breadcrumbs` property with one entry, `values`, which is an array of breadcrumb objects. The entries are ordered from oldest to newest. Consequently, the last entry in the list should be the last entry before the event occurred.
+Alternatively, the `breadcrumbs` property may be an array of breadcrumb objects by itself.
 
 The following example illustrates the breadcrumbs part of the event payload and omits other attributes for simplicity.
 
@@ -36,7 +37,33 @@ The following example illustrates the breadcrumbs part of the event payload and 
 }
 ```
 
-A breadcrumb object contains the property `values`, which is an array of objects with the following properties:
+Or, alternatively:
+
+```json
+{
+  "breadcrumbs": [
+    {
+      "timestamp": "2016-04-20T20:55:53.845Z",
+      "message": "Something happened",
+      "category": "log",
+      "data": {
+        "foo": "bar",
+        "blub": "blah"
+      }
+    },
+    {
+      "timestamp": "2016-04-20T20:55:53.847Z",
+      "type": "navigation",
+      "data": {
+        "from": "/login",
+        "to": "/dashboard"
+      }
+    }
+  ]
+}
+```
+
+A breadcrumb object has the following properties:
 
 `type` (optional)
 

--- a/src/docs/sdk/event-payloads/exception.mdx
+++ b/src/docs/sdk/event-payloads/exception.mdx
@@ -10,6 +10,7 @@ An <Link to="/sdk/event-payloads/">event</Link> may contain one or more exceptio
 The `exception` attribute should be an object with the attribute `values`
 containing a list of one or more values that are objects in the format described
 below.
+Alternatively, the `exception` attribute may be a flat list of objects in the format below.
 
 Multiple values represent chained exceptions and should be sorted oldest to
 newest. For example, consider this Python code snippet:
@@ -306,5 +307,22 @@ Generic unhandled crash:
       }
     ]
   }
+}
+```
+
+Flat list, omitting `values`:
+
+```json
+{
+  "exception": [
+    {
+      "type": "Error",
+      "value": "An error occurred",
+      "mechanism": {
+        "type": "generic",
+        "handled": false
+      }
+    }
+  ]
 }
 ```

--- a/src/docs/sdk/event-payloads/threads.mdx
+++ b/src/docs/sdk/event-payloads/threads.mdx
@@ -10,6 +10,7 @@ An [event](/sdk/event-payloads/) may contain one or more threads in an attribute
 
 The `threads` attribute should be an object with the attribute `values`
 containing one or more values that are objects in the format described below.
+Alternatively, the `threads` attribute may be a flat list of objects in the format below.
 
 As per Sentry policy, the thread that crashed with an [exception](/sdk/event-payloads/exception/) should not
 have a stack trace, but instead, the `thread_id` attribute should be set on the
@@ -62,5 +63,20 @@ other attributes for simplicity.
       }
     ]
   }
+}
+```
+
+Or, alternatively:
+
+```json
+{
+  "threads": [
+    {
+      "id": "0",
+      "name": "main",
+      "crashed": true,
+      "stacktrace": {}
+    }
+  ]
 }
 ```


### PR DESCRIPTION
Sentry's ingestion server can deal with flat lists, and some SDKs have historically used that. To avoid confusion, document that possibility.

For implementation details, see
https://github.com/getsentry/relay/blob/4639455273ed8caccf5c11b929ef42d3a7ac6d61/relay-general/src/protocol/types.rs#L29
https://github.com/getsentry/relay/blob/4639455273ed8caccf5c11b929ef42d3a7ac6d61/relay-general/src/protocol/event.rs#L406-L430

Related: https://github.com/getsentry/sentry-go/pull/408