### PR TITLE
feat(docs): Use functional components instead of class based

### DIFF
--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -31,29 +31,31 @@ The use of an index file should comply with the following rules:
 
 ### Defining React components
 
-New components use the class syntax, and the class field+arrow function method definition when they need to access this.
+New components should be created as functional components, using function declarations instead of arrow functions. 
+Props should be declared above the component.
 
-```javascript
-class Note extends React.Component {
-  static propTypes = {
-    author: PropTypes.object.isRequired,
-    onEdit: PropTypes.func.isRequired,
-  };
+```typescript
+type Props = {
+  author: object;
+  content: string;
+  onEdit: Function;
+};
 
-  // Note that method is defined using an arrow function class field (to bind "this")
+function Note(props: Props) {
+  // use destructuring assignment for props
+  const {author, content, onEdit} = props;
+  
   handleChange = value => {
-    let user = ConfigStore.get('user');
+    const user = ConfigStore.get('user');
 
     if (user.isSuperuser) {
-      this.props.onEdit(value);
+      onEdit(value);
     }
   };
 
-  render() {
-    let {content} = this.props; // use destructuring assignment for props
-
-    return <div onChange={this.handleChange}>{content}</div>;
-  }
+  return (
+    <div onChange={handleChange}>{content}</div>
+  );
 }
 
 export default Note;

--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -38,7 +38,7 @@ Props should be declared above the component.
 type Props = {
   author: object;
   content: string;
-  onEdit: Function;
+  onEdit: (value: string) => void;
 };
 
 function Note(props: Props) {

--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -61,8 +61,6 @@ function Note(props: Props) {
 export default Note;
 ```
 
-Some older components use `createReactClass` and mixins, but this is deprecated.
-
 ### Components vs views
 
 Both the `app/components/` and `app/views` folders contain React components.


### PR DESCRIPTION
In the Frontend Handbook page in our developer docs, the code snippet for creating React components still says to use class based components, although we've moved onto using functional components instead. 

This PR changes the code snippet to use a functional component instead of class-based.