### PR TITLE
fix: Document `span.finish` optional endTimestamp arg

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -93,11 +93,13 @@ tree as well as the unit of reporting to Sentry.
 
 - `Span.finish()`
 
-  - Just set `endTimestamp` to the current time (in payload `timestamp`)
+  - Accepts an optional `endTimestamp` to allow users to set a custom `endTimestamp` on the finished span
+  - If an `endTimestamp` value is not provided, set `endTimestamp` to the current time (in payload `timestamp`)
 
 - `Transaction.finish()`
   - `super.finish()` (call finish on Span)
   - Send it to Sentry only if `sampled == true`
+  - Like spans, can be given an optional `endTimestamp` value that should be passed into the `span.finish()` call
   - A `Transaction` needs to be wrapped in an `Envelope` and sent to the [Envelope Endpoint](/sdk/envelopes/)
   - The `Transport` should use the same internal queue for `Transactions` / `Events`
   - The `Transport` should implement category-based rate limiting →


### PR DESCRIPTION
The `span.finish()` and `transaction.finish()` methods can be given an optional `endTimestamp` value that allows for users to override the endTimestamp of a span/transaction. This is currently implemented in the JavaScript SDK

https://github.com/getsentry/sentry-javascript/blob/bb6f86502e1ea551fa503136a954844f77cca322/packages/tracing/src/span.ts#L232-L234

This PR updates the develop documentation to reflect this capability.