### PR TITLE
chore(apidocs): update from decorator to attribute for public

### DIFF
--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -82,13 +82,14 @@ API Documentation consists of a few items:
 
 Below we'll describe how to document these for an endpoint.
 
-Declare the endpoint public using the `@public` decorator, specifying the methods on the view which should be public.
+Declare the endpoint public by setting the `public` attribute with the appropriate HTTP verbs.
 
 ```python
 from sentry.apidocs.decorators import public
 
-@public(methods={"GET"})
+
 class OrganizationSCIMMemberDetails(...):
+  public = {"GET"}
 ```
 
 Tag the endpoint view if needed (a parent class may already be tagged), this is how the endpoint makes it into a particular [sidebar endpoint grouping](https://docs.sentry.io/api/). You can see the current list of tags or add tags [here](https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/build.py).
@@ -97,9 +98,9 @@ Tag the endpoint view if needed (a parent class may already be tagged), this is 
 from drf_spectacular.utils import extend_schema
 from sentry.apidocs.decorators import public
 
-@public(methods={"GET"})
 @extend_schema(tags=["SCIM"])
 class SCIMEndpoint(...):
+  public = {"GET"}
 ```
 
 For the rest of the documentation, we'll use `@extend_schema` on the various endpoint methods, for example:


### PR DESCRIPTION
with https://github.com/getsentry/sentry/pull/31711 we switched `public` from being a decorator to an attribute. the docs are updated accordingly.