### PR TITLE
fix: Data categories for client reports

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -69,7 +69,7 @@ will assume the current UTC timestamp. In the data model, this is called
 : _List of outcome objects_ {`reason`, `category`, `quantity`}
 
 - `reason`: A string reason that defines why events were lost.
-- `category`: The data category for which the discard reason applies. These are the same data categories used for [envelopes](/sdk/envelopes/#data-model) and [rate limits](/sdk/rate-limiting/#definitions).
+- `category`: The data category for which the discard reason applies. These are the same data categories used for [rate limits](/sdk/rate-limiting/#definitions).
 - `quantity`: The number of events which were lost
 
 The following discard reasons are currently defined for `discarded_events`:

--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -139,7 +139,7 @@ There are two generic headers for every Item:
 `type`
 
 : **String, required.** Specifies the type of this Item and its contents. Based
-  on the Item type, more headers may be required. See Data Integrity for a list
+  on the Item type, more headers may be required. See [Data Model](#data-model) for a list
   of all Item types.
 
 `length`
@@ -255,7 +255,9 @@ EOF:**
 Each Envelope consists of headers and a potentially empty list of Items, each
 with their own headers. Which Headers are required depends on the Items in an
 Envelope. This section describes all Item types and their respective required
-headers.
+headers. It is worth noting that the list of Item types doesn't match the data
+categories used for [rate limiting]((/sdk/rate-limiting/#definitions)) and
+client reports.
 
 The type of an Item is declared in the `type` header, as well as the payload
 size in `length`. See Serialization Format for a list of common Item headers.

--- a/src/docs/sdk/rate-limiting.mdx
+++ b/src/docs/sdk/rate-limiting.mdx
@@ -14,7 +14,7 @@ X-Sentry-Rate-Limits: <quota_limit>, <quota_limit>, ...
 Each *quota_limit* has the form `retry_after:categories:scope:reason_code:...` with the following parameters:
 
 - `retry_after`: Number of seconds (as an integer or a floating point number) until this rate limit expires.
-- `categories`: Semicolon-separated list of data categories. **If empty, this limit applies to all categories**.
+- `categories`: Semicolon-separated list of [data categories](https://github.com/getsentry/relay/blob/29a9211696f31d3b3682d3a3abb3d05d729edffe/relay-common/src/constants.rs#L97-L115). **If empty, this limit applies to all categories**.
 - `scope`: The scope that this limit applies to. Can be ignored by SDKs.
 - `reason_code`: A unique identifier for the quota hinting at the rate limiting reason. Can be ignored by SDKs.
 - More parameters can be added in the future, and can be ignored by SDKs (promise of backward compatibility).


### PR DESCRIPTION
The data categories used for client reports are not the same as for
the envelope item types.