### PR TITLE
Add client report item type to envelopes spec

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -465,6 +465,26 @@ The item contains a user feedback / user report JSON payload:
 
 *None*
 
+### Client Report
+
+Item type `"client_report"` contains a client report payload encoded in JSON.
+
+See the <Link to="/sdk/client-reports/">client reports</Link> documentation for the payload
+details.
+
+**Constraints:**
+
+- This Item may occur at most once per Envelope.
+- This Item can either be included in an Envelope with other Items, or it may be sent by itself.
+
+**Envelope Headers:**
+
+*None*
+
+**Additional Item Headers:**
+
+*None*
+
 ### Reserved Types
 
 Reserved types may not be written by any implementation. They are reserved for


### PR DESCRIPTION
The [Envelopes Data Model](https://develop.sentry.dev/sdk/envelopes/#data-model) lists each possible envelope item type.  Client Reports was documented on its own page, but was missing from this list.