### PR TITLE
fix: Data Category Confusion

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -256,7 +256,7 @@ Each Envelope consists of headers and a potentially empty list of Items, each
 with their own headers. Which Headers are required depends on the Items in an
 Envelope. This section describes all Item types and their respective required
 headers. It is worth noting that the list of Item types doesn't match the data
-categories used for [rate limiting]((/sdk/rate-limiting/#definitions)) and
+categories used for [rate limiting](/sdk/rate-limiting/#definitions) and
 client reports.
 
 The type of an Item is declared in the `type` header, as well as the payload

--- a/src/docs/sdk/rate-limiting.mdx
+++ b/src/docs/sdk/rate-limiting.mdx
@@ -14,7 +14,8 @@ X-Sentry-Rate-Limits: <quota_limit>, <quota_limit>, ...
 Each *quota_limit* has the form `retry_after:categories:scope:reason_code:...` with the following parameters:
 
 - `retry_after`: Number of seconds (as an integer or a floating point number) until this rate limit expires.
-- `categories`: Semicolon-separated list of [data categories](https://github.com/getsentry/relay/blob/29a9211696f31d3b3682d3a3abb3d05d729edffe/relay-common/src/constants.rs#L97-L115). **If empty, this limit applies to all categories**.
+- `categories`: Semicolon-separated list of [data categories](https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs#L97-L115). **If empty, this limit applies to all categories**. 
+    While these categories might look similar to the [envelope item types](/sdk/envelopes/#data-model) be aware that they don't map 100% to these.
 - `scope`: The scope that this limit applies to. Can be ignored by SDKs.
 - `reason_code`: A unique identifier for the quota hinting at the rate limiting reason. Can be ignored by SDKs.
 - More parameters can be added in the future, and can be ignored by SDKs (promise of backward compatibility).
@@ -72,7 +73,8 @@ Guidelines for how SDKs should determine the current rate limits:
 
 As stated earlier, SDKs can ignore the `scope` dimension. These definitions are here as a suplement to explain what the `X-Sentry-Rate-Limits` header is made of.
 
-- **Category:** Classifies the type of data that is being counted. Arbitrary categories can be added as long as they can be inferred from the event or data being ingested.
+- **Category:** Classifies the type of data that is being counted. Arbitrary categories can be added as long as they can be inferred from the event or data being ingested. 
+While these [data categories](https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs#L97-L115) might look similar to the [envelope item types](/sdk/envelopes/#data-model) be aware that they don't map 100% to these.
   - `default`: Events with an event_type not listed explicitly below.
   - `error`: Error events.
   - `transaction`: Transaction type events.

--- a/src/docs/sdk/rate-limiting.mdx
+++ b/src/docs/sdk/rate-limiting.mdx
@@ -15,7 +15,7 @@ Each *quota_limit* has the form `retry_after:categories:scope:reason_code:...` w
 
 - `retry_after`: Number of seconds (as an integer or a floating point number) until this rate limit expires.
 - `categories`: Semicolon-separated list of [data categories](https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs#L97-L115). **If empty, this limit applies to all categories**. 
-    While these categories might look similar to the [envelope item types](/sdk/envelopes/#data-model) be aware that they don't map 100% to these.
+    While these categories might look similar to the [envelope item types](/sdk/envelopes/#data-model), they are not identical, and have slight differences.
 - `scope`: The scope that this limit applies to. Can be ignored by SDKs.
 - `reason_code`: A unique identifier for the quota hinting at the rate limiting reason. Can be ignored by SDKs.
 - More parameters can be added in the future, and can be ignored by SDKs (promise of backward compatibility).

--- a/src/docs/sdk/rate-limiting.mdx
+++ b/src/docs/sdk/rate-limiting.mdx
@@ -74,7 +74,7 @@ Guidelines for how SDKs should determine the current rate limits:
 As stated earlier, SDKs can ignore the `scope` dimension. These definitions are here as a suplement to explain what the `X-Sentry-Rate-Limits` header is made of.
 
 - **Category:** Classifies the type of data that is being counted. Arbitrary categories can be added as long as they can be inferred from the event or data being ingested. 
-While these [data categories](https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs#L97-L115) might look similar to the [envelope item types](/sdk/envelopes/#data-model) be aware that they don't map 100% to these.
+While these [data categories](https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs#L97-L115) might look similar to the [envelope item types](/sdk/envelopes/#data-model), they are not identical, and have slight differences.
   - `default`: Events with an event_type not listed explicitly below.
   - `error`: Error events.
   - `transaction`: Transaction type events.


### PR DESCRIPTION
Add more hints that data categories and envelope item types are not the same.