### PR TITLE
fix: Client report sdk recommendations

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -105,14 +105,15 @@ the SDKs should ensure not dropping too many reports. It is not required, for ex
  - to persist the data when an application crashes.
  - to move an envelope item with a client report to the next envelope when the cache for envelopes is full.
 
-SDKs are encouraged to reduce the total amount of needless communication, especially
-on mobile. A recommended approach is to keep track of the discard events in the transport.
-For applications with a low frequency of envelopes to ingest, such as mobile apps or web
-apps, the SDK can attach the discarded events to an already scheduled envelope. We accept
-the tradeoff that apps rarely sending events will have fewer client reports. When the SDK
-schedules envelopes continuously, like on the backend, the SDK can choose to flush the
-discarded events periodically to avoid the overhead of serializing an extra envelope item
-for almost every envelope.
+SDKs are encouraged to reduce needless communication. They shall not send an envelope
+everytime they record a discarded event. The following approaches are recommendations
+that can be adjusted if required. The SDKs should keep track of the discard events in
+the transport. For applications with a low frequency of envelopes to ingest, such as
+mobile or web apps, the SDK shall attach the discarded events to an already scheduled
+envelope. We accept the tradeoff that apps rarely sending events will have fewer
+client reports. When the SDK schedules envelopes continuously, like on the backend,
+the SDK shall either choose to flush the discarded events periodically or attach them
+to an already scheduled envelope.
 
 The one who drops an envelope item must record and report it. If the server drops
 an envelope item, for example, with the response 429, the client SDK must not record


### PR DESCRIPTION
Clarify that SDKs should primarily reduce needless communication.
Communicate that the requirements are recommendations that can
be adapted if needed.