### PR TITLE
fix: Client report reasons

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -80,12 +80,11 @@ The following discard reasons are currently defined for `discarded_events`:
   instructed the SDK to back off.
 - `network_error`: events were dropped because of network errors and were not retried.
 - `sample_rate`: an event was dropped because of the configured sample rate.
+- `before_send`: an event was dropped in `before_send`
+- `event_processor`: an event was dropped by an event processor
 
 Additionally the following discard reasons are reserved but there is no expectation
 that SDKs send these under normal operation:
-
-- `before_send`: an event was dropped in `before_send`
-- `event_processor`: an event was dropped by an event processor
 
 `rate_limited_events`, `filtered_events`, `filtered_sampling_events`
 


### PR DESCRIPTION
`before_send` and `event_processor` should be in the list of discard reasons and not below the sentence

> Additionally the following discard reasons are reserved but there is no expectation
that SDKs send these under normal operation: