### PR TITLE
Document config option for sending client reports

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -119,6 +119,10 @@ an envelope item, for example, with the response 429, the client SDK must not re
 this as the server already does. Still, the SDK must record lost envelope items
 when dropping them itself, for example, caused by an active rate limit.
 
+### Configuration
+
+SDKs should provide a way to turn sending of client reports on and off. This option is called `send_client_reports` or `sendClientReports` on SDKs that have already implemented it.
+
 ### Legacy Events
 For SDKs still sending legacy events instead of envelopes for backward compatibility with
 older Sentry servers, the recommendation is to send the client report as a separate


### PR DESCRIPTION
Document that there should be an option to turn on/off sending of client reports.