### PR TITLE
Document how to handle ignored exceptions

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -81,7 +81,7 @@ The following discard reasons are currently defined for `discarded_events`:
 - `network_error`: events were dropped because of network errors and were not retried.
 - `sample_rate`: an event was dropped because of the configured sample rate.
 - `before_send`: an event was dropped in `before_send`
-- `event_processor`: an event was dropped by an event processor
+- `event_processor`: an event was dropped by an event processor; may also be used for ignored exceptions / errors
 
 Additionally the following discard reasons are reserved but there is no expectation
 that SDKs send these under normal operation:


### PR DESCRIPTION
Document that ignored exceptions (`ignore_errors` / `ignoredExceptionForTypes`) should be sent as reason: `event_processor`.