### PR TITLE
Add a blurb about increasing memory for docker

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -41,9 +41,12 @@ brew bundle --verbose
 ### Docker (Mac specific)
 
 <Alert title="Note" level="info">
-  It's recommended to increase the Docker memory limit to something higher than the default(2048MB).
+  It's recommended to increase the Docker memory limit to something higher than the default (2048MB).
 </Alert>
 
+On Docker Desktop, you can adjust the memory limits by going to: `Preferences > Resources > Memory`
+
+Or through CLI:
 ```shell
 # quit Docker if its running
 osascript -e 'quit app "Docker"'

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -40,6 +40,26 @@ brew bundle --verbose
 
 ### Docker (Mac specific)
 
+<Alert title="Note" level="info">
+  It's recommended to increase the Docker memory limit to something higher than the default(2048MB).
+</Alert>
+
+```shell
+# quit Docker if its running
+osascript -e 'quit app "Docker"'
+
+# check what the default is configured currently
+cat /Users/`id -un`/Library/Group\ Containers/group.com.docker/settings.json | grep "memoryMiB"
+
+# increase configured memory to something reasonable
+sed -i .bak 's/"memoryMiB":.*/"memoryMiB": 7168,/g' /Users/`id -un`/Library/Group\ Containers/group.com.docker/settings.json
+
+# check configuration 
+cat /Users/`id -un`/Library/Group\ Containers/group.com.docker/settings.json | grep "memoryMiB"
+
+# start up docker with next steps
+```
+
 On Mac, `docker` (which brew has already installed for you under `/Applications/Docker.app`) needs some manual
 intervention. You can run this command to set it up automatically for you:
 


### PR DESCRIPTION
Our internal docs recommends us to increase docker memory limits:
https://www.notion.so/sentry/Dev-Environment-98b18b1e96e04f018e6e3d5d87f2889e#c5daa8c7cae647d4893348b6e5eaf97b

We should probably do the same on the environments we setup for developing sentry.