### PR TITLE
Scrap "type(scope): " from PR format

### DIFF
--- a/src/docs/commit-messages.mdx
+++ b/src/docs/commit-messages.mdx
@@ -34,8 +34,6 @@ If you’re working locally, it often can be useful to `--amend` a commit, or ut
 
 Each commit message consists of a **header**, a **body**, and an optional **footer**.
 
-The header has a special format that includes a scope and a subject:
-
 ```
 <subject> (<jira-id>)
 <BLANK LINE>
@@ -44,7 +42,7 @@ The header has a special format that includes a scope and a subject:
 <footer>
 ```
 
-The **header** is mandatory and the **scope** of the header is optional. If you have a Jira issue to link to, add the **jira-id** the commit belongs to. This helps to connect changes back to Jira tickets.
+The **header** is mandatory. If you have a Jira issue to link to, add the **jira-id** the commit belongs to. This helps to connect changes back to Jira tickets.
 
 Any line of the commit message should not be longer 100 characters! This allows the message to be easier to read on GitHub as well as in various git tools.
 

--- a/src/docs/commit-messages.mdx
+++ b/src/docs/commit-messages.mdx
@@ -34,10 +34,10 @@ If you’re working locally, it often can be useful to `--amend` a commit, or ut
 
 Each commit message consists of a **header**, a **body**, and an optional **footer**.
 
-The header has a special format that includes a type, a scope and a subject:
+The header has a special format that includes a scope and a subject:
 
 ```
-<type>(<scope>): <subject> (<jira-id>)
+<subject> (<jira-id>)
 <BLANK LINE>
 <body>
 <BLANK LINE>
@@ -53,7 +53,7 @@ The footer should contain a closing reference to an issue as well as a relevant 
 For example:
 
 ```
-feat(stream): Add resolve in next release action
+Add resolve in next release action
 
 Expose a new action labeled 'resolve in next release'. It uses the existing API
 behavior and sends the 'inNextRelease=true' payload.
@@ -64,7 +64,7 @@ Fixes GH-1234
 As well as:
 
 ```
-fix(stream): Handle empty reference on resolve action
+Handle empty reference on resolve action
 
 Gracefully handle when a user has not selected any issues and tries to complete
 the resolve action in the UI.
@@ -76,90 +76,6 @@ Fixes SENTRY-1234
 #### Revert
 
 If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
-
-#### Type
-
-Must be one of the following:
-
-<table className="table">
-  <tbody valign="top">
-    <tr>
-      <th>build:</th>
-      <td>
-        Changes that affect the build system or external dependencies (example
-        scopes: webpack, python, npm)
-      </td>
-    </tr>
-    <tr>
-      <th>ci:</th>
-      <td>
-        Changes to our CI configuration files and scripts (example scopes:
-        travis, zeus)
-      </td>
-    </tr>
-    <tr>
-      <th>docs:</th>
-      <td>Documentation only changes</td>
-    </tr>
-    <tr>
-      <th>feat:</th>
-      <td>A new feature</td>
-    </tr>
-    <tr>
-      <th>fix:</th>
-      <td>A bug fix</td>
-    </tr>
-    <tr>
-      <th>perf:</th>
-      <td>A code change that improves performance</td>
-    </tr>
-    <tr>
-      <th>ref:</th>
-      <td>
-        A code change that neither fixes a bug nor adds a feature (refactor)
-      </td>
-    </tr>
-    <tr>
-      <th>style:</th>
-      <td>
-        Changes that do not affect the meaning of the code (white-space,
-        formatting, missing semi-colons, etc)
-      </td>
-    </tr>
-    <tr>
-      <th>test:</th>
-      <td>Adding missing tests or correcting existing tests</td>
-    </tr>
-    <tr>
-      <th>meta:</th>
-      <td>
-        Some meta information in the repo changes (example scopes: owner files,
-        editor config etc.)
-      </td>
-    </tr>
-    <tr>
-      <th>license:</th>
-      <td>Changes to licenses</td>
-    </tr>
-  </tbody>
-</table>
-
-#### Scope
-
-The scope should be the name of the core component affected (as perceived by person reading changelog generated from commit messages). This means it should be the system impacted, not the literal file changed. For example, if the code primarily affects billing, you’d use the _billing_ scope, even if the changes are in utility files or db schema.
-
-The following is the list of suggested scopes:
-
-- **api**
-- **auth**
-- **billing**
-- **dashboards**
-- **discover**
-- **integrations**
-- **ui**
-- **workflow**
-
-It is also acceptable to use the feature/project name as a scope.
 
 #### Subject
 


### PR DESCRIPTION
We had some discussion about this a while ago and people seemed to agree that this is busywork that creates noise without adding much value. Can we overcome months of additional inertia? :)

**Old:** https://develop.sentry.dev/commit-messages/#type

**New:** https://develop-git-cwlw-scrap-types-and-scopes.sentry.dev/commit-messages/#commit-message-format