### PR TITLE
fix: Document min Sentry version for client reports

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -8,6 +8,10 @@ about themselves to Sentry.  They are currently mainly used to emit outcomes
 for events that were never sent.  Chained relays are also able to emit these
 client reports to inform the next relay in chain about _some_ outcomes.
 
+Due to a bug in Relay, which discards envelopes containing unknown envelope
+items, the minimum required version of Sentry for client reports is 
+[21.9.0](https://github.com/getsentry/relay/blob/master/CHANGELOG.md#2190).
+
 ## Basic Operation
 
 Client reports are sent as envelope items to Sentry, typically as separate


### PR DESCRIPTION
#skip-changelog