### PR TITLE
fix: replace git.io links with redirect targets

### DIFF
--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -102,7 +102,7 @@ SENTRY_LOG_LEVEL=WARNING sentry ...
 
 <ConfigValue name="LOGGING" location="python"><markdown>
 
-You can modify or override the full logging configuration with this setting. Be careful not to remove or override important defaults. You can check [the default configuration](https://git.io/fjjna) for reference.
+You can modify or override the full logging configuration with this setting. Be careful not to remove or override important defaults. You can check [the default configuration](https://github.com/getsentry/sentry/blob/8f500feaf8f9cce3a56a4a4517931acc9f47f90a/src/sentry/conf/server.py#L649-L777) for reference.
 
 ```python
 LOGGING['default_level'] = 'WARNING'


### PR DESCRIPTION
see: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Committed via https://github.com/asottile/all-repos




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
