### PR TITLE
fix(Jira Server): Update docs link

### DIFF
--- a/src/docs/integrations/jira-server.mdx
+++ b/src/docs/integrations/jira-server.mdx
@@ -2,4 +2,4 @@
 title: "Jira Server Integration"
 ---
 
-Follow our [documentation on configuring the Jira Server integration](https://docs.sentry.io/product/integrations/project-mgmt/jira/#jira-server) to setup and install the integration, replacing any mention of sentry.io with your domain. For example, the application URL will be `{YOUR_DOMAIN}/extensions/jira_server/setup/` instead of `https://sentry.io/extensions/jira_server/setup/`.
+Follow our [documentation on configuring the Jira Server integration](https://docs.sentry.io/product/integrations/issue-tracking/jira/#jira-server) to setup and install the integration, replacing any mention of sentry.io with your domain. For example, the application URL will be `{YOUR_DOMAIN}/extensions/jira_server/setup/` instead of `https://sentry.io/extensions/jira_server/setup/`.


### PR DESCRIPTION
Update the link here to the correct one so that it actually goes to the intended anchor - it was redirecting to https://docs.sentry.io/product/integrations/issue-tracking/jira/