### PR TITLE
Drop manual license guidance

### DIFF
--- a/src/docs/python-dependencies.mdx
+++ b/src/docs/python-dependencies.mdx
@@ -9,21 +9,13 @@ project no longer supports our version of Python.
 Additionally, all these dependencies run on the server, thus, making them riskier as they have direct access to customer
 data if they turn out to be malicious.
 
-So here are the rules we worked with so far:
+So here are the rules:
 
-## Rules on Dependencies
-
-1. Any new dependency needs to be thoroughly reviewed and approved
-2. Dependencies **must** be hard pinned in [the requirements file of **sentry**](https://github.com/getsentry/sentry/blob/master/requirements-base.txt)
+1. Any new dependency needs to be thoroughly reviewed and approved.
+2. Dependencies **must** be hard pinned in [the requirements file of **sentry**](https://github.com/getsentry/sentry/blob/master/requirements-base.txt).
 
 Note: If you need to add a dependency with a URL you will have to place it with a range in Sentry and place the URL in getsentry's
 requirements. This is because we release sentry as a package in PyPI and it does not accept URLs.
-
-## Rules on Licenses
-
-Sentry uses BSD/MIT/ISC and Apache 2 licenses. Whatever we used needs to be compatible with this. This means an absolute
-hard no on GPL/AGPL and a soft no on LGPL unless absolutely necessary. Acceptable uses of LGPL are swappable components
-like database drivers.
 
 ## Unclear?
 


### PR DESCRIPTION
We no longer need devs to manually police license compliance because this is automated now.