### PR TITLE
ref(measurements): Link to Relay MetricUnit and update wording [INGEST-1131]

### DIFF
--- a/src/docs/sdk/event-payloads/properties/measurements.mdx
+++ b/src/docs/sdk/event-payloads/properties/measurements.mdx
@@ -27,15 +27,14 @@ Standard measurement keys currently supported are from the following list taken 
 ]
 ```
 
-Custom measurements need units to be specified. Units currently supported are durations from the list `["ns" , "ms" , "s"]` taken from [here](https://github.com/getsentry/relay/blob/1e45a8817e45408ecbdbd3f0a679a5f5e4885290/relay-metrics/src/protocol.rs#L14-L21). Note that in the future we will extend the available units (for instance, memory units) but we will not implement a generic user-defined unit interface.
-
+For the well-known measurements listed above, Sentry automatically infers units. Custom measurements need units to be specified, defaulting to `"none"` if missing. The full list of supported units is specified on [Relay's `MetricUnit`](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html). Sentry's event ingestion supports arbitrary custom units, but many SDKs will not expose a generic user-defined unit interface.
 
 ```json
 {
   "measurements": {
     "lcp": { "value": 100 },
     "fp": { "value": 123 },
-    "my.custom.metric": { "value": 456, "unit": "ms" }
+    "my.custom.metric": { "value": 456, "unit": "millisecond" }
   }
 }
 ```


### PR DESCRIPTION
Links to Relay's canonical `MetricUnit` documentation and updates the notice on custom units. Custom units are in fact supported in ingestion, but SDKs are encouraged not to expose them for the time being where possible. Also, there's now a range of information and fraction units in addition to durations.

This paragraph deliberately doesn't give SDK implementation advice since this document - like all payload docs - are more likely to be consumed by end users.

See https://github.com/getsentry/relay/pull/1256