### PR TITLE
Fix hards stop for self-hosted installation

### DIFF
--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -38,9 +38,13 @@ We have three hards stops that you need to go through in order to pick up signif
 
 1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2` and follow the next steps:
    ```
-   <your.sentry.version> -> 9.1.2 -> 21.5.0 -> 21.6.3 -> latest
+   <your.sentry.version> -> 9.1.2 -> 20.12.1 -> 21.5.0 -> 21.6.3 -> latest
    ```
-1. If you are coming from `9.1.2`, you first need to upgrade to `21.5.0` and follow the next steps:
+1. If you are coming from `9.1.2`, you first need to upgrade to `20.12.1` and follow the next steps:
+   ```
+   <your.sentry.version> -> 20.12.1 -> 21.5.0 -> 21.6.3 -> latest
+   ```
+1. If you are coming from `20.12.1`, you first need to upgrade to `21.5.0` and follow the next steps:
    ```
    <your.sentry.version> -> 21.5.0 -> 21.6.3 -> latest
    ```


### PR DESCRIPTION
During our sentry upgrade, I ran into the same issues describled in this post: https://forum.sentry.io/t/migration-errors-9-1-2-to-21-6-1-project-object-has-no-attribute-get-option/14279

This fix the doc by specifying 20.12.1 as an hard stop, solution that also worked in our case :)