### PR TITLE
docs: remove kibana employee block

### DIFF
--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -110,10 +110,6 @@ LOGGING['default_level'] = 'WARNING'
 
 If logging in a particular module is not showing up when you expect it to, you should check the log level for that module in `src/sentry/conf/server.py` in the `LOGGING` variable.
 
-<Note><markdown>
-If you are a Sentry employee looking for logs in Kibana and they aren't showing up when as expected, one potential reason is that a field in the log message does not match Elasticsearch's schema. Check <a href="https://kibana.getsentry.net/app/kibana#/management/kibana/indices/0ba261d0-97ca-11e9-90db-dfacda4da93b?_g=()&_a=(tab:indexedFields)">the index patterns</a> to see whether this is the reason.
-</markdown></Note>
-
 </markdown></ConfigValue>
 
 ## Redis


### PR DESCRIPTION
This block is outdated. Kibana was replaced with google cloud logging.
