### PR TITLE
Improve GitHub Integration configuration docs

### DIFF
--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -262,7 +262,7 @@ The secret used to verify GitHub App Webhook event.
 
 <ConfigValue name="github-app.private-key" location="yaml"><markdown>
 
-Your app's private key.
+Your app's private key, best to use [multiline](https://yaml-multiline.info/):
 
 ```yml
 github-app.private-key: |

--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -264,9 +264,16 @@ The secret used to verify GitHub App Webhook event.
 
 Your app's private key.
 
-<Alert level="warning">
-Replace the newlines with `\n` to preserve them.
-</Alert>
+```yml
+github-app.private-key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  -----END RSA PRIVATE KEY-----
+```
 
 </markdown></ConfigValue>
 

--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -10,26 +10,34 @@ To configure the GitHub integration you'll need to create a GitHub app and obtai
   The GitHub App name must not contain any spaces.
 </Alert>
 
+<CreateGitHubAppForm url="https://github.com/organizations/:org/settings/apps/new?name=:org-Sentry-Integration&public=false&members=read&emails=read&administration=read&contents=read&issues=write&pull_requests=write&repository_hooks=write&url=:url-prefix&callback_url=:url-prefix%2Fauth%2Fsso%2F&setup_url=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&webhook_url=:url-prefix%2Fextensions%2Fgithub%2Fwebhook%2F&events[]=push&events[]=pull_request&webhook_active=true" defaultOrg="your-organization" defaultUrlPrefix="https://your-sentry-url-prefix.com" />
+
 Start by following GitHub's [official guide on creating a GitHub App](https://developer.github.com/apps/building-github-apps/creating-a-github-app/).
 
-When configuring the app, use the following values:
+If the form above does not work for you, you need the following settings for your GitHub Application:
 
-| Setting                         | Value                                     |
-| ------------------------------- | ----------------------------------------- |
-| Homepage URL                    | `${YOUR_DOMAIN}`                            |
-| User authorization callback URL | `${YOUR_DOMAIN}/auth/sso/`                  |
-| Setup URL (optional)            | `${YOUR_DOMAIN}/extensions/github/setup/`   |
-| Webhook URL                     | `${YOUR_DOMAIN}/extensions/github/webhook/` |
+| Setting                         | Value                                      |
+| ------------------------------- | ------------------------------------------ |
+| Homepage URL                    | `${url-prefix}`                            |
+| User authorization callback URL | `${url-prefix}/auth/sso/`                  |
+| Setup URL (optional)            | `${url-prefix}/extensions/github/setup/`   |
+| Webhook URL                     | `${url-prefix}/extensions/github/webhook/` |
 
 When prompted for permissions, choose the following:
 
-| Permission                | Setting      |
-| ------------------------- | ------------ |
-| Repository administration | Read-only    |
-| Repository contents       | Read-only    |
-| Issues                    | Read & write |
-| Pull requests             | Read & write |
-| Repository webhooks       | Read & write |
+| Permission                                        | Setting      |
+| ------------------------------------------------- | ------------ |
+| Repository administration                         | Read-only    |
+| Repository contents                               | Read-only    |
+| Organization permissions / members (optional `*`) | Read-only    |
+| User permissions / Email addresses (optional `*`) | Read-only    |
+| Issues                                            | Read & write |
+| Pull requests                                     | Read & write |
+| Repository webhooks                               | Read & write |
+
+<Alert title="Trick" level="info">
+   `*` Enabling those permissions will also enable the <Link to="/self-hosted/sso/#github-auth">GitHub SSO</Link> for your instance.
+</Alert>
 
 You'll be given various credentials, configure them in `config.yml`:
 

--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -25,18 +25,18 @@ If the form above does not work for you, you need the following settings for you
 
 When prompted for permissions, choose the following:
 
-| Permission                                        | Setting      |
-| ------------------------------------------------- | ------------ |
-| Repository administration                         | Read-only    |
-| Repository contents                               | Read-only    |
-| Organization permissions / members (optional `*`) | Read-only    |
-| User permissions / Email addresses (optional `*`) | Read-only    |
-| Issues                                            | Read & write |
-| Pull requests                                     | Read & write |
-| Repository webhooks                               | Read & write |
+| Permission                                    | Setting      |
+| --------------------------------------------- | ------------ |
+| Repository administration                     | Read-only    |
+| Repository contents                           | Read-only    |
+| Organization permissions / members (optional) | Read-only    |
+| User permissions / Email addresses (optional) | Read-only    |
+| Issues                                        | Read & write |
+| Pull requests                                 | Read & write |
+| Repository webhooks                           | Read & write |
 
 <Alert title="Trick" level="info">
-   `*` Enabling those permissions will also enable the <Link to="/self-hosted/sso/#github-auth">GitHub SSO</Link> for your instance.
+  Enabling optional permissions will also enable the <Link to="/self-hosted/sso/#github-auth">GitHub SSO</Link> for your instance.
 </Alert>
 
 You'll be given various credentials, configure them in `config.yml`:

--- a/src/docs/self-hosted/sso.mdx
+++ b/src/docs/self-hosted/sso.mdx
@@ -96,19 +96,19 @@ GITHUB_REQUIRE_VERIFIED_EMAIL = True  # Optional but recommended
 In [`sentry/config.yaml`](https://github.com/getsentry/self-hosted/blob/master/sentry/config.example.yml)
 
 ```yaml
-# github-app.id: <App ID>
-# github-app.name: '<GitHub App name>'
-# github-app.webhook-secret: '<Webhook secret>' # Use only if configured in GitHub
-# github-app.client-id: '<Client ID>'
-# github-app.client-secret: '<Client secret>'
-# github-app.private-key: |
-#   -----BEGIN RSA PRIVATE KEY-----
-#   privatekeyprivatekeyprivatekeyprivatekey
-#   privatekeyprivatekeyprivatekeyprivatekey
-#   privatekeyprivatekeyprivatekeyprivatekey
-#   privatekeyprivatekeyprivatekeyprivatekey
-#   privatekeyprivatekeyprivatekeyprivatekey
-#   -----END RSA PRIVATE KEY-----
+github-app.id: <App ID>
+github-app.name: '<GitHub App name>'
+github-app.webhook-secret: '<Webhook secret>' # Use only if configured in GitHub
+github-app.client-id: '<Client ID>'
+github-app.client-secret: '<Client secret>'
+github-app.private-key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  privatekeyprivatekeyprivatekeyprivatekey
+  -----END RSA PRIVATE KEY-----
 ```
 
 This will also enable the [GitHub Integration](/integrations/github/) for your instance.

--- a/src/docs/self-hosted/sso.mdx
+++ b/src/docs/self-hosted/sso.mdx
@@ -49,7 +49,7 @@ As of [Sentry 10](https://github.com/getsentry/self-hosted/releases/tag/10.0.1),
   The GitHub App name must not contain any spaces.
 </Alert>
 
-<CreateGitHubAppForm url="https://github.com/organizations/:org/settings/apps/new?name=:org-SentryIntegration&public=false&members=read&emails=read&administration=read&contents=read&issues=write&pull_requests=write&repository_hooks=write&url=:url-prefix&callback_url=:url-prefix%2Fauth%2Fsso%2F&setup_url=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&webhook_url=:url-prefix%2Fextensions%2Fgithub%2Fwebhook%2F&events[]=push&events[]=pull_request&webhook_active=true" defaultOrg="your-organization" defaultUrlPrefix="https://your-sentry-url-prefix.com" />
+<CreateGitHubAppForm url="https://github.com/organizations/:org/settings/apps/new?name=:org-Sentry-Integration&public=false&members=read&emails=read&administration=read&contents=read&issues=write&pull_requests=write&repository_hooks=write&url=:url-prefix&callback_url=:url-prefix%2Fauth%2Fsso%2F&setup_url=:url-prefix%2Fextensions%2Fgithub%2Fsetup%2F&webhook_url=:url-prefix%2Fextensions%2Fgithub%2Fwebhook%2F&events[]=push&events[]=pull_request&webhook_active=true" defaultOrg="your-organization" defaultUrlPrefix="https://your-sentry-url-prefix.com" />
 
 
 If the form above does not work for you, you need the following settings for your GitHub Application:


### PR DESCRIPTION
- Fix bad documentation in configuration page
- Add button to auto-generate GitHub app in GitHub Integration page
- Improve auto-generated GitHub app name in GitHub SSO

Closes : https://github.com/getsentry/self-hosted/issues/1486