### PR TITLE
Update the build process

### DIFF
--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -180,8 +180,8 @@ The openapi-diff test will fail when CI runs on your pull request, this is expec
 Once you make changes to an endpoint and merge the change into Sentry, a series of GitHub Actions will be triggered to make your changes automatically go live:
 
 1. The `openapi / deref_json` GitHub Action in [sentry](https://github.com/getsentry/Sentry) will update the schema in [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) with the OpenAPI build artifact.
-2. In [sentry-api-schema](https://github.com/getsentry/sentry-api-schema), the `sentry-docs / bump` GitHub Action will be triggered and this will bump the SHA that references [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) in [sentry-docs](https://github.com/getsentry/sentry-docs) with the latest.
-3. Finally, a build is triggered in [sentry-docs](https://github.com/getsentry/sentry-docs).
+2. Once [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) is updated, in a local copy of [sentry-docs](https://github.com/getsentry/sentry-docs) run `./scripts/bump-version.sh` to update the `SENTRY_API_SCHEMA_SHA` with the latest.
+3. Finally, merge your docs change so a build is triggered in [sentry-docs](https://github.com/getsentry/sentry-docs).
 
 ### Requesting an API to be public
 


### PR DESCRIPTION
API docs are no longer built automatically by CI, updating the steps with the manual process