### PR TITLE
Removing Raven reference from Documentation

### DIFF
--- a/src/docs/docs/index.mdx
+++ b/src/docs/docs/index.mdx
@@ -2,7 +2,7 @@
 title: "Documentation Guide"
 ---
 
-A part of every development project (especially Open Source projects) is documentation that explains how it works. Sentry and Raven are not any different. Because documentation is a big part of what makes Sentry work we’ve outlined some guidelines about how this documentation is structured and how to extend it.
+A part of every development project (especially Open Source projects) is documentation that explains how it works. Sentry are not any different. Because documentation is a big part of what makes Sentry work we’ve outlined some guidelines about how this documentation is structured and how to extend it.
 
 Sentry's documentation lives in numerous repositories, so what we're covering here is _this site_ and our general approach to documentation.
 


### PR DESCRIPTION
Since [Raven.js is deprecated](https://docs.sentry.io/clients/javascript/) should we be removing this reference for clarity?