### PR TITLE
Fix doc coding error

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -147,7 +147,7 @@ When the user opts-in, if technically possible, take a screenshot of the applica
 
 This feature only applies to SDKs with a user interface, such as Mobile and Desktop. 
 In some environments such as native iOS, taking a screenshot requires the UI thread and in the event of a crash, that might not be available. So inherently this feature will be a best effort solution.
-Also, some environments don`t allow access to the UI or some features during a hard crash, iOS, for example, doesn't allow running Objective-C code after a signal break, therefore no hard crash screenshot capture will be possible.
+Also, some environments don't allow access to the UI or some features during a hard crash, iOS, for example, doesn't allow running Objective-C code after a signal break, therefore no hard crash screenshot capture will be possible.
 It's advised to provide this feature through a single option called `attachScreenshot`. That's the preferred way but in platforms such as Flutter, a wrapping widget is required so documentation can point users to that instead of the suggested option name.
 
 The feature is achieved by adding an attachment with:


### PR DESCRIPTION
There is an error in the docs:
![Screenshot 2022-06-13 at 09 23 10](https://user-images.githubusercontent.com/10229883/173300927-bcbc48e9-44db-4912-a867-1fd3146807f1.png)

This fixes the issue