### PR TITLE
Switch Forum link to GitHub discussions

### DIFF
--- a/src/docs/self-hosted/support.mdx
+++ b/src/docs/self-hosted/support.mdx
@@ -12,7 +12,7 @@ Please see our <Link to="/self-hosted/#troubleshooting">troubleshooting section<
 Our principles for the support of self-hosted Sentry are:
 
 1. We **DO NOT** provide dedicated support for self-hosted.
-2. **DO** use our [community forum](https://forum.sentry.io/c/on-premise) for questions about your setup.
+2. **DO** use our [community forum](https://github.com/getsentry/sentry/discussions) for questions about your setup.
 3. **DO** [file an issue](https://github.com/getsentry/self-hosted/issues/new/choose) for missing docs, bugs during upgrades or installation.
 4. **DO** [file an issue](https://github.com/getsentry/sentry/issues/new/choose) for functionality problems such as broken auth, features not working, etc.
 5. **DO** [submit PRs](https://github.com/getsentry/self-hosted/compare) directly for simple fixes.


### PR DESCRIPTION
The forum is in read only mode. Therefore users should be sent to GitHub Discussions instead.

It looks like https://github.com/getsentry/develop/blob/c36c3ad4a58b6a4fab7d3c3ef07b4030f10572cc/src/components/sidebar.tsx#L298 might need to change too - but I'm not sure if that should be to the same place?