### PR TITLE
Remove workaround for API docs

### DIFF
--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -180,12 +180,8 @@ The openapi-diff test will fail when CI runs on your pull request, this is expec
 Once you make changes to an endpoint and merge the change into Sentry, a series of GitHub Actions will be triggered to make your changes automatically go live:
 
 1. The [`openapi` workflow in `sentry`](https://github.com/getsentry/sentry/blob/master/.github/workflows/openapi.yml) updates the schema in [sentry-api-schema](https://github.com/getsentry/sentry-api-schema) with the OpenAPI build artifact.
-2. The [`cascade-to-sentry-docs` workflow in `sentry-api-schema`](https://github.com/getsentry/sentry-api-schema/blob/main/.github/workflows/cascade-to-sentry-docs.yml) reacts to the push to `main` by triggering the [`bump-api-schema-sha` workflow in `sentry-docs`](https://github.com/getsentry/sentry-docs/blob/master/.github/workflows/bump-api-schema-sha.yml).
-3. The [`bump-api-schema-sha` workflow in `sentry-docs`](https://github.com/getsentry/sentry-docs/blob/master/.github/workflows/bump-api-schema-sha.yml) fetches the latest commit SHA from `sentry-api-schema` and writes it into the correct file, then makes ~~and merges~~ a PR~~, which kicks off a deploy of `sentry-docs` via Vercel to https://docs.sentry.io/~~&mdash;*due to a bug in GHA, PR checks do not run when making a PR automatically from a workflow; to work around*:
-   1. Locate the "Bump API schema to $sha" [PR on `sentry-docs`](https://github.com/getsentry/sentry-docs/pulls?q=is%3Apr+%22Bump+API+schema+to%22+is%3Aopen).
-   1. Close and re-open the PR to kick off CI.
-   1. Merge manually when green.
-   1. [Write in to GitHub Support](https://support.github.com/contact?tags=rr-general-technical) reminding them that this is still a problem.
+2. The [`cascade-to-sentry-docs` workflow in `sentry-api-schema`](https://github.com/getsentry/sentry-api-schema/blob/main/.github/workflows/cascade-to-sentry-docs.yml) reacts to the push to `main` in (1) by triggering the [`bump-api-schema-sha` workflow in `sentry-docs`](https://github.com/getsentry/sentry-docs/blob/master/.github/workflows/bump-api-schema-sha.yml).
+3. The [`bump-api-schema-sha` workflow in `sentry-docs`](https://github.com/getsentry/sentry-docs/blob/master/.github/workflows/bump-api-schema-sha.yml) fetches the latest commit SHA from `sentry-api-schema` and writes it into the correct file, then makes and merges a PR in `sentry-docs`, which kicks off a deploy via Vercel to https://docs.sentry.io/.
 
 ### Requesting an API to be public
 


### PR DESCRIPTION
Gone with https://github.com/getsentry/sentry-docs/pull/5191.