### PR TITLE
fix(docs): Add new API Scopes for configuring Vercel Integration

### DIFF
--- a/src/docs/integrations/vercel.mdx
+++ b/src/docs/integrations/vercel.mdx
@@ -6,20 +6,31 @@ title: "Vercel Integration"
 
 To use the Vercel integration you'll need to create your own integration in Vercel. To start, click "Create" in the [Integrations Developer Console](https://vercel.com/dashboard/integrations/console).
 
-When configuring the app:
-* Set the `Redirect URL` to `{YOUR_DOMAIN}/extensions/vercel/configure/`
-* Set the `Webhook URL` to `{YOUR_DOMAIN}/extensions/vercel/delete/` and subscribe to the following events:
-  * Deployment Created
-  * Configuration Removed
-* Leave the `Configuration URL` empty
+When configuring the app, under the **Settings** section:
 
-Take note of your client ID, client secret, and integration URL slug (the value you entered in the URL Slug field. This will be used to construct the integration installation URL). Add those to `config.yml` like this:
+- Set the `Redirect URL` to `{YOUR_DOMAIN}/extensions/vercel/configure/`
+- Set the following API Scopes:
+
+| API Scope                     | Value      |
+| ----------------------------- | ---------- |
+| Integration Configuration     | Read/Write |
+| Projects                      | Read/Write |
+| Project Environment Variables | Read/Write |
+| Teams                         | Read       |
+
+- Set the `Webhook URL` to `{YOUR_DOMAIN}/extensions/vercel/delete/` and subscribe to the following events:
+  - Deployment Created
+  - Configuration Removed
+- Leave the `Configuration URL` empty
+
+After saving, take note of your **Client ID** and **Client Secret** which will help authenticate Sentry, and your **URL Slug** which will setup the installation URL.
+Add those to `config.yml` like this:
 
 ```yml
 # Vercel #
 vercel.client-id: your-client-id
-vercel.client-secret: your-secret
-vercel.integration-slug: your-integration-slug
+vercel.client-secret: your-client-secret
+vercel.integration-slug: your-url-slug
 ```
 
 Then, go to your integration in Vercel and click on `View in Marketplace`. Add the integration and then follow our [documentation on configuring the Vercel integration](https://docs.sentry.io/product/integrations/deployment/vercel/#configure) to use the integration.

--- a/src/docs/integrations/vercel.mdx
+++ b/src/docs/integrations/vercel.mdx
@@ -17,6 +17,7 @@ When configuring the app, under the **Settings** section:
 | Projects                      | Read/Write |
 | Project Environment Variables | Read/Write |
 | Teams                         | Read       |
+| Current User                  | Read       |
 
 - Set the `Webhook URL` to `{YOUR_DOMAIN}/extensions/vercel/delete/` and subscribe to the following events:
   - Deployment Created


### PR DESCRIPTION
Vercel recently introduced [API Scopes](https://vercel.com/changelog/enhanced-security-with-new-api-scopes-for-integrations) for integrations on their marketplace, meaning Self-Hosted users will need instructions on which scopes to set up when they create their own apps.