### PR TITLE
Document self-hosted installation behind a proxy

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -10,7 +10,7 @@ Our recommendation is to download the [latest release of the self-hosted reposi
 
 ### Installing Behind a Proxy
 
-In some enterprise setups there is no direct Internet connection, you must use an HTTP proxy server. How do you install Sentry in this environment? Let us assume: 
+In some enterprise setups there is no direct Internet connection, so you must use an HTTP proxy server. How do you install Sentry in this environment? Let us assume: 
 
 1. Your Sentry installation is running on Linux.
 1. `http://proxy:3128` is your proxy address.

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -8,6 +8,42 @@ In addition to making its source code available publicly, Sentry offers and main
 
 Our recommendation is to download the [latest release of the self-hosted repository](https://github.com/getsentry/self-hosted/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker-compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
 
+### Installing Behind a Proxy
+
+In some enterprise setups there is no direct Internet connection, you must use an HTTP proxy server. How do you install Sentry in this environment? Let us assume: 
+
+1. Your Sentry installation is running on Linux.
+1. `http://proxy:3128` is your proxy address.
+1. `127.0.0.0/8` is the only network that should be accessed without a proxy.
+
+Here are the steps to follow:
+
+1. Set `http_proxy`, `https_proxy` and `no_proxy` variables in the `/etc/environment` file.
+2. To make the `docker pull` command respect your proxy settings, create a `/etc/systemd/system/docker.service.d/http-proxy.conf` file with these contents:
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy:3128"
+Environment="HTTPS_PROXY=http://proxy:3128"
+Environment="NO_PROXY=127.0.0.0/8"
+```
+3. Run `systemctl daemon-reload` and restart Docker with `systemctl restart docker.service`.
+4. To add your proxy environment variables into Sentry's Docker containers, create `~/.docker/config.json` with these contents:
+```json
+{
+ "proxies":
+ {
+   "default":
+   {
+     "httpProxy": "http://proxy:3128",
+     "httpsProxy": "http://proxy:3128",
+     "noProxy": "127.0.0.0/8"
+   }
+ }
+}
+```
+
+From there you can run `./install.sh` like usual.
+
 ## Configuration
 
 You very likely will want to adjust the default configuration for Sentry. These facilities are available for that purpose:


### PR DESCRIPTION
Here's the documentation to go with https://github.com/getsentry/self-hosted/pull/1543. I pulled it from https://github.com/getsentry/self-hosted/commit/ee2be4623417f155da35baccd426bc62627d37ca and edited it somewhat.

cc: @goganchic @BYK @aminvakil 