### PR TITLE
fix(gitlab): Update config docs

### DIFF
--- a/src/docs/integrations/gitlab.mdx
+++ b/src/docs/integrations/gitlab.mdx
@@ -14,7 +14,7 @@ When configuring the app, use the following values:
 | Redirect URI                    | `{YOUR_DOMAIN}/extensions/gitlab/setup/`      |
 | Scopes                          | api                                           |
 
-Select 'Confidential' and 'Expire access tokens'.
+Ensure 'Confidential' is checked.
 
 Take note of your application ID and secret as you'll need it in the next step. 
 


### PR DESCRIPTION
Remove mention of "expire access tokens" checkbox as it no longer exists, and the "confidential" box is checked by default so just say to make sure it's checked. 

See: https://github.com/getsentry/sentry/pull/36234