### PR TITLE
feat(transactions): Add transaction_info.source [INGEST-1427]

### DIFF
--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -18,11 +18,11 @@ from the transaction name, or replace the entire name with a placeholder.
 
 | Source             | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `raw-url`          | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
-| `raw-url-fallback` | The SDK is configured to send `url-pattern`, but has to fall back to a raw URL for this particular transaction.                 |
-| `url-pattern`      | URL pattern / route                                                                                                             | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
-| `view`             | Name of the view handling the request.                                                                                          | `UserListView`                                         |
 | `custom`           | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
+| `url`              | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
+| `raw-url-fallback` | The SDK is configured to send a `route`, but has to fall back to a raw URL for this particular transaction.                     |
+| `route`            | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
+| `view`             | Name of the view handling the request.                                                                                          | `UserListView`                                         |
 | `unknown`          | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |
 | `component`        | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
-| `background-task`  | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
+| `task`             | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -1,28 +1,28 @@
 `transaction_info`
 
-: _Required_. Additional information about the name of the transaction.
+: _Recommended_. Additional information about the name of the transaction.
 
 ```json
 {
   "transaction_info": {
-    "source": "raw-url"
+    "source": "url"
   }
 }
 ```
 
 `transaction_info.source`
 
-: _Required_. Contains information about how the name of the transaction was determined.
+: _Recommended_. Contains information about how the name of the transaction was determined.
 This will be used by the server to decide whether or not to scrub identifiers
 from the transaction name, or replace the entire name with a placeholder.
 
-| Source             | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `custom`           | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
-| `url`              | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
-| `raw-url-fallback` | The SDK is configured to send a `route`, but has to fall back to a raw URL for this particular transaction.                     |
-| `route`            | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
-| `view`             | Name of the view handling the request.                                                                                          | `UserListView`                                         |
-| `unknown`          | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |
-| `component`        | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
-| `task`             | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
+| Source              | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `custom`            | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
+| `url`               | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
+| `url-fallback`      | The SDK is configured to send a `route`, but has to fall back to a raw URL for this particular transaction.                     |
+| `route`             | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
+| `view`              | Name of the view handling the request.                                                                                          | `UserListView`                                         |
+| `component`         | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
+| `task`              | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
+| `unknown` (default) | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -16,7 +16,7 @@
 This will be used by the server to decide whether or not to scrub identifiers
 from the transaction name, or replace the entire name with a placeholder.
 
-| Source             | Description                                                                                                                     | Examples                                               |
+| Source             | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | `raw-url`          | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
 | `raw-url-fallback` | The SDK is configured to send `url-pattern`, but has to fall back to a raw URL for this particular transaction.                 |
@@ -24,5 +24,5 @@ from the transaction name, or replace the entire name with a placeholder.
 | `view`             | Name of the view handling the request.                                                                                          | `UserListView`                                         |
 | `custom`           | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
 | `unknown`          | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |
-| `component`        | Named after a software component, such as function or class names                                                               | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
+| `component`        | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
 | `background-task`  | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -1,5 +1,3 @@
-## Transaction Annotations
-
 `transaction_info`
 
 : _Required_. Additional information about the name of the transaction.

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -1,3 +1,5 @@
+## Transaction Annotations
+
 `transaction_info`
 
 : _Required_. Additional information about the name of the transaction.

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -20,7 +20,6 @@ from the transaction name, or replace the entire name with a placeholder.
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | `custom`            | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
 | `url`               | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
-| `url-fallback`      | The SDK is configured to send a `route`, but has to fall back to a raw URL for this particular transaction.                     |
 | `route`             | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
 | `view`              | Name of the view handling the request.                                                                                          | `UserListView`                                         |
 | `component`         | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -1,0 +1,28 @@
+`transaction_info`
+
+: _Required_. Additional information about the name of the transaction.
+
+```json
+{
+  "transaction_info": {
+    "source": "raw-url"
+  }
+}
+```
+
+`transaction_info.source`
+
+: _Required_. Contains information about how the name of the transaction was determined.
+This will be used by the server to decide whether or not to scrub identifiers
+from the transaction name, or replace the entire name with a placeholder.
+
+| Source             | Description                                                                                                                     | Examples                                               |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `raw-url`          | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
+| `raw-url-fallback` | The SDK is configured to send `url-pattern`, but has to fall back to a raw URL for this particular transaction.                 |
+| `url-pattern`      | URL pattern / route                                                                                                             | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
+| `view`             | Name of the view handling the request.                                                                                          | `UserListView`                                         |
+| `custom`           | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
+| `unknown`          | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |
+| `component`        | Named after a software component, such as function or class names                                                               | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
+| `background-task`  | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |

--- a/src/docs/sdk/event-payloads/transaction.mdx
+++ b/src/docs/sdk/event-payloads/transaction.mdx
@@ -64,4 +64,6 @@ import "./properties/spans.mdx";
 
 import "./properties/measurements.mdx";
 
+## Transaction Annotations
+
 import "./properties/transaction_info.mdx";

--- a/src/docs/sdk/event-payloads/transaction.mdx
+++ b/src/docs/sdk/event-payloads/transaction.mdx
@@ -63,3 +63,5 @@ import "./properties/status.mdx";
 import "./properties/spans.mdx";
 
 import "./properties/measurements.mdx";
+
+import "./properties/transaction_info.mdx";

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -2,7 +2,7 @@
 title: "Guidelines for Performance Monitoring"
 ---
 
-This document covers how SDKs should add support for Performance Monitoring  with [Distributed
+This document covers how SDKs should add support for Performance Monitoring with [Distributed
 Tracing](https://docs.sentry.io/product/performance/distributed-tracing/).
 
 This should give an overview of the APIs that SDKs need to implement, without
@@ -64,6 +64,7 @@ The [Transaction](/sdk/event-payloads/transaction/) class is like a span, with a
 few key differences:
 
 - Transactions have `name`, spans don't.
+- Transactions must specify the [source](/sdk/event-payloads/transaction/#transaction-annotations) of its `name` to indicate how the transaction name was generated.
 - Calling the `finish` method on spans record the span's end timestamp. For
   transactions, the `finish` method additionally sends an event to Sentry.
 
@@ -89,7 +90,6 @@ tree as well as the unit of reporting to Sentry.
   - A transaction is either sampled (`sampled = true`) or unsampled (`sampled = false`), a decision which is either inherited or set once during the transaction's lifetime, and in either case is propagated to all children. Unsampled transactions should not be sent to Sentry.
   - `TransactionContext` should have a static/ctor method called `fromSentryTrace` which prefills a `TransactionContext` with data received from a `sentry-trace` header value
   - `TransactionContext` should have a static/ctor method called `continueFromHeaders(headerMap)` which is really just a thin wrapper around `fromSentryTrace(headerMap.get("sentry-trace"))` right now. This should be preferred by integration/framework-sdk authors over `fromSentryTrace` as it hides the exact header names used deeper in the core sdk, and leaves opportunity for using additional headers (from the W3C) in the future without changing all integrations.
-
 
 - `Span.finish()`
 
@@ -196,6 +196,7 @@ keep track of it themselves.
   - The value should be the trace header string of the `Span` that is currently on the `Scope`
 
 - Introduce a method called `startTransaction`
+
   - Takes the same two arguments as `Sentry.startTransaction`
   - Creates a new `Transaction` instance
   - Should implement sampling as described in more detail in the 'Sampling' section of this document


### PR DESCRIPTION
Add a `source` label to every transaction that indicates how the transaction name was generated, as decided in https://www.notion.so/sentry/Annotating-Transaction-Names-a08a05ff97b348b0903de03a17baa731.

Rendered version is [here](https://develop-git-feat-transaction-source.sentry.dev/sdk/event-payloads/properties/transaction_info/) and will be included on the "Transaction Type" page.