### PR TITLE
ref(DSC): Only include `user_id` in DSC if the `send-default-pii` option is enabled

### DIFF
--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -106,6 +106,10 @@ After the DSC of a particular trace has been frozen, API calls like `set_user` o
 Dynamic Sampling Context is sent to Sentry via the `trace` envelope header and is propagated to downstream SDKs via a baggage header.
 
 All of the values in the payloads below are required (non-optional) in a sense, that when they are known to an SDK at the time a transaction envelope is sent to Sentry, or at the time a baggage header is propagated, they must also be included in said envelope or baggage.
+
+The **only exception** is the `user_id` field.
+To avoid sensitive data being leaked to third parties, `user_id` should only be included, if the <Link to="/sdk/data-handling/#sensitive-data">`send-default-pii`</Link> option was enabled in the init options.
+
 In any case, `trace_id`, `public_key`, and `sample_rate` should always be known to an SDK, so these values are strictly required.
 
 ### Envelope Header
@@ -118,7 +122,7 @@ The value of this envelope header is a JSON object with the following fields:
 - `sample_rate` (string) - The sample rate as defined by the user on the SDK. This string should always be a number between (and including) 0 and 1 in basic float notation (`0.04242`) - no funky business like exponents or anything similar. If a `tracesSampler` callback was used for the sampling decision, its result should be used for `sample_rate` instead of the `tracesSampleRate` from `SentryOptions`. In case `tracesSampler` returns `True` it should be sent as `1.0`, `False` should be sent as `0.0`.
 - `release` (string) - The release name as specified in client options`.
 - `environment` (string) - The environment name as specified in client options.
-- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>.
+- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>. **Only included, if `send-default-pii` is enabled**
 - `user_segment` (string) - User segment as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>.
 - `transaction` (string) - The transaction name set on the scope.
 
@@ -133,7 +137,7 @@ SDKs may use the following keys to set entries on `baggage` HTTP headers:
 - `sentry-sample_rate`
 - `sentry-release`
 - `sentry-environment`
-- `sentry-user_id`
+- `sentry-user_id` - **Only included, if `send-default-pii` is enabled**
 - `sentry-user_segment`
 - `sentry-transaction`
 

--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -108,7 +108,10 @@ Dynamic Sampling Context is sent to Sentry via the `trace` envelope header and i
 All of the values in the payloads below are required (non-optional) in a sense, that when they are known to an SDK at the time a transaction envelope is sent to Sentry, or at the time a baggage header is propagated, they must also be included in said envelope or baggage.
 
 The **only exception** is the `user_id` field.
-To avoid sensitive data being leaked to third parties, `user_id` should only be included, if the <Link to="/sdk/data-handling/#sensitive-data">`send-default-pii`</Link> option was enabled in the init options.
+To avoid sensitive data being leaked to third parties, `user_id` should only be added to the DSC, if the <Link to="/sdk/data-handling/#sensitive-data">`send-default-pii`</Link> option was enabled in the SDK's init options.
+Note that this only applies for the head-of-trace SDK that populates the DSC content.
+In case downstream SDKs receive a `user_id` in incoming DSC, they should continue to propagate it. The rationale behind this is
+that incoming DSC [must be frozen](#freezing-dynamic-sampling-context) and users must make DS rules based on the head SDK's DSC data anyway.
 
 In any case, `trace_id`, `public_key`, and `sample_rate` should always be known to an SDK, so these values are strictly required.
 

--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -108,7 +108,7 @@ Dynamic Sampling Context is sent to Sentry via the `trace` envelope header and i
 All of the values in the payloads below are required (non-optional) in a sense, that when they are known to an SDK at the time a transaction envelope is sent to Sentry, or at the time a baggage header is propagated, they must also be included in said envelope or baggage.
 
 The **only exception** is the `user_id` field.
-To avoid sensitive data being leaked to third parties, `user_id` should only be added to the DSC, if the <Link to="/sdk/data-handling/#sensitive-data">`send-default-pii`</Link> option was enabled in the SDK's init options.
+To avoid sensitive data being leaked to third parties, `user_id` should only be added to the DSC, if the <Link to="/sdk/data-handling/#sensitive-data">`send_default_pii`</Link> option was enabled in the SDK's init options.
 Note that this only applies for the head-of-trace SDK that populates the DSC content.
 In case downstream SDKs receive a `user_id` in incoming DSC, they should continue to propagate it. The rationale behind this is
 that incoming DSC [must be frozen](#freezing-dynamic-sampling-context) and users must make DS rules based on the head SDK's DSC data anyway.
@@ -125,7 +125,7 @@ The value of this envelope header is a JSON object with the following fields:
 - `sample_rate` (string) - The sample rate as defined by the user on the SDK. This string should always be a number between (and including) 0 and 1 in basic float notation (`0.04242`) - no funky business like exponents or anything similar. If a `tracesSampler` callback was used for the sampling decision, its result should be used for `sample_rate` instead of the `tracesSampleRate` from `SentryOptions`. In case `tracesSampler` returns `True` it should be sent as `1.0`, `False` should be sent as `0.0`.
 - `release` (string) - The release name as specified in client options`.
 - `environment` (string) - The environment name as specified in client options.
-- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>. **Only included, if `send-default-pii` is enabled**
+- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>. **Only included, if `send_default_pii` is enabled**
 - `user_segment` (string) - User segment as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>.
 - `transaction` (string) - The transaction name set on the scope.
 
@@ -140,7 +140,7 @@ SDKs may use the following keys to set entries on `baggage` HTTP headers:
 - `sentry-sample_rate`
 - `sentry-release`
 - `sentry-environment`
-- `sentry-user_id` - **Only included, if `send-default-pii` is enabled**
+- `sentry-user_id` - **Only included, if `send_default_pii` is enabled**
 - `sentry-user_segment`
 - `sentry-transaction`
 

--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -107,11 +107,26 @@ Dynamic Sampling Context is sent to Sentry via the `trace` envelope header and i
 
 All of the values in the payloads below are required (non-optional) in a sense, that when they are known to an SDK at the time a transaction envelope is sent to Sentry, or at the time a baggage header is propagated, they must also be included in said envelope or baggage.
 
-The **only exception** is the `user_id` field.
-To avoid sensitive data being leaked to third parties, `user_id` should only be added to the DSC, if the <Link to="/sdk/data-handling/#sensitive-data">`send_default_pii`</Link> option was enabled in the SDK's init options.
+### Handling Sensitive Data and PII
+
+<Alert level="info">
+
+The currently specified solution is subject to change and will be revisited, once all SDKs implemented a mechanism of controlling where DSC and tracing data should be propagated to.
+This mechanism is still up for discussion and implementation but it will be similar to the `tracingOrigins` property that is already used in some SDKs right now.
+In the meantime, the solution below should be adopted from all SDKs to handle PII concerns.
+
+</Alert>
+
+It should be noted that DSC holds potentially sensitive data, such as PII, which needs to be handled carefully.
+
+Therefore, the **only exception** to the rule that all available DSC values must be collected at DSC
+population time, is the `user_id` field.
+To avoid this sensitive information being leaked to third parties, `user_id` should only be added to the DSC, if the <Link to="/sdk/data-handling/#sensitive-data">`send_default_pii`</Link> option was enabled in the SDK's init options.
 Note that this only applies for the head-of-trace SDK that populates the DSC content.
-In case downstream SDKs receive a `user_id` in incoming DSC, they should continue to propagate it. The rationale behind this is
-that incoming DSC [must be frozen](#freezing-dynamic-sampling-context) and users must make DS rules based on the head SDK's DSC data anyway.
+In case downstream SDKs receive a `user_id` in incoming DSC, they should continue to propagate it.
+The rationale behind this is that incoming DSC [must be frozen](#freezing-dynamic-sampling-context) and users must make DS rules based on the head SDK's DSC data anyway.
+
+#### Strictly required values
 
 In any case, `trace_id`, `public_key`, and `sample_rate` should always be known to an SDK, so these values are strictly required.
 
@@ -125,7 +140,7 @@ The value of this envelope header is a JSON object with the following fields:
 - `sample_rate` (string) - The sample rate as defined by the user on the SDK. This string should always be a number between (and including) 0 and 1 in basic float notation (`0.04242`) - no funky business like exponents or anything similar. If a `tracesSampler` callback was used for the sampling decision, its result should be used for `sample_rate` instead of the `tracesSampleRate` from `SentryOptions`. In case `tracesSampler` returns `True` it should be sent as `1.0`, `False` should be sent as `0.0`.
 - `release` (string) - The release name as specified in client options`.
 - `environment` (string) - The environment name as specified in client options.
-- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>. **Only included, if `send_default_pii` is enabled**
+- `user_id` (string) - User ID as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>. **Only included, if [`send_default_pii`](#handling-sensitive-data-and-pii) is enabled.**
 - `user_segment` (string) - User segment as set by the user with <Link to="/sdk/unified-api/#scope">`scope.set_user`</Link>.
 - `transaction` (string) - The transaction name set on the scope.
 
@@ -140,7 +155,7 @@ SDKs may use the following keys to set entries on `baggage` HTTP headers:
 - `sentry-sample_rate`
 - `sentry-release`
 - `sentry-environment`
-- `sentry-user_id` - **Only included, if `send_default_pii` is enabled**
+- `sentry-user_id` - **Only included, if [`send_default_pii`](#handling-sensitive-data-and-pii) is enabled.**
 - `sentry-user_segment`
 - `sentry-transaction`
 


### PR DESCRIPTION
This PR adds a condition to including the `user_id` field in the dynamic sampling context (DSC) that is sent via the `trace` envelope header to relay or propagated via the `baggage` Http header in outgoing requests. 

As discussed in TSC and in Slack, adding `user_id` to the DSC raises a PII concern because many SDKs currently propagate the DSC via `baggage` in all outgoing Http requests. This means, that PII could be sent to third parties. To avoid this, the decision was made to only include the `user_id` if the `send-default-pii` init option was set to `true`.

It's important to note that another way of addressing issues like this one is in discussion, which is making the `tracingOrigins` option part of every SDK. With this option, users can clearly specify where tracing data should be sent to, and thereby also disable the propagation of DSC to third parties. Until this is defined more clearly and ready for development, we propose the solution added with this PR in the meantime. 

Resolves #626