### PR TITLE
docs: Help note for Firefox users

### DIFF
--- a/src/docs/frontend/development-server.mdx
+++ b/src/docs/frontend/development-server.mdx
@@ -34,4 +34,4 @@ You can now run the dev server with `yarn dev-ui` and open [https://localhost:79
 
 ![lock icon in address bar](../img/addressBarLockIcon.png)
 
-
+**NOTE**: For Firefox users that use the master password you will be prompted for it with this message: "Enter Password or Pin for "NSS Certificate DB":"


### PR DESCRIPTION
Some Firefox users may use a master password and the process to create a local certificate will prompt for such password.

Unfortunately, the wording is not clear and this note should help.