### PR TITLE
docs: Warn users against using an IP value

### DIFF
--- a/src/docs/frontend/development-server.mdx
+++ b/src/docs/frontend/development-server.mdx
@@ -35,3 +35,5 @@ You can now run the dev server with `yarn dev-ui` and open [https://localhost:79
 ![lock icon in address bar](../img/addressBarLockIcon.png)
 
 **NOTE**: For Firefox users that use the master password you will be prompted for it with this message: "Enter Password or Pin for "NSS Certificate DB":"
+
+**NOTE**: Webpack outputs the IP from where the SPA is being served (e.g. `https://192.168.0.200:7999/`). Do not use it or you will still get the message above. The generated local certificates are only for `localhost`, `127.0.0.1` and `dev.getsentry.net`: Any of these values would work.


### PR DESCRIPTION
A developer may use the IPv4 URL from webpack's output and believe this did not work.