### PR TITLE
Update database-migrations documentation

### DIFF
--- a/src/docs/database-migrations.mdx
+++ b/src/docs/database-migrations.mdx
@@ -48,6 +48,8 @@ When you include a migration in a pr, also generate the sql for the migration an
 
 You can also generate an empty migration with `sentry django makemigrations <app_name> --empty`. This is useful for data migrations and other custom work.
 
+Note that if you have added a new model, you also need to import the model in `__init__.py`, or the model will not be recognized in testing.
+
 ## Merging migrations to master
 
 When merging to master you might notice a conflict with `migrations_lockfile.txt`. This file is in place to help us avoid merging two migrations with the same migration number to master, and if you're conflicting with it then it's likely someone has committed a migration ahead of you.


### PR DESCRIPTION
Short addition specifying that the developer must also add to the __init__.py file when creating a new model, or it will not be recognized in testing. Multiple people have run into this issue recently.