### PR TITLE
ref(sdk): Mark sentry_client as recommended

### DIFF
--- a/src/docs/sdk/overview.mdx
+++ b/src/docs/sdk/overview.mdx
@@ -188,7 +188,7 @@ it’s possible to send these values via the querystring:
 
 `sentry_client`
 
-: An arbitrary string that identifies your SDK, including its version. The
+: **Recommended.** An arbitrary string that identifies your SDK, including its version. The
   typical pattern for this is `client_name/client_version`.
 
   For example, the Python SDK might send this as `sentry.python/1.0`.


### PR DESCRIPTION
The `sentry_client` value, part of the sentry authentication header or query params helps ingestion detect clients even in cases where the payload cannot contain an SDK identifier. It's therefore recommended -- while not strictly required -- to send this from all official SDKs.