### PR TITLE
chore(docs): Add link to docs contribution guidelines

### DIFF
--- a/src/docs/docs/index.mdx
+++ b/src/docs/docs/index.mdx
@@ -4,7 +4,7 @@ title: "Documentation Guide"
 
 A part of every development project (especially Open Source projects) is documentation that explains how it works. Sentry is not any different. Because documentation is a big part of what makes Sentry work we’ve outlined some guidelines about how this documentation is structured and how to extend it.
 
-Sentry's documentation lives in numerous repositories, so what we're covering here is _this site_ and our general approach to documentation.
+Sentry's documentation lives in numerous repositories, so what we're covering here is _this site_ and our general approach to documentation. For a guide on contributing to user-facing docs, please see the `getsentry/sentry-docs` [contribution guidelines](https://docs.sentry.io/contributing/).
 
 ## Repositories
 
@@ -43,11 +43,11 @@ Avoid too many short paragraphs in short succession as they read and render terr
 
 ### Adjacent Code Blocks
 
-Avoid adjacent code blocks without a paragraph of text in between.  A code block should typically come with a paragraph that sets it into context.
+Avoid adjacent code blocks without a paragraph of text in between. A code block should typically come with a paragraph that sets it into context.
 
 ### Inclusive Language
 
-Sentry is a product used and developed by many people from different cultural backgrounds and we try to avoid language that has been identified as hurtful or insensitive.  For detailed recommendations see <Link to="/inclusion/">Inclusive Language</Link>.
+Sentry is a product used and developed by many people from different cultural backgrounds and we try to avoid language that has been identified as hurtful or insensitive. For detailed recommendations see <Link to="/inclusion/">Inclusive Language</Link>.
 
 ## Documentation Source
 


### PR DESCRIPTION
I always forget all of the places where docs guidelines live. This links two of them for better discoverability.