### PR TITLE
Note on using Ngrok for local dev and installing Slack App

### DIFF
--- a/src/docs/integrations/slack/index.mdx
+++ b/src/docs/integrations/slack/index.mdx
@@ -20,6 +20,8 @@ slack.client-secret: <client secret>
 slack.signing-secret: <signing secret>
 ```
 
+**NOTE**: If you're doing local Sentry development, you should use a tool like Ngrok and add `system.url-prefix: "https://armenzg.ngrok.io"` to your `~/.sentry/config.yml`, otherwise, installing the Slack APP will complain because the redirect URI points to `localhost:8000`.
+
 After you update the <code>config.yml</code> you need to restart your Sentry server to continue configuring the Slack app.
 
 Now that you’ve created your app and updated your Sentry config, you can navigate to __Interactivity & Shortcuts__ under __Features__.

--- a/src/docs/integrations/slack/index.mdx
+++ b/src/docs/integrations/slack/index.mdx
@@ -20,7 +20,7 @@ slack.client-secret: <client secret>
 slack.signing-secret: <signing secret>
 ```
 
-**NOTE**: If you're doing local Sentry development, you should use a tool like Ngrok and add `system.url-prefix: "https://armenzg.ngrok.io"` to your `~/.sentry/config.yml`, otherwise, installing the Slack APP will complain because the redirect URI points to `localhost:8000`.
+**NOTE**: If you're doing local Sentry development, you should use a tool like Ngrok and add `system.url-prefix: "https://<your_subdomain>.ngrok.io"` to your `~/.sentry/config.yml`, otherwise, installing the Slack APP will complain because the redirect URI points to `localhost:8000`. Also, install the Slack integration from the ngrok subdomain or it will fail to install.
 
 After you update the <code>config.yml</code> you need to restart your Sentry server to continue configuring the Slack app.
 


### PR DESCRIPTION
If this step is not taken, the installation of the Slack App will complain that the redirect URI points to http://localhost:8000.