### PR TITLE
Add `app_memory` to `app` context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -354,7 +354,7 @@ The `type` and default key is `"app"`.
 
 : _Optional_. Internal build identifier, as it appears on the platform.
 
-`memory_used`
+`app_memory`
 
 : _Optional_. Amount of memory used by the application in bytes.
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -354,6 +354,10 @@ The `type` and default key is `"app"`.
 
 : _Optional_. Internal build identifier, as it appears on the platform.
 
+`memory_used`
+
+: _Optional_. Amount of memory used by the application in bytes.
+
 ## Browser Context
 
 Browser context carries information about the browser or user agent for


### PR DESCRIPTION
Currently the `device` context has properties for the device memory usage but it can be useful to know how much memory an app was using when an event or transaction was captured. 

Open to better naming than `memory_used` 🤔

Related issues:
https://github.com/getsentry/sentry-cocoa/issues/999