### PR TITLE
Discourage use of transaction source unknown

### DIFF
--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -18,12 +18,12 @@ This will be used by the server to decide whether or not to scrub identifiers
 from the transaction name, or replace the entire name with a placeholder. The `source` should
 only be set by integrations and not by developers directly.
 
-| Source              | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `custom`            | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
-| `url`               | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
-| `route`             | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
-| `view`              | Name of the view handling the request.                                                                                          | `UserListView`                                         |
-| `component`         | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
-| `task`              | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
-| `unknown` (default) | This is the default value set by Relay for legacy SDKs.                                                                         |                                                        |
+| Source      | Description                                                                                                                     | <div style="width:220px">Examples</div>                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `custom`    | User-defined name, see [`setTransactionName()`](https://docs.sentry.io/platforms/javascript/enriching-events/transaction-name/) | `my_transaction`                                       |
+| `url`       | Raw URL, potentially containing identifiers.                                                                                    | `/auth/login/john123/`<br />`GET /auth/login/john123/` |
+| `route`     | Parametrized URL / route                                                                                                        | `/auth/login/:userId/`<br />`GET /auth/login/{user}/`  |
+| `view`      | Name of the view handling the request.                                                                                          | `UserListView`                                         |
+| `component` | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
+| `task`      | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
+| (`unknown`) | This is the default value set by Relay for legacy SDKs. Do not set this value in SDKs!                                          |                                                        |

--- a/src/docs/sdk/event-payloads/properties/transaction_info.mdx
+++ b/src/docs/sdk/event-payloads/properties/transaction_info.mdx
@@ -26,4 +26,4 @@ only be set by integrations and not by developers directly.
 | `view`      | Name of the view handling the request.                                                                                          | `UserListView`                                         |
 | `component` | Named after a software component, such as a function or class name.                                                             | `AuthLogin.login`<br /> `LoginActivity.login_button`   |
 | `task`      | Name of a background task (e.g. a Celery task)                                                                                  | `sentry.tasks.do_something`                            |
-| (`unknown`) | This is the default value set by Relay for legacy SDKs. Do not set this value in SDKs!                                          |                                                        |
+| `unknown`   | _Value set by Relay for legacy SDKs. SDKs must not set this value explicitly._                                                  |                                                        |


### PR DESCRIPTION
`unknown` should only be set by Relay, as a value for SDKs that do not send the `source` attribute.

![image](https://user-images.githubusercontent.com/1565449/184102181-bd629a72-987e-4794-801c-bdf419e0684a.png)
