### PR TITLE
Update DS SDKs list to link to product docs

### DIFF
--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -53,7 +53,7 @@ Because there are quite a few things to keep in mind for DSC propagation and to 
 
 #### Currently supported SDKs:
 
-The currently supported SDKs are documented on the [Dynamic Sampling Product docs](https://docs.sentry.io/product/data-management-settings/server-side-sampling/getting-started/#current-limitations). Please update that list once you launch release an SDK that support dynamic sampling features. To be considered a supported SDK for dynamic sampling, the SDK must support both creating the DSC at the head of the trace, and propogating DSC from continuing traces (if possible for that environment).
+The currently supported SDKs are documented on the [Dynamic Sampling Product docs](https://docs.sentry.io/product/data-management-settings/server-side-sampling/getting-started/#current-limitations). Please update that list once you release an SDK that supports dynamic sampling features. To be considered a supported SDK for dynamic sampling, the SDK must support both creating the DSC at the head of the trace, and propagating the DSC from continuing traces (if possible for that environment).
 
 
 ## Baggage

--- a/src/docs/sdk/performance/dynamic-sampling-context.mdx
+++ b/src/docs/sdk/performance/dynamic-sampling-context.mdx
@@ -52,13 +52,8 @@ This involves:
 Because there are quite a few things to keep in mind for DSC propagation and to avoid every SDK running into the same problems, we defined a [unified propagation mechanism](#unified-propagation-mechanism) (step-by-step instructions) that all SDK implementations should be able to follow.
 
 #### Currently supported SDKs:
-As this is an experimental feature and not yet available on all SDKs, we will communicate supported SDKs here.
 
-| SDK | Starting the head trace | Propagating head of the trace |
-|-----|:---:|:---:|
-|[sentry-javascript](https://github.com/getsentry/sentry-javascript)|✅|✅|
-|[sentry-python](https://github.com/getsentry/sentry-python)|❌|✅|
-|other SDKs|❌|❌|
+The currently supported SDKs are documented on the [Dynamic Sampling Product docs](https://docs.sentry.io/product/data-management-settings/server-side-sampling/getting-started/#current-limitations). Please update that list once you launch release an SDK that support dynamic sampling features. To be considered a supported SDK for dynamic sampling, the SDK must support both creating the DSC at the head of the trace, and propogating DSC from continuing traces (if possible for that environment).
 
 
 ## Baggage


### PR DESCRIPTION
Link to https://docs.sentry.io/product/data-management-settings/server-side-sampling/getting-started/#current-limitations, rather than maintain a list in 2 places. Also add clarifying docs around what it means to be a fully featured DS SDK.