### PR TITLE
Remove delimiters from default regex for `tracePropagationTargets`

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -40,7 +40,7 @@ Sentry SDKs propagate trace information to downstream SDKs via headers on outgoi
 
 This option takes an array of strings and/or regular expressions, and SDKs should only add trace headers to an outgoing request if the request's URL matches (or, in the case of string literals, contains) at least one of the items from the array.
 
-SDKs may choose a default value which makes sense for their use case. Most SDKs default to the regex `/.*/` (meaning they attach headers to all outgoing requests), but deviation is allowed if necessary. For example, because of CORS, browser-based SDKs default to only adding headers to domain-internal requests.
+SDKs may choose a default value which makes sense for their use case. Most SDKs default to the regex `.*` (meaning they attach headers to all outgoing requests), but deviation is allowed if necessary. For example, because of CORS, browser-based SDKs default to only adding headers to domain-internal requests.
 
 See [`sentry-trace`](#header-sentry-trace) and [`baggage`](/sdk/performance/dynamic-sampling-context/#baggage) for more details on the individual headers which are attached to outgoing requests.
 


### PR DESCRIPTION
As not to confuse non JS devs who don't know that `/` is just a short hand syntax to create a regex in JS.