### PR TITLE
Document that message params can be a dictionary

### DIFF
--- a/src/docs/sdk/event-payloads/message.mdx
+++ b/src/docs/sdk/event-payloads/message.mdx
@@ -25,8 +25,8 @@ help to group similar messages into the same issue.
 
 `params`
 
-: _Optional_: A list of formatting parameters, preferably strings. Non-strings
-  will be coerced to strings.
+: _Optional_: A list or dictionary of formatting parameters, preferably strings.
+  Non-strings will be coerced to strings.
 
 
 ## Examples


### PR DESCRIPTION
As far as I can tell, message params can be either a list or a dictionary of key-value pairs, but the latter is not well documented. An example might be helpful here too.