### PR TITLE
ref: Add Angular SDK span ops

### DIFF
--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -74,7 +74,7 @@ JS Frameworks should be prepended with the `ui` category for operations related 
 | ui.angular |                                 | Spans related to [Angular](https://angular.io/) components           |
 |            | ui.angular.init                 |                                                                      |
 |            | ui.angular.routing              |                                                                      |
-|            | ui.angular.<methodName>         | Created when a method wrapped with `TraceMethodDecorator` was called |
+|            | ui.angular.[methodName]         | Created when a method wrapped with `TraceMethodDecorator` was called |
 | ui.ember   |                                 | Spans related to [EmberJS](https://emberjs.com/) components          |
 |            | ui.ember.route.before_model     |                                                                      |
 |            | ui.ember.route.model            |                                                                      |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -56,27 +56,30 @@ If a span operation is not provided, the value of `default` is set by Relay.
 
 JS Frameworks should be prepended with the `ui` category for operations related to UI components.
 
-| Category   | Usage                           | Description                                                 |
-| ---------- | ------------------------------- | ----------------------------------------------------------- |
-| ui.react   |                                 | Spans related to [React](https://reactjs.org/) components   |
-|            | ui.react.render                 |                                                             |
-|            | ui.react.update                 |                                                             |
-|            | ui.react.mount                  |                                                             |
-| ui.vue     |                                 | Spans related to [Vue.js](https://vuejs.org/) components    |
-|            | ui.vue.activate                 |                                                             |
-|            | ui.vue.create                   |                                                             |
-|            | ui.vue.destroy                  |                                                             |
-|            | ui.vue.mount                    |                                                             |
-|            | ui.vue.update                   |                                                             |
-| ui.svelte  |                                 | Spans related to [Svelte](https://svelte.dev/) components   |
-|            | ui.svelte.init                  |                                                             |
-|            | ui.svelte.update                |                                                             |
-| ui.angular |                                 | Spans related to [Angular](https://angular.io/) components  |
-| ui.ember   |                                 | Spans related to [EmberJS](https://emberjs.com/) components |
-|            | ui.ember.route.before_model     |                                                             |
-|            | ui.ember.route.model            |                                                             |
-|            | ui.ember.route.after_model      |                                                             |
-|            | ui.ember.route.setup_controller |                                                             |
+| Category   | Usage                           | Description                                                          |
+| ---------- | ------------------------------- | -------------------------------------------------------------------- |
+| ui.react   |                                 | Spans related to [React](https://reactjs.org/) components            |
+|            | ui.react.render                 |                                                                      |
+|            | ui.react.update                 |                                                                      |
+|            | ui.react.mount                  |                                                                      |
+| ui.vue     |                                 | Spans related to [Vue.js](https://vuejs.org/) components             |
+|            | ui.vue.activate                 |                                                                      |
+|            | ui.vue.create                   |                                                                      |
+|            | ui.vue.destroy                  |                                                                      |
+|            | ui.vue.mount                    |                                                                      |
+|            | ui.vue.update                   |                                                                      |
+| ui.svelte  |                                 | Spans related to [Svelte](https://svelte.dev/) components            |
+|            | ui.svelte.init                  |                                                                      |
+|            | ui.svelte.update                |                                                                      |
+| ui.angular |                                 | Spans related to [Angular](https://angular.io/) components           |
+|            | ui.angular.init                 |                                                                      |
+|            | ui.angular.routing              |                                                                      |
+|            | ui.angular.<methodName>         | Created when a method wrapped with `TraceMethodDecorator` was called |
+| ui.ember   |                                 | Spans related to [EmberJS](https://emberjs.com/) components          |
+|            | ui.ember.route.before_model     |                                                                      |
+|            | ui.ember.route.model            |                                                                      |
+|            | ui.ember.route.after_model      |                                                                      |
+|            | ui.ember.route.setup_controller |                                                                      |
 
 ## Web Server
 


### PR DESCRIPTION
The Angular SDK adds a few spans when using [component tracking](https://docs.sentry.io/platforms/javascript/guides/angular/components/tracehelpers/) features as well as when the [Angular routing instrumentation](https://docs.sentry.io/platforms/javascript/guides/angular/components/tracehelpers/) is used.

This PR adds these span operations to the JS Frameworks table, analogously to the span ops of our other Framework SDKs.

Open question: In [the docs (last code example on this page)](https://docs.sentry.io/platforms/javascript/guides/angular/components/tracehelpers/), we give an example on how to add custom spans to the Angular bootstrapping process. The span op we suggest for this span is `ui.angular.bootstrap`. Do we want to mention this in the dev spec? I didn't yet add it because technically speaking, our SDK doesn't do this automatically. Probably fine this way but I just wanted to mention it anyway. 