### PR TITLE
Document geo location

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@sentry/tracing": "^7.0.0",
     "@sentry/webpack-plugin": "^1.18.3",
     "@types/dompurify": "^2.0.3",
-    "@types/node": "^16",
+    "@types/node": "^14",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@sentry/tracing": "^7.0.0",
     "@sentry/webpack-plugin": "^1.18.3",
     "@types/dompurify": "^2.0.3",
-    "@types/node": "^12",
+    "@types/node": "^16",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.1.0",

--- a/src/docs/sdk/event-payloads/user.mdx
+++ b/src/docs/sdk/event-payloads/user.mdx
@@ -37,7 +37,7 @@ Sentry.
 
 `geo`
 
-: An optional object describing the [geographical-location](#geo) of the end user or device.
+: An optional object describing the [geographical location](#geographical-location) of the end user or device.
 
 ## Geographical location
 

--- a/src/docs/sdk/event-payloads/user.mdx
+++ b/src/docs/sdk/event-payloads/user.mdx
@@ -37,7 +37,7 @@ Sentry.
 
 `geo`
 
-: An optional object describing the [geographical location](#geographical-location) of the end user or device, this object is automatically inferred if `ip_address` is provided.
+: An optional object describing the [geographical location](#geographical-location) of the end user or device, this object is automatically inferred by Relay if `ip_address` is provided.
 
 ## Geographical location
 

--- a/src/docs/sdk/event-payloads/user.mdx
+++ b/src/docs/sdk/event-payloads/user.mdx
@@ -35,6 +35,28 @@ of these attributes and only custom attributes is valid, but not as useful.
 All other keys are stored as extra information but not specifically processed by
 Sentry.
 
+`geo`
+
+: An optional object describing the [geographical-location](#geo) of the end user or device.
+
+## Geographical location
+
+Approximate geographical location of the end user or device.
+
+### Attributes
+
+`city`
+
+: Human readable city name.
+
+`country_code`
+
+: Two-letter country code (ISO 3166-1 alpha-2).
+
+`region`
+
+: Human readable region name or code.
+
 ## Automatic IP addresses
 
 SDKs running on client platforms, such as browsers and mobile applications,

--- a/src/docs/sdk/event-payloads/user.mdx
+++ b/src/docs/sdk/event-payloads/user.mdx
@@ -37,7 +37,7 @@ Sentry.
 
 `geo`
 
-: An optional object describing the [geographical location](#geographical-location) of the end user or device.
+: An optional object describing the [geographical location](#geographical-location) of the end user or device, this object is automatically inferred if `ip_address` is provided.
 
 ## Geographical location
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,15 +2781,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
+"@types/node@^14":
+  version "14.18.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.32.tgz#8074f7106731f1a12ba993fe8bad86ee73905014"
+  integrity sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==
+
 "@types/node@^14.14.10":
   version "14.18.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
   integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
-
-"@types/node@^16":
-  version "16.11.65"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.65.tgz#59500b86af757d6fcabd3dec32fecb6e357d7a45"
-  integrity sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==
 
 "@types/node@^8.5.7":
   version "8.10.66"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,15 +2781,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
-"@types/node@^12":
-  version "12.20.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.52.tgz#2fd2dc6bfa185601b15457398d4ba1ef27f81251"
-  integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
-
 "@types/node@^14.14.10":
   version "14.18.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
   integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+
+"@types/node@^16":
+  version "16.11.65"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.65.tgz#59500b86af757d6fcabd3dec32fecb6e357d7a45"
+  integrity sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==
 
 "@types/node@^8.5.7":
   version "8.10.66"


### PR DESCRIPTION
Document https://develop.sentry.dev/sdk/event-payloads/types/#geo

> Error: Node.js Version "12.x" is discontinued and must be upgraded. Please set Node.js Version to 16.x in your Project Settings to use Node.js 16.