### PR TITLE
feat(analytics): ports analytics page from notion and updates content

### DIFF
--- a/src/docs/analytics.mdx
+++ b/src/docs/analytics.mdx
@@ -6,39 +6,228 @@ This guide steps you through instrumenting your code with Sentry's 3rd-party ana
 
 ## Big Query
 
-Send events to Big Query and run queries in [Redash](https://redash.getsentry.net/).
+[BigQuery](https://cloud.google.com/bigquery/) is a Google data warehouse that a lot of our data calls home. This includes all our analytics data and some (not all) production data that might be of interest when joins are necessary for answering richer more complex questions. From sentry/getsentry, our data goes through [reload](https://github.com/getsentry/reload), our ETL for BigQuery.
 
-Create a new file in `src/sentry/analytics/events` using the key in snake case as the filename.
+## Adding It In Code
 
-In this file, you will need to register the event with attributes (for validation).
+### Step 1: Create your Analytics Events!
+
+Conventionally, the analytics events are stored in a file named `analytics` within the folder of the code it tracks. i.e.: `sentry/integrations/analytics.py` for the Integration analytic events and `sentry/api/analytics.py` for the API analytic events.
+
+The Event classes look like this:
+
+```python
+from __future__ import absolute_import, print_function
+
+from sentry import analytics
+
+class ExampleTutorialCreatedEvent(analytics.Event):
+  type = 'example_tutorial.created'
+
+   attributes = (
+      analytics.Attribute('id'),
+      analytics.Attribute('user_id'),
+  )
+
+class ExampleTutorialDeletedEvent(analytics.Event):
+  type = 'example_tutorial.deleted'
+
+   attributes = (
+      analytics.Attribute('id'),
+      analytics.Attribute('user_id'),
+  )
+
+analytics.register(ExampleTutorialCreatedEvent)
+analytics.register(ExampleTutorialDeletedEvent)
+```
+
+Your event classes will inherit from `[analytics.Event](https://github.com/getsentry/sentry/blob/master/src/sentry/analytics/event.py)` as shown above. All events have a `type` and `attributes`.
+
+`type`
+
+The `type` describes what the Event is, and this name should be unique across all analytics event classes.
+
+`attributes`
+
+The `attributes` will be what you would like to track, for example the `user_id` of the user performing the action. All `attributes` must be an `Attribute` object as shown above. Note that you cannot create an `attribute` named `'type'`.
+
+Finally, register your event classes so that the analytics [event_manager](https://github.com/getsentry/sentry/blob/master/src/sentry/analytics/event_manager.py) will pick them up.
+
+### If you are creating the [analytics.py](http://analytics.py) file for the first time:
+
+If you are creating a new analytics file for the first time, you will need to add an import to the package's `__init__.py`.
+
+If the Event classes are defined in a file named: `sentry/examples/analytics`, then the class below would be defined at `sentry/examples/__init__.py`:
+
+```python
+from __future__ import absolute_import
+
+from .analytics import *  # NOQA
+```
+
+Here, you have your usual `absolute_import` but in addition you will import every class in your `[analytics.py](http://analytics.py)` add `# NOQA` to avoid linter complaints.
+
+### Step 2: Add it to the code you want to track
+
+You'll be adding code in some user-facing area like an API endpoint.
+
 ```python
 from sentry import analytics
 
-class CodeownersAssignment(analytics.Event):
-    type = "codeowners.assignment" # replace with your key
+class ExampleEndpoint(Endpoint):
 
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("group_id"),
-        # more attributes
+  def post(self, request):
+    example = Example.objects.create(...)
+    analytics.record(
+        'example_tutorial.created',
+        id=example.id,
+        user_id=request.user.id,
     )
-
-analytics.register(CodeownersAssignment)
+    return Response(serialize(example, request.user))
 ```
 
-Now in the code that you want instrumented, use the `analytics.record` function with the registered key.
-```python 
-from sentry import analytics
+Do whatever you would normally with the endpoint, then use the `analytics.record` method to gather the information you want. Note that it takes input of the form:
 
+```python
 analytics.record(
-    "codeowners.assignment", # replace with your key
-    organization_id=project.organization_id,
-    project_id=project.id,
-    group_id=group.id,
-    # more attributes
+	'event_type_as_string',
+	<attribute_name_0>=<value>,
+		....
+	<attribute_name_n>=<value>,
 )
 ```
+
+Run the tests that touch the endpoint to ensure everything is Gucci.
+
+### Step 3: Add it to ETL
+
+To also send the analytics event in Amplitude, add the event to this file: [https://github.com/getsentry/etl/blob/master/etl/operators/analytics_events_schema.py](https://github.com/getsentry/etl/blob/master/etl/operators/analytics_events_schema.py)
+
+```jsx
+'my_backend_event.sent': { // Needs to match the `type` field in the class you created in step 1
+    'name': 'My Backend Event', // The event name in Amplitude
+    'uid_field': 'target_user_id' // Optional. Field name that represents the user id of the event.
+},
+```
+
+Note that in the future this will change so that by default, all events will go to Amplitude.
+
+## For Frontend events
+
+All front end events should come from a function generated by `makeAnalyticsFunction` which will type events to just the ones passed in as a generic. In Sentry, you can use the `trackAdvancedAnalyticsEvent` and in Getsentry there is `trackGetsentryAnalytics` (but it is possible to make a custom one like `trackIntegrationAnalytics`). These functions always send events to [reload](https://github.com/getsentry/reload) and can be configured to send events to Amplitude as well. These tie into the hook `analytics:track-event-v2`.
+
+
+### Step 1: Add the Typescript Definition
+
+First, add the Typescript definiition of the event to an analytics event file inside the `analytics` directory like [issueAnalyticsEvents.tsx](https://github.com/getsentry/sentry/blob/master/static/app/utils/analytics/issueAnalyticsEvents.tsx). There are two parts of this:
+1. Define the event parameters that get exported (ex: `IssueEventParameters`)
+2. Define the Reload to Amplitude name mapping (ex: `'issue_search.failed': 'Issue Search: Failed'`). If the value is `null`, then the event will not be sent to Amplitude.
+
+### Step 2: Add the Event in Code
+
+Now, you can use the event in code using a function generated by `makeAnalyticsFunction` (primarily `trackAdvancedAnalyticsEvent` in Sentry). The function takes the following arguments:
+
+`eventKey`
+
+This describes the key used in Sentry's own analytics system (Reload). It will map to an Amplitude name as determined in step 1.
+
+`analyticsParams`
+
+This object will hold all the information you're interested in tracking. Generally, you always pass in an `Organization` object into it unless the event is not tied to a specific organization. In getsentry, you should pass the `Subscription` as well. Certain fields like the role and plan will be pulled out of those entities and added to the event payloads.
+
+`options`
+
+This field allows passing the following optional fields:
+
+* `mapValuesFn`: An arbitrary function to map the parameters to new parameters
+* `startSession`:  If true, starts an analytics session. This session can be used to construct funnels. The start of the funnel should have startSession set to `true`.
+* `time`: Optional unix timestamp.
+
+### Typing and Mapping
+
+All events should be typed which specifies what the payload should be. We also define a mapping from the Reload event name to the Amplitude event name.
+
+### Naming Convention
+
+Our current naming convention for Reload events is `descriptor.action` e.g. what we have above with `example_tutorial.created` and `example_tutorial.deleted` . You want these to be specific enough to capture the action of interest but not too specific that you have a million distinctly named events with information that could be captured in the data object. For example, if you can create your example tutorial from multiple places, fight the urge to have the source as part of your descriptor i.e. `example_tutorial_onboarding.created` and `example_tutorial_settings.created`. Your future self running analytics will thank you. Amplitude event names should be similar to the Reload event name except you should capitalize the words and use spaces instead of underscores.
+
+**getsentry**
+
+```jsx
+import PropTypes from "prop-types";
+import React from "react";
+
+import trackGetsentryAnalytics from "getsentry/utils/trackGetsentryAnalytics";
+
+class ExampleComponent extends React.Component {
+  static propTypes = {
+    organization: PropTypes.object,
+  };
+
+  componentDidMount() {
+    trackGetsentryAnalytics("example_tutorial.created", {
+      organization,
+      subscription,
+      source: "wakanda",
+    });
+  }
+
+  render() {
+    return <h1> HI! </h1>;
+  }
+}
+```
+
+**sentry**
+
+All you'll actually need is to import analytics from utils and call it wherever you need. Keep in mind the effect of React lifecycles on your data. In this case, we only want to send one event when the component mounts so we place it in `componentDidMount` .
+
+```jsx
+import PropTypes from "prop-types";
+import React from "react";
+
+import trackAdvancedAnalyticsEvent from "sentry/utils/analytics/trackAdvancedAnalyticsEvent";
+
+class ExampleComponent extends React.Component {
+  static propTypes = {
+    organization: PropTypes.object,
+  };
+
+  componentDidMount() {
+    trackAdvancedAnalyticsEvent("example_tutorial.deleted", {
+      organization,
+      source: "wakanda",
+    });
+  }
+  render() {
+    return <h1> HI! </h1>;
+  }
+}
+```
+
+## For Backend and Frontend
+
+### Add the events to Reload
+
+We have a repo called [https://github.com/getsentry/reload](https://github.com/getsentry/reload). The [https://github.com/getsentry/reload/blob/master/reload_app/events.py](https://github.com/getsentry/reload/blob/master/reload_app/events.py) is a legacy list that specifies an optional schema for events. Newer front-end analytics events don't need to be added to this reload Schema.
+file holds a list of all accepted events.
+
+Here's an example of what that schema looks like:
+
+```python
+'example_tutorial.created': {
+	'org_id': int,
+	'source': str,
+	'plan': str,
+},
+
+'example_tutorial.deleted': {
+	'org_id': int,
+	'source': str,
+},
+```
+
+Deploy your changes in Reload through freight.
 
 ## Metrics
 
@@ -55,4 +244,5 @@ metrics.incr(
     tags={"status": status},
 )
 ```
+
 If you don't put a sample rate, you get 1 in 10 events. If the service is expected to have low traffic, we can start with a sample rate of 1.

--- a/src/docs/analytics.mdx
+++ b/src/docs/analytics.mdx
@@ -41,7 +41,7 @@ analytics.register(ExampleTutorialCreatedEvent)
 analytics.register(ExampleTutorialDeletedEvent)
 ```
 
-Your event classes will inherit from `[analytics.Event](https://github.com/getsentry/sentry/blob/master/src/sentry/analytics/event.py)` as shown above. All events have a `type` and `attributes`.
+Your event classes will inherit from [`analytics.Event`](https://github.com/getsentry/sentry/blob/master/src/sentry/analytics/event.py) as shown above. All events have a `type` and `attributes`.
 
 `type`
 
@@ -65,7 +65,7 @@ from __future__ import absolute_import
 from .analytics import *  # NOQA
 ```
 
-Here, you have your usual `absolute_import` but in addition you will import every class in your `[analytics.py](http://analytics.py)` add `# NOQA` to avoid linter complaints.
+Here, you have your usual `absolute_import` but in addition you will import every class in your [`analytics.py`](http://analytics.py) add `# NOQA` to avoid linter complaints.
 
 ### Step 2: Add it to the code you want to track
 


### PR DESCRIPTION
This ports over the Notion docs from here (https://www.notion.so/sentry/How-to-Add-Analytics-340256f377d94b43a05fc042033c185e) to the developer docs. I've also updated some content for accuracy based on some recent changes.