### PR TITLE
ref: use sentry's setup-volta for better caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: volta-cli/action@v4
+      - uses: getsentry/action-setup-volta@v1.1.0
       - run: yarn install
       - run: yarn test


### PR DESCRIPTION
this saves about ~30 seconds from the build time by caching yarn packages