### PR TITLE
feat: app.in_foreground and thread.main context flags

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -360,6 +360,10 @@ The `type` and default key is `"app"`.
 
 : _Optional_. Amount of memory used by the application in bytes.
 
+`in_foreground`
+
+: _Optional_. A flag indicating whether the app is in foreground or not. An app is in foreground when it's visible to the user.
+
 ## Browser Context
 
 Browser context carries information about the browser or user agent for

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -360,7 +360,7 @@ The `type` and default key is `"app"`.
 
 : _Optional_. Amount of memory used by the application in bytes.
 
-`app_in_foreground`
+`in_foreground`
 
 : _Optional_. A flag indicating whether the app is in foreground or not. An app is in foreground when it's visible to the user.
 

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -360,7 +360,7 @@ The `type` and default key is `"app"`.
 
 : _Optional_. Amount of memory used by the application in bytes.
 
-`in_foreground`
+`app_in_foreground`
 
 : _Optional_. A flag indicating whether the app is in foreground or not. An app is in foreground when it's visible to the user.
 

--- a/src/docs/sdk/event-payloads/threads.mdx
+++ b/src/docs/sdk/event-payloads/threads.mdx
@@ -26,7 +26,8 @@ attribute to cross-reference this thread.
 
 `crashed`
 
-: _Optional_. A flag indicating whether the thread was the cause for the event being sent, e.g. due to a crash. Defaults to `false`.
+: _Optional_. A flag indicating whether the thread was the cause for the event being sent, e.g. due to a crash.
+Defaults to `false`.
 
 `current`
 
@@ -36,7 +37,7 @@ Defaults to `false`.
 `ui`
 
 : _Optional_. If applicable, a flag indicating whether the thread was responsible for rendering the user interface.
-Defaults to `false`. On mobile platforms this is oftentimes referred to as the "main thread" or "ui thread".
+On mobile platforms this is oftentimes referred to as the "main thread" or "ui thread".
 
 `name`
 

--- a/src/docs/sdk/event-payloads/threads.mdx
+++ b/src/docs/sdk/event-payloads/threads.mdx
@@ -33,6 +33,11 @@ attribute to cross-reference this thread.
 : _Optional_. A flag indicating whether the thread was in the foreground. A thread is in foreground when it's executing.
 Defaults to `false`.
 
+`ui`
+
+: _Optional_. If applicable, a flag indicating whether the thread was responsible for rendering the user interface.
+Defaults to `false`. On mobile platforms this is oftentimes referred to as the "main thread" or "ui thread".
+
 `name`
 
 : _Optional_. The thread name.

--- a/src/docs/sdk/event-payloads/threads.mdx
+++ b/src/docs/sdk/event-payloads/threads.mdx
@@ -34,7 +34,7 @@ Defaults to `false`.
 : _Optional_. A flag indicating whether the thread was in the foreground. A thread is in foreground when it's executing.
 Defaults to `false`.
 
-`ui`
+`main`
 
 : _Optional_. If applicable, a flag indicating whether the thread was responsible for rendering the user interface.
 On mobile platforms this is oftentimes referred to as the "main thread" or "ui thread".

--- a/src/docs/sdk/event-payloads/threads.mdx
+++ b/src/docs/sdk/event-payloads/threads.mdx
@@ -26,11 +26,11 @@ attribute to cross-reference this thread.
 
 `crashed`
 
-: _Optional_. A flag indicating whether the thread crashed. Defaults to `false`.
+: _Optional_. A flag indicating whether the thread was the cause for the event being sent, e.g. due to a crash. Defaults to `false`.
 
 `current`
 
-: _Optional_. A flag indicating whether the thread was in the foreground.
+: _Optional_. A flag indicating whether the thread was in the foreground. A thread is in foreground when it's executing.
 Defaults to `false`.
 
 `name`


### PR DESCRIPTION
Relevant rendered parts:
https://develop-git-feat-app-in-foreground-and-threading.sentry.dev/sdk/event-payloads/contexts/#app-context
https://develop-git-feat-app-in-foreground-and-threading.sentry.dev/sdk/event-payloads/threads/

Adds `in_foreground` to the App Context event payload, as well as `main` to the Thread Context. 
As these are all similar but not the same and given that we already have some thread flags this PR tries to clear up their meanings and make their purpose hopefully more understandable.

@marandaneto I'm adding you as an early reviewer as I suspect you have some strong opinions about this 😊 

Related mobile issue: https://github.com/getsentry/team-mobile/issues/36