### PR TITLE
Update otel algo to read map

### DIFF
--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -63,7 +63,7 @@ class SentrySpanProcessor implements SpanProcessor {
 
     const otelSpanId = otelSpan.spanContext().spanId;
 
-    const parentSpan = scope.getSpan();
+    const parentSpan = this._map[otelSpanId];
     if (parentSpan) {
       // create a new span as a child of the parentSpan
       const childSpan = parentSpan.startChild({
@@ -177,20 +177,18 @@ All SDKs are required to add event context with the key `otel` to events generat
 
 ```ts
 {
-  contexts: {
-    otel: {
-      attributes: {
+  "contexts": {
+    "otel": {
+      "attributes": {
         "http.method": "GET",
         "http.url": "https://example.com",
         "http.status_code": 200,
       },
-      service: {
-        name: "my-service",
-        version: "1.0.0",
-      },
-      otel_sdk: {
-        name: "opentelemetry-node"
-        version: "4.0.0",
+      "resource": {
+        "service.name": "my-service",
+        "service.version": "1.0.0",
+	"telemetry.sdk.name": "opentelemetry-node",
+	"telemetry.sdk.version": "4.0.0",
       },
       // ...
     }

--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -65,7 +65,7 @@ class SentrySpanProcessor implements SpanProcessor {
 
     const mapVal = this._map[otelSpanId];
     if (mapVal) {
-    const [parentSpan] = mapVal;
+      const [parentSpan] = mapVal;
       // create a new span as a child of the parentSpan
       const childSpan = parentSpan.startChild({
         description: otelSpan.name,

--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -63,8 +63,9 @@ class SentrySpanProcessor implements SpanProcessor {
 
     const otelSpanId = otelSpan.spanContext().spanId;
 
-    const parentSpan = this._map[otelSpanId];
-    if (parentSpan) {
+    const mapVal = this._map[otelSpanId];
+    if (mapVal) {
+    const [parentSpan] = mapVal;
       // create a new span as a child of the parentSpan
       const childSpan = parentSpan.startChild({
         description: otelSpan.name,


### PR DESCRIPTION
We need to read from a map instead from scope in case we mistakenly create the wrong parent-child relationship.