### PR TITLE
Add info on self-hosted beacon

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -12,7 +12,27 @@ Our recommendation is to download the [latest release of the self-hosted reposi
 
 When you run `./install.sh`, you have a choice to opt in or out of our monitoring. This monitoring is used for development and debugging purposes so that we're on top of issues you're facing, allowing us to provide a more seamless installation process. For more details please see the [section in the self-hosted README](https://github.com/getsentry/self-hosted#self-hosted-monitoring).
 
-Note that choosing whether to send errors or not will become mandatory beginning with the 22.10.0 release.
+Note that choosing whether to send errors or not will become mandatory beginning with the 22.11.0 release.
+
+### Self-hosted Beacon
+
+Self-hosted will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
+- Getting information about the current version of Sentry
+- Retrieving important system notices
+The remote server is operated by the Sentry team (sentry.io), and the information reported follows the company's [privacy policy](https://sentry.io/privacy/).
+
+The following information is reported:
+1. A unique installation ID
+2. The version of Sentry
+3. A technical contact email (system.admin-email)
+4. General anonymous statistics on the data pattern (such as the number of users and volume of errors)
+5. Names and version of the installed Python modules
+Note: The contact email is utilized for security announcements, and will never be used outside of such.
+
+The data reported is minimal and it greatly helps the development team behind Sentry. With that said, you can disable the beacon with the following setting:
+```
+SENTRY_BEACON = False
+```
 
 ### Installing Behind a Proxy
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -16,7 +16,7 @@ Note that choosing whether to send errors or not will become mandatory beginning
 
 ### Self-hosted Beacon
 
-Self-hosted will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
+If you opt-in to it, self-hosted Sentry will periodically communicate with a remote beacon server. This is utilized for a couple of things, primarily:
 - Getting information about the current version of Sentry
 - Retrieving important system notices
 The remote server is operated by the Sentry team (sentry.io), and the information reported follows the company's [privacy policy](https://sentry.io/privacy/).

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -24,10 +24,10 @@ The remote server is operated by the Sentry team (sentry.io), and the informatio
 The following information is reported:
 1. A unique installation ID
 2. The version of Sentry
-3. A technical contact email (system.admin-email)
+3. A technical contact email if opted in to sending contact info (system.admin-email)
 4. General anonymous statistics on the data pattern (such as the number of users and volume of errors)
 5. Names and version of the installed Python modules
-Note: The contact email is utilized for security announcements, and will never be used outside of such.
+Note: The contact email is utilized for security announcements, and will never be used outside of such. You can change your opt in/out settings for sending contact info at any time in the settings of the admin panel.
 
 The data reported is minimal and it greatly helps the development team behind Sentry. With that said, you can disable the beacon with the following setting:
 ```


### PR DESCRIPTION
Adds some info on the self-hosted beacon from old docs that seem to no longer exist