### PR TITLE
Update otel specs for span attribute mapping

### DIFF
--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -395,13 +395,6 @@ This is based on a mapping done as part of work on the [OpenTelemetry Sentry Exp
                 >
                     kind
                 </a>
-                ,
-                <a
-                    title="OpenTelemetry Span Status Protobuf definitions"
-                    href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L253-L255"
-                >
-                    status
-                </a>
             </td>
             <td>
                 <a

--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -188,8 +188,8 @@ All SDKs are required to add event context with the key `otel` to events generat
       "resource": {
         "service.name": "my-service",
         "service.version": "1.0.0",
-	"telemetry.sdk.name": "opentelemetry-node",
-	"telemetry.sdk.version": "4.0.0",
+        "telemetry.sdk.name": "opentelemetry-node",
+        "telemetry.sdk.version": "4.0.0",
       },
       // ...
     }
@@ -390,13 +390,6 @@ This is based on a mapping done as part of work on the [OpenTelemetry Sentry Exp
         <tr>
             <td>
                 <a
-                    title="OpenTelemetry Span attributes Protobuf definitions"
-                    href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186"
-                >
-                    attributes
-                </a>
-                ,
-                <a
                     title="OpenTelemetry Span kind Protobuf definitions"
                     href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L153-L156"
                 >
@@ -421,6 +414,26 @@ This is based on a mapping done as part of work on the [OpenTelemetry Sentry Exp
             <td>
                 The <a title="OpenTelemetry Span Status Message Protobuf definitions" href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L263-L264">OpenTelemetry Span Status message</a> and span kind are set as tags on the Sentry span. Note, if you are constructing a transaction, *DO NOT ADD TO TAGS*.
             </td>
+        </tr>
+        <tr>
+            <td>
+                <a
+                    title="OpenTelemetry Span attributes Protobuf definitions"
+                    href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186"
+                >
+                    attributes
+                </a>
+              
+            </td>
+            <td>
+                <a
+                    title="Sentry Span data Relay definitions"
+                    href="https://github.com/getsentry/relay/blob/d7c5698888a2148799697d5427b37bfbe3b895bc/relay-general/src/protocol/span.rs#L48"
+                >
+                    data
+                </a>
+            </td>
+            <td></td>
         </tr>
         <tr>
             <td>


### PR DESCRIPTION
Small update to the otel specs. Otel span attributes should be mapped to sentry span data, as attributes can be arbitrary - so mapping them to tags (which have to be strings) is tricky.