### PR TITLE
Otel `kind` should be mapped to `data`

### DIFF
--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -390,33 +390,17 @@ This is based on a mapping done as part of work on the [OpenTelemetry Sentry Exp
         <tr>
             <td>
                 <a
+                    title="OpenTelemetry Span attributes Protobuf definitions"
+                    href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186"
+                >
+                    attributes
+                </a>,
+               <a
                     title="OpenTelemetry Span kind Protobuf definitions"
                     href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L153-L156"
                 >
                     kind
                 </a>
-            </td>
-            <td>
-                <a
-                    title="Sentry Span tags Relay definitions"
-                    href="https://github.com/getsentry/relay/blob/d7c5698888a2148799697d5427b37bfbe3b895bc/relay-general/src/protocol/span.rs#L44"
-                >
-                    tags
-                </a>
-            </td>
-            <td>
-                The <a title="OpenTelemetry Span Status Message Protobuf definitions" href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L263-L264">OpenTelemetry Span Status message</a> and span kind are set as tags on the Sentry span. Note, if you are constructing a transaction, *DO NOT ADD TO TAGS*.
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <a
-                    title="OpenTelemetry Span attributes Protobuf definitions"
-                    href="https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186"
-                >
-                    attributes
-                </a>
-              
             </td>
             <td>
                 <a


### PR DESCRIPTION
As `kind` is actually an integer, it does not make sense to map it to a tag, which has to be a string.