### PR TITLE
Fix some typos in grouping documentation

### DIFF
--- a/src/docs/grouping.mdx
+++ b/src/docs/grouping.mdx
@@ -89,9 +89,9 @@ In **Python** as an example each frame contributes `module` name, `function` nam
 the source code of the line where the frame pointer pointed with leading and trailing whitespace removed).
 The motivation here is the following: modules and functions are relatively coarse indicators and a function
 can often fail from different branches, so taking the source code into account in additiona is less likely
-to over-group.  This however also means that when a refactorign takes places in a line that does not change
+to over-group.  This however also means that when a refactoring takes places in a line that does not change
 the functionality but the source code, it can cause a new line to be created unnecessarily.  The other
-consequences of this is also that we require source code to be available for grouping.  This works well in
+consequence of this is that we require source code to be available for grouping.  This works well in
 Python as the Python SDK generally submits the source code along, but for instance we cannot use the same
 rule in C++ for instance where the availability of the source code is not guaranteed and one release can
 come with source, whereas another one might not.
@@ -101,7 +101,7 @@ challenges with determining a reliable function name due to limitations with the
 minified function names to show up at times which are unstable between builds.  Because of this we instead
 feed `module` name, `filename` (that is the base name of the path only converted to lowercase) as well as
 the `context-line`.  This again is risky as the `context-line` might slightly change over time.  An additional
-complication with JavaScript is that the browser supplied stack trace is not guarnateed to be particularly
+complication with JavaScript is that the browser supplied stack trace is not guaranteed to be particularly
 stable.  Different browsers have very different behavior in how the stack trace looks like when browser
 native functions are involved.  For instance the use of `Array.forEach` can produce vastly different stack
 traces between browsers.  Some will show `Array.forEach` as a stack frame, some will not.  As such the grouping


### PR DESCRIPTION
Noticed a few spelling mistakes while reviewing the grouping documentation