### PR TITLE
Added configuration for not tracing HTTP OPTION requests by default

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -44,6 +44,10 @@ SDKs may choose a default value which makes sense for their use case. Most SDKs 
 
 See [`sentry-trace`](#header-sentry-trace) and [`baggage`](/sdk/performance/dynamic-sampling-context/#baggage) for more details on the individual headers which are attached to outgoing requests.
 
+### `traceOptionRequests`
+
+This should be a boolean value. Default is `false`. When set to `true` transactions should be created for HTTP `OPTION` requests. When set to `false` NO transactions should be created for HTTP `OPTION` requests. This configuration is most valuable on backend server SDKs. If this configuration does not make sense for an SDK it can be omitted.
+
 #### Example
 
 The following example shows which URLs of outgoing requests would (not) match a given `tracePropagationTargets` array:


### PR DESCRIPTION
SDKs should not create transactions for HTTP `OPTION` requests by default, but the user should have the possibility to opt into to creating transactions for `OPTION` requests. 