### PR TITLE
fix(otel): Fix typo `instrumentor` to `instrumenter`

### DIFF
--- a/src/docs/sdk/performance/opentelemetry.mdx
+++ b/src/docs/sdk/performance/opentelemetry.mdx
@@ -61,7 +61,7 @@ class SentrySpanProcessor implements SpanProcessor {
     if (sentryParentSpan) {
       const sentryChildSpan = sentryParentSpan.startChild({
         description: otelSpan.name,
-        instrumentor: 'otel',
+        instrumenter: 'otel',
         startTimestamp: convertOtelTimeToSeconds(otelSpan.startTime),
         spanId: otelSpanId,
       });
@@ -72,7 +72,7 @@ class SentrySpanProcessor implements SpanProcessor {
       const transaction = hub.startTransaction({
         name: otelSpan.name,
         ...traceCtx,
-        instrumentor: 'otel',
+        instrumenter: 'otel',
         startTimestamp: convertOtelTimeToSeconds(otelSpan.startTime),
         spanId: otelSpanId,
       });


### PR DESCRIPTION
This was accidentally used inconsistently.