### PR TITLE
docs(ci): Clarify deployment instructions

### DIFF
--- a/src/docs/continuous-integration.mdx
+++ b/src/docs/continuous-integration.mdx
@@ -29,12 +29,14 @@ To deploy to production using Freight, follow these steps:
 
 If you've deployed something bad, you'll need to do the following:
 
-- Deploy the most recently known good commit that succeeded ASAP. Keep an eye on
-  this as deploys MUST finish, otherwise it's possible some web machines will
-  still be stuck on the bad deploy's code.
+- Immediately deploy the most recently known good commit using Freight. Under "Deploy History" click the release you want to roll back to, and click "Re-deploy" in the bottom right
+- Lock Freight deploys by clicking the "Lock Deploys" button in the top right
 - Inform #team-engineering that you're rolling back a bad deploy, and that no
   one should deploy getsentry master until the issue is resolved.
+- Keep an eye on the deploy, as deploys MUST finish, otherwise it's possible some web machines will
+  still be stuck on the bad deploy's code.
 - Fix the issue, and get it merged into master.
+- Unlock Freight deploys
 - Deploy the fix, and verify that the issue has indeed been fixed.
 - Inform #team-engineering that it is safe to deploy getsentry again.
 

--- a/src/docs/continuous-integration.mdx
+++ b/src/docs/continuous-integration.mdx
@@ -13,6 +13,18 @@ GitHub actions is our primary CI system and runs our tests on every pull request
 
 Freight is how we deploy our applications to staging & production.
 
+### Deploying to Production
+
+To deploy to production using Freight, follow these steps:
+
+- Click the "Deploy" button in the top right
+- Select the application using the dropdown. To deploy changes to Sentry select either `getsentry-backend` or `getsentry-frontend`, whichever is relevant to your changes
+- Select the environment. It should be "production" for regular production deploys
+- Select the ref. Using `master` is usually right, but you can also opt to deploy a specific commit
+- Freight will show you the list of undeployed commits. At this point you may choose to deploy an earlier commit rather than `master`. If so, update the ref to the commit SHA
+- If all looks well, click "Ship It!"
+- Wait for the deploy to finish
+
 ### Reverting / Rolling Back After a Bad Deploy
 
 If you've deployed something bad, you'll need to do the following:


### PR DESCRIPTION
I had to have all of this explained to me during onboarding, and then it immediately changed anyway, so I figure others might benefit. The [corresponding Notion document](https://www.notion.so/sentry/Deploying-Code-a39bd647e4e04f7a99cb30068feaed96) is stale.

- Update deployment instructions
- Clarify rollback instructions
