### PR TITLE
Fixed wrong HTTP OPTIONS spelling

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -44,9 +44,9 @@ SDKs may choose a default value which makes sense for their use case. Most SDKs 
 
 See [`sentry-trace`](#header-sentry-trace) and [`baggage`](/sdk/performance/dynamic-sampling-context/#baggage) for more details on the individual headers which are attached to outgoing requests.
 
-### `traceOptionRequests`
+### `traceOptionsRequests`
 
-This should be a boolean value. Default is `false`. When set to `true` transactions should be created for HTTP `OPTION` requests. When set to `false` NO transactions should be created for HTTP `OPTION` requests. This configuration is most valuable on backend server SDKs. If this configuration does not make sense for an SDK it can be omitted.
+This should be a boolean value. Default is `false`. When set to `true` transactions should be created for HTTP `OPTIONS` requests. When set to `false` NO transactions should be created for HTTP `OPTIONS` requests. This configuration is most valuable on backend server SDKs. If this configuration does not make sense for an SDK it can be omitted.
 
 #### Example
 


### PR DESCRIPTION
It is called optionS and not option.