### PR TITLE
add ui.ttid to span operations

### DIFF
--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -181,6 +181,7 @@ Serverless related spans are expected to follow OpenTelemetry's [Function as a S
 |            | app.start.cold            |                               |
 | ui         |                           | An operation on a mobile UI   |
 |            | ui.load                   |                               |
+|            | ui.ttid                   |                               |
 |            | ui.action                 |                               |
 |            | ui.action.click           |                               |
 |            | ui.action.swipe           |                               |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -182,6 +182,7 @@ Serverless related spans are expected to follow OpenTelemetry's [Function as a S
 | ui         |                           | An operation on a mobile UI   |
 |            | ui.load                   |                               |
 |            | ui.load.initial_display   |                               |
+|            | ui.load.full_display      |                               |
 |            | ui.action                 |                               |
 |            | ui.action.click           |                               |
 |            | ui.action.swipe           |                               |

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -181,7 +181,7 @@ Serverless related spans are expected to follow OpenTelemetry's [Function as a S
 |            | app.start.cold            |                               |
 | ui         |                           | An operation on a mobile UI   |
 |            | ui.load                   |                               |
-|            | ui.ttid                   |                               |
+|            | ui.load.initial_display   |                               |
 |            | ui.action                 |                               |
 |            | ui.action.click           |                               |
 |            | ui.action.swipe           |                               |


### PR DESCRIPTION
We are going to add a ttid (time to initial display) span to the automatic activity transactions.
The use case is mainly for mobile developers.
The current activity transaction duration is not reliable to have an understanding of how much time it took to actually load an activity, due to possible other spans added during the transaction.