### PR TITLE
Use Python 3 docs for log level references

### DIFF
--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -80,7 +80,7 @@ in a production system, because the Celery logger can be extremely verbose when 
 
 Sentry can override logger levels by providing the CLI with the `-l/--loglevel` flag.
 
-The value of this can be one of the [standard Python logging level strings](https://docs.python.org/2/library/logging.html#levels).
+The value of this can be one of the [standard Python logging level strings](https://docs.python.org/3/library/logging.html#logging-levels).
 
 ```shell
 sentry --loglevel=WARNING
@@ -92,7 +92,7 @@ sentry --loglevel=WARNING
 
 Sentry can override logger levels with the `SENTRY_LOG_LEVEL` environment variable.
 
-The value of this can be one of the [standard Python logging level strings](https://docs.python.org/2/library/logging.html#levels).
+The value of this can be one of the [standard Python logging level strings](https://docs.python.org/3/library/logging.html#logging-levels).
 
 ```shell
 SENTRY_LOG_LEVEL=WARNING sentry ...


### PR DESCRIPTION
Updates links from https://develop.sentry.dev/config/#logging to log levels at Python docs with Python 3-based ones.

cf. https://www.python.org/doc/sunset-python-2/

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>