### PR TITLE
chore(frontend): Tidy up upgrade policies doc

### DIFF
--- a/src/docs/frontend/upgrade-policies.mdx
+++ b/src/docs/frontend/upgrade-policies.mdx
@@ -4,15 +4,15 @@ title: Dependency Upgrade Policies
 
 ## Our philosophy
 
-- Core packages such as `react`, `emotion`, `typescript`, `@babel` etc. should be kept up with. These packages have minimal dependences and typically have well documented and thoughtful upgrade paths. updating core dependencies is non negotiable because of the increasing marginal cost of major version updates. For packages like this it may also be a good idea to delay major upgrades until a month or two have passed.
+- Core packages such as `react`, `emotion`, `typescript`, `@babel` etc. should be kept up with. These packages have minimal dependencies and typically have well documented and thoughtful upgrade paths. Updating core dependencies is non negotiable because of the increasing marginal cost of major version updates. For packages like this it may also be a good idea to delay major upgrades until a month or two have passed.
 
 - Avoid upgrading packages that are constantly releasing patch versions. Prefer upgrading once the package has stabilized.
 
-- Upgrades that drop sub-dependencies are a win! The less packages installed the better. This means less code to ship and less possibility for library specific bugs.
+- Upgrades that drop sub-dependencies are a win! The fewer packages installed the better. This means less code to ship and less possibility for library specific bugs.
 
-- Upgrades that reduce the number of discrepant shared sub-dependencies are a win! If upgrading a package a minor version means that it will share the same version dependency with another top-level package this reduces the amount of code that is shipped.
+- Upgrades that reduce the number of discrepant shared sub-dependencies are a win! If upgrading a package minor version means that it will share the same version dependency with another top-level package this reduces the amount of code that is shipped.
 
-- Upgrades for non-critical packages such as `jest`, `eslint`, `prettier` can be done as time permits. eg, if all tests pass and everything looks OK, upgrading is a no brainer.
+- Upgrades for non-critical packages such as `jest`, `eslint`, `prettier` can be done as time permits. e.g., if all tests pass and everything looks OK, upgrading is a no brainer.
 
 - When in doubt, discuss upgrades in the [Frontend Technical Steering Committee (TSC)](https://www.notion.so/Frontend-Technical-Steering-Committee-TSC-504b63ca92204f068ffda7e36feefc04)
 
@@ -100,7 +100,7 @@ The general category of frontend dependencies we have are
 
 4. **Application build dependencies**
 
-   This is a package that is used to either compile the sentry application into javascript files that will be shipped to production. These types of dependencies can be relatively quickly validated since generally if something breaks, the application will fail to build and CI will fail.
+   This is a package that is used to either compile the sentry application into JavaScript files that will be shipped to production. These types of dependencies can be relatively quickly validated since generally if something breaks, the application will fail to build and CI will fail.
 
 5. **Development dependencies**
 
@@ -136,7 +136,7 @@ For example, some dependencies such as `webpack` fall both into the app build **
 
    - For dependencies affecting specific UI components you can reference the **Vercel Storybook Previews** to validate that the component behaves as it should.
 
-   - For framework dependencies, you’ll want to spot-check as much as you can. You should take into consideration the changes in the new version of the package and validate that whatever was changed behaves as expected. Looking for “odd” usage of APIs can be helpful here (eg, are we doing manual `ReactDOM` calls anywhere? etc)
+   - For framework dependencies, you’ll want to spot-check as much as you can. You should take into consideration the changes in the new version of the package and validate that whatever was changed behaves as expected. Looking for “odd” usage of APIs can be helpful here (e.g., are we doing manual `ReactDOM` calls anywhere? etc)
 
    - For application build dependencies we should already be feeling pretty good at this step, considering the application built and passed CI. But it’s still worth checking the change log to make sure nothing in the build pipeline may have affected the application. However, problems with the application build here may be hard to spot as they will likely be subtle if CI did not catch them.
 
@@ -160,7 +160,7 @@ For example, some dependencies such as `webpack` fall both into the app build **
 
 6. **Read the `yarn.lock` diff**
 
-   It’s good to understand exactly what has changed with the upgrade. It’s generally a bad thing if upgrading has caused a discrepancy in shared sub dependency versions. For example, if you upgrade `lodash` but another top level package specifies that it needs and older version of `lodash` we will now have **two versions** of `lodash` installed. That means two separate versions of `lodash`l will be shipped!
+   It’s good to understand exactly what has changed with the upgrade. It’s generally a bad thing if upgrading has caused a discrepancy in shared sub dependency versions. For example, if you upgrade `lodash` but another top level package specifies that it needs and older version of `lodash` we will now have **two versions** of `lodash` installed. That means two separate versions of `lodash` will be shipped!
 
    Generally you will want to make sure nothing has duplicated versions, in that case you may need to use `[yarn-deduplicate](https://www.npmjs.com/package/yarn-deduplicate)` or in the worst case you may need to upgrade the package which is pulling in the offending older versions.
 
@@ -168,7 +168,7 @@ For example, some dependencies such as `webpack` fall both into the app build **
 
 7. **Validate in production after the upgrade is merged**
 
-   Finally, in some cases, it may be worth checking that the production application is operating as expected in production. In some rare cases a package may behave differently in production (though this is very rare, as checking the frontend preview is very close to the same production bundle).
+   Finally, in some cases, it may be worth checking that the application is operating as expected in production. In some rare cases a package may behave differently in production (though this is very rare, as checking the frontend preview is very close to the same production bundle).
 
 ## Take advantage of tooling
 
@@ -185,7 +185,6 @@ It has two primary modes of operation
 - **Opening version upgrade PRs**
 
   The PRs this mode creates is equivalent to manually doing upgrades of packages in the `package.json`. This is convenient because we can at a glance see if CI is passing for the upgrade. Dependabot also is smart about upgrading groups of packages, for example, it will upgrade `@type/*` packages alongside the library.
-  We configure
 
 **Both of these modes are currently in use for `getsentry/sentry`.** You can look at the [dependabot.yml](https://github.com/getsentry/sentry/blob/master/.github/dependabot.yml) for more specifics on the interval for how often it will automatically open PRs and how many it will open at once.
 


### PR DESCRIPTION
Cleans up a few stray things:

- `eg,` should be `e.g.` to match our docs (and most style guides)
- remove some stray characters, words, and phrases
- fix a few typos
