### PR TITLE
docs(application): Add options documentation

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -66,6 +66,7 @@ export default () => {
           <SidebarLink to="/sentry-vs-getsentry/">sentry vs getsentry</SidebarLink>
           <SidebarLink to="/config/">Configuration</SidebarLink>
           <SidebarLink to="/feature-flags/">Feature Flags</SidebarLink>
+          <SidebarLink to="/options/">Options</SidebarLink>
           <SidebarLink to="/serializers/">Serializers</SidebarLink>
           <SidebarLink to="/grouping/">Grouping</SidebarLink>
           <SidebarLink to="/api/" title="API">

--- a/src/docs/feature-flags.mdx
+++ b/src/docs/feature-flags.mdx
@@ -76,7 +76,7 @@ default_manager.add('organizations:test-feature', OrganizationFeature)
 
 Flagr has significant latency, and is somewhat flakey. If you're working in
 high throughput areas like Ingest or Relay, Flagr is not fast enough or
-reliable enough. In these cases, you should use [options](/options) instead.
+reliable enough. In these cases, you should use [options](/options/) instead.
 
 ### Add it to the Organization Model Serializer
 

--- a/src/docs/feature-flags.mdx
+++ b/src/docs/feature-flags.mdx
@@ -68,7 +68,7 @@ add a third optional boolean parameter when adding the feature, for example:
 default_manager.add('organizations:test-feature', OrganizationFeature, True)
 ```
 
-If you don't plan to use flagr don't pass this third parameter, for example: 
+If you don't plan to use flagr don't pass this third parameter, for example:
 
 ```python
 default_manager.add('organizations:test-feature', OrganizationFeature)
@@ -192,7 +192,7 @@ flags are then configured via `sentry.conf.py`. For Sentry's SaaS deployment,
 Flagr is used to configure flags in production.
 
 If you want to enable your feature for a subset of production users, you will
-need to set up your feature in Flagr. If you haven't already make sure that 
+need to set up your feature in Flagr. If you haven't already make sure that
 when you add your flag in sentry that you passed the third option so that Flagr
 knows to check this feature in production.
 
@@ -404,7 +404,7 @@ clicking **Delete Flag** at the bottom of the page.
 ## Getsentry feature handlers
 
 Getsentry contains a variety of feature handlers that override the
-`SENTRY_FEATURES` map. 
+`SENTRY_FEATURES` map.
 
 ### Plan specific features
 
@@ -418,7 +418,7 @@ you need to:
 ### Custom handlers
 
 If your feature requires additional logic to become active, you can also
-implement a feature handler in getsentry, follow these steps:
+implement a feature handler in getsentry. For example, you can create a feature flag that is backed by [options](/options/). follow these steps:
 
 1. Disable the feature in `getsentry/conf/settings/defaults.py` by updating `SENTRY_FEATURES`.
 2. Add a new feature handler class in `getsentry/features.py` that determines availability of the feature based on the organization or actor.

--- a/src/docs/feature-flags.mdx
+++ b/src/docs/feature-flags.mdx
@@ -74,6 +74,10 @@ If you don't plan to use flagr don't pass this third parameter, for example:
 default_manager.add('organizations:test-feature', OrganizationFeature)
 ```
 
+Flagr has significant latency, and is somewhat flakey. If you're working in
+high throughput areas like Ingest or Relay, Flagr is not fast enough or
+reliable enough. In these cases, you should use [options](/options) instead.
+
 ### Add it to the Organization Model Serializer
 
 The Organization model serializer

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -52,10 +52,6 @@ from sentry import options
 options.set("performance.some-feature-rate", 0.01)
 ```
 
-<Alert level="warning">
-Do not use <code>options.set</code> in your application code.
-</Alert>
-
 <Alert level="info">
 If you do not have access to the shell, you'll need to contact OPS to set the option value for you.
 </Alert>

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -58,7 +58,7 @@ If you do not have access to the shell, you'll need to contact OPS to set the op
 
 ### Management UI
 
-If you expect to frequently update your option, you can make it editable in the management UI. The `/admin/settings` page in the Sentry app has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx).
+If you expect to frequently update your option, you can make it editable in the management UI. The `/admin/settings` page in the Sentry app has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx). Editing options requires the `"options.admin"` permission, and all changes are added to an audit log.
 
 ## Using Options for Feature Rollout
 

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -58,9 +58,9 @@ options.set("performance.some-feature-rate", 0.01)
   value for you.
 </Alert>
 
-### Management UI
+### Options UI
 
-If you expect to frequently update your option, you can make it editable in the management UI. The `/admin/settings` page in the Sentry app has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx). Editing options requires the `"options.admin"` permission, and all changes are added to an audit log.
+If you expect to frequently update your option, you can make it editable in the options UI. The `/admin/settings` page in the Sentry app has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx). The options UI is only available to superusers. Editing options requires the `"options.admin"` permission, and all changes are added to an audit log.
 
 ## Using Options for Feature Rollout
 

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -1,3 +1,118 @@
 ---
 title: 'Options'
 ---
+
+Options are a way to store generic system-wide configuration. They serve a similar purpose to configuration files, but they are backed by a database, so it's possible to change them at runtime. This makes options well-suited for rates, quotas, and limits.
+
+## Adding New Options
+
+To add a new system option, add it to [`sentry/options/defaults.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/options/defaults.py). e.g.,
+
+```python
+register("performance.some-feature-rate", default=0.0)
+```
+
+### Tips
+
+- namespace your option. Something like `feature-scope.feature-name`
+- colocate your `register` with similar options
+- use dashes and not underscores
+- always set a default value with `default=`
+- the default value can be a boolean, integer, string, or float
+
+<Alert level="warning">
+  Always split up registering the new option and the code that relies on the new option. Register new options in their own pull requests, ahead of the code changes.
+</Alert>
+
+## Using Options
+
+To check the value of an option at runtime, import the `options` module and use the `get` method. e.g.,
+
+```python
+from sentry import options
+feature_rate = options.get("performance.some-feature-rate")
+```
+
+## Setting Options
+
+Options are stored in the database and are cached. You can change the value of an option using `sentry shell`, or by using the management UI.
+
+### Sentry Shell
+
+You can set option values using `sentry shell`. e.g.,
+
+```bash
+sentry shell
+```
+
+then,
+
+```python
+from sentry import options
+options.set("performance.some-feature-rate", 0.01)
+```
+
+<Alert level="warning">
+Do not use <code>options.set</code> in your application code. <code>options.set</code> is meant for OPS use.
+</Alert>
+
+<Alert level="info">
+If you do not have access to the shell, you'll need to contact OPS to set the option value for you.
+</Alert>
+
+### Management UI
+
+If you expect to frequently update your option, you may want to make it editable in the management UI. The `/admin/settings` page has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx).
+
+## Using Options for Feature Rollout
+
+If you're working on a system-wide feature, you may choose to use options for your rollout instead of feature flags. Unlike feature flags, options don't allow for easy segmentation, but they are fast and simple. e.g.,
+
+```python
+from sentry import options
+
+rate = options.get("performance.some-feature-rate")
+if rate and rate > random.random():
+    do_feature_stuff()
+```
+
+However, be careful! Using `random.random` will cause your feature to be enabled and disabled randomly between page requests. This may be unacceptable for user-facing features. Instead, you should use the `sample_modulo` helper. e.g.,
+
+```python
+from sentry.utils.options import sample_modulo
+
+if sample_modulo("performance.some-feature-rate", organization.id):
+    do_feature_stuff()
+```
+
+`sample_modulo` guarantees that for a given value of the option and a given organization it will always return `True` or `False` for every invocation.
+
+## Setting Options in Tests
+
+In order to test features that check options, you can use the `override_options` decorator. e.g.,
+
+```python
+from sentry.testutils.helpers import override_options
+
+@override_options({"performance.some-feature-rate": 1.0})
+def test_some_feature(self):
+    ...
+```
+
+## Removing Options
+
+If your option is short-lived, you should remove it once it's no longer needed. First, create a pull request to remove the option and its usage. Then, remove the option from the database. To do this, you can use the Sentry shell. e.g.,
+
+```bash
+sentry shell
+```
+
+then,
+```python
+from sentry import options
+options.delete("performance.some-feature-rate")
+```
+
+<Alert level="info">
+If you do not have access to the shell, you'll need to contact OPS to remove the option for you.
+</Alert>

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -1,0 +1,3 @@
+---
+title: 'Options'
+---

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -2,11 +2,11 @@
 title: 'Options'
 ---
 
-Options are a way to store generic system-wide configuration. They serve a similar purpose to configuration files, but they are backed by a database, so it's possible to change them at runtime. This makes options well-suited for rates, quotas, and limits.
+Options are a way to store generic system-wide configuration. They serve a similar purpose to configuration files, but they are backed by a database, so it's possible to change them at runtime without a deploy. This makes options well-suited for rates, quotas, and limits.
 
 ## Adding New Options
 
-To add a new system option, add it to [`sentry/options/defaults.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/options/defaults.py). e.g.,
+To add a new system option, add it to [`sentry/options/defaults.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/options/defaults.py) by registering it. e.g.,
 
 ```python
 register("performance.some-feature-rate", default=0.0)
@@ -14,11 +14,11 @@ register("performance.some-feature-rate", default=0.0)
 
 ### Tips
 
-- namespace your option. Something like `feature-scope.feature-name`
-- colocate your `register` with similar options
+- namespace your option (e.g., `feature-scope.feature-name`)
+- colocate your new option with related existing options
 - use dashes and not underscores
 - always set a default value with `default=`
-- the default value can be a boolean, integer, string, or float
+- the value of an option can be any pickleable value
 
 <Alert level="warning">
   Always split up registering the new option and the code that relies on the new option. Register new options in their own pull requests, ahead of the code changes.
@@ -26,7 +26,7 @@ register("performance.some-feature-rate", default=0.0)
 
 ## Using Options
 
-To check the value of an option at runtime, import the `options` module and use the `get` method. e.g.,
+To check the value of an option, import the `options` module and use the `get` method. e.g.,
 
 ```python
 from sentry import options
@@ -53,7 +53,7 @@ options.set("performance.some-feature-rate", 0.01)
 ```
 
 <Alert level="warning">
-Do not use <code>options.set</code> in your application code. <code>options.set</code> is meant for OPS use.
+Do not use <code>options.set</code> in your application code.
 </Alert>
 
 <Alert level="info">
@@ -62,21 +62,22 @@ If you do not have access to the shell, you'll need to contact OPS to set the op
 
 ### Management UI
 
-If you expect to frequently update your option, you may want to make it editable in the management UI. The `/admin/settings` page has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx).
+If you expect to frequently update your option, you can make it editable in the management UI. The `/admin/settings` page in the Sentry app has inputs for a small set of the available options. You can submit a pull request to add your option to the UI by [updating the corresponding React view](https://github.com/getsentry/sentry/blob/master/static/app/views/admin/options.tsx).
 
 ## Using Options for Feature Rollout
 
-If you're working on a system-wide feature, you may choose to use options for your rollout instead of feature flags. Unlike feature flags, options don't allow for easy segmentation, but they are fast and simple. e.g.,
+If you're working on a system-wide feature, you may choose to use options for your rollout instead of feature flags. Unlike feature flags, options don't allow for easy segmentation, but they are performance, stable, and simple. e.g.,
 
 ```python
+import random
 from sentry import options
 
 rate = options.get("performance.some-feature-rate")
-if rate and rate > random.random():
+if rate > random.random():
     do_feature_stuff()
 ```
 
-However, be careful! Using `random.random` will cause your feature to be enabled and disabled randomly between page requests. This may be unacceptable for user-facing features. Instead, you should use the `sample_modulo` helper. e.g.,
+However, be careful! Using `random.random` will cause your feature to be enabled and disabled randomly between page requests. This may be unacceptable for user-facing features. To avoid this, you can use the `sample_modulo` helper. e.g.,
 
 ```python
 from sentry.utils.options import sample_modulo
@@ -85,7 +86,7 @@ if sample_modulo("performance.some-feature-rate", organization.id):
     do_feature_stuff()
 ```
 
-`sample_modulo` guarantees that for a given value of the option and a given organization it will always return `True` or `False` for every invocation.
+`sample_modulo` guarantees that for a given value of the option and a given organization it will always return the same boolean value.
 
 ## Setting Options in Tests
 
@@ -99,9 +100,19 @@ def test_some_feature(self):
     ...
 ```
 
+There is also a matching `override_options` context manager:
+
+```python
+from sentry.testutils.helpers.options import override_options
+
+def test_some_feature(self):
+    with override_options({"performance.some-feature-rate": 1.0}):
+        ...
+```
+
 ## Removing Options
 
-If your option is short-lived, you should remove it once it's no longer needed. First, create a pull request to remove the option and its usage. Then, remove the option from the database. To do this, you can use the Sentry shell. e.g.,
+If your option is short-lived, you should remove it once it's no longer needed. First, create a pull request to remove the option and its usage. Once it's merged and deployed, remove the option from the database. To do this, you can use the Sentry shell. e.g.,
 
 ```bash
 sentry shell

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -64,7 +64,7 @@ If you expect to frequently update your option, you can make it editable in the 
 
 ## Using Options for Feature Rollout
 
-If you're working on a system-wide feature, you may choose to use options for your rollout instead of feature flags. Unlike feature flags, options don't allow for easy segmentation, but they are performance, stable, and simple. e.g.,
+If you're working on a system-wide feature, you may choose to use options for your rollout instead of feature flags. Unlike feature flags, options don't allow for easy segmentation, but they are performant, stable, and simple to implement. e.g.,
 
 ```python
 import random

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -23,7 +23,11 @@ The value of an option can be any pickleable value.
 
 <Alert level="warning">
   Always split up registering the new option and the code that relies on the new option.
-  Register new options in their own pull requests, ahead of the code changes.
+  Register new options in their own pull requests (e.g.,{' '}
+  <Link to="https://github.com/getsentry/sentry/pull/26009">#26009</Link>
+  ), ahead of the code changes (e.g., <Link to="https://github.com/getsentry/sentry/pull/26003">
+    #26003
+  </Link>).
 </Alert>
 
 ## Using Options

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -6,7 +6,6 @@ Options are a way to store generic system-wide configuration. They serve a simil
 
 ## Adding New Options
 
-ch
 To add a new system option, add it to [`sentry/options/defaults.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/options/defaults.py) by registering it. e.g.,
 
 ```python

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -12,13 +12,14 @@ To add a new system option, add it to [`sentry/options/defaults.py`](https://git
 register("performance.some-feature-rate", default=0.0)
 ```
 
-### Tips
+Follow these rules when adding new options:
 
 - namespace your option (e.g., `feature-scope.feature-name`)
 - colocate your new option with related existing options
 - use dashes and not underscores
 - always set a default value with `default=`
-- the value of an option can be any pickleable value
+
+The value of an option can be any pickleable value.
 
 <Alert level="warning">
   Always split up registering the new option and the code that relies on the new option.

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -115,6 +115,7 @@ sentry shell
 ```
 
 then,
+
 ```python
 from sentry import options
 options.delete("performance.some-feature-rate")

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -36,7 +36,7 @@ feature_rate = options.get("performance.some-feature-rate")
 
 ## Setting Options
 
-Options are stored in the database and are cached. You can change the value of an option using `sentry shell`, or by using the management UI.
+Options are stored in the database and are cached. You can change the value of an option using `sentry shell`, or by using the [options UI](#options-ui).
 
 ### Sentry Shell
 

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -2,10 +2,11 @@
 title: 'Options'
 ---
 
-Options are a way to store generic system-wide configuration. They serve a similar purpose to configuration files, but they are backed by a database, so it's possible to change them at runtime without a deploy. This makes options well-suited for rates, quotas, and limits.
+Options are a way to store generic system-wide configuration. They serve a similar purpose to configuration files, but they are backed by a database, so it's possible to change them at runtime without a deploy. Options are stored in the database and cached, so they are performant and reliable. This makes options well-suited for rates, quotas, and limits.
 
 ## Adding New Options
 
+ch
 To add a new system option, add it to [`sentry/options/defaults.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/options/defaults.py) by registering it. e.g.,
 
 ```python
@@ -41,7 +42,7 @@ feature_rate = options.get("performance.some-feature-rate")
 
 ## Setting Options
 
-Options are stored in the database and are cached. You can change the value of an option using `sentry shell`, or by using the [options UI](#options-ui).
+You can change the value of an option using `sentry shell`, or by using the [options UI](#options-ui).
 
 ### Sentry Shell
 

--- a/src/docs/options.mdx
+++ b/src/docs/options.mdx
@@ -21,7 +21,8 @@ register("performance.some-feature-rate", default=0.0)
 - the value of an option can be any pickleable value
 
 <Alert level="warning">
-  Always split up registering the new option and the code that relies on the new option. Register new options in their own pull requests, ahead of the code changes.
+  Always split up registering the new option and the code that relies on the new option.
+  Register new options in their own pull requests, ahead of the code changes.
 </Alert>
 
 ## Using Options
@@ -53,7 +54,8 @@ options.set("performance.some-feature-rate", 0.01)
 ```
 
 <Alert level="info">
-If you do not have access to the shell, you'll need to contact OPS to set the option value for you.
+  If you do not have access to the shell, you'll need to contact OPS to set the option
+  value for you.
 </Alert>
 
 ### Management UI
@@ -122,5 +124,6 @@ options.delete("performance.some-feature-rate")
 ```
 
 <Alert level="info">
-If you do not have access to the shell, you'll need to contact OPS to remove the option for you.
+  If you do not have access to the shell, you'll need to contact OPS to remove the option
+  for you.
 </Alert>


### PR DESCRIPTION
There's appetite for updated `options` documentation. There's a smorgasbord of documents about `options` in Notion, but a lot of them are stale and/or confusing. This adds a dedicated `options` page, and adds it to the sidebar.
