### PR TITLE
Move traceOptionsRequests section

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -44,10 +44,6 @@ SDKs may choose a default value which makes sense for their use case. Most SDKs 
 
 See [`sentry-trace`](#header-sentry-trace) and [`baggage`](/sdk/performance/dynamic-sampling-context/#baggage) for more details on the individual headers which are attached to outgoing requests.
 
-### `traceOptionsRequests`
-
-This should be a boolean value. Default is `false`. When set to `true` transactions should be created for HTTP `OPTIONS` requests. When set to `false` NO transactions should be created for HTTP `OPTIONS` requests. This configuration is most valuable on backend server SDKs. If this configuration does not make sense for an SDK it can be omitted.
-
 #### Example
 
 The following example shows which URLs of outgoing requests would (not) match a given `tracePropagationTargets` array:
@@ -65,6 +61,10 @@ URLs not matching: 'someHost.com/data', 'myApi.com/v1/projects'
 This Option replaces the non-standardized `tracingOrigins` option which was previously used in some SDKs. SDKs that support `tracingOrigins` are encouraged to deprecate and and eventually remove `tracingOrigins` in favour `tracePropagationTargets`. In case both options are specified by users, SDKs should only rely on the `tracePropagationTargets` array.
 
 </Alert>
+
+### `traceOptionsRequests`
+
+This should be a boolean value. Default is `false`. When set to `true` transactions should be created for HTTP `OPTIONS` requests. When set to `false` NO transactions should be created for HTTP `OPTIONS` requests. This configuration is most valuable on backend server SDKs. If this configuration does not make sense for an SDK it can be omitted.
 
 ### `maxSpans`
 


### PR DESCRIPTION
Looks like the `traceOptionsRequests` section was moved inside the `tracePropagationTargets` section. This moves it after `tracePropagationTargets`.