### PR TITLE
Add enableTracing option

### DIFF
--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -18,7 +18,7 @@ Reference implementations:
 
 This section describes the options SDKs should expose to configure tracing and performance monitoring.
 
-Tracing is enabled by setting any of three SDK config options, `enablePerformance`, `tracesSampleRate` and `tracesSampler`. If not set, both default to `undefined`, making tracing opt-in.
+Tracing is enabled by setting any of three SDK config options, `enablePerformance`, `tracesSampleRate` and `tracesSampler`. If not set, these options default to `undefined`, making tracing opt-in.
 
 ### `enablePerformance`
 

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -22,7 +22,7 @@ Tracing is enabled by setting any of three SDK config options, `enableTracing`, 
 
 ### `enableTracing`
 
-This option shall replace the need to configure a `tracesSampleRate` for many users. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options should their use case need it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
+This option shall enable the generateion of transactions and propagation of trace data. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options, listed below, should their use case require it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
 
 ### `tracesSampleRate`
 

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -18,9 +18,9 @@ Reference implementations:
 
 This section describes the options SDKs should expose to configure tracing and performance monitoring.
 
-Tracing is enabled by setting any of three SDK config options, `enablePerformance`, `tracesSampleRate` and `tracesSampler`. If not set, these options default to `undefined`, making tracing opt-in.
+Tracing is enabled by setting any of three SDK config options, `enableTracing`, `tracesSampleRate` and `tracesSampler`. If not set, these options default to `undefined`, making tracing opt-in.
 
-### `enablePerformance`
+### `enableTracing`
 
 This option shall replace the need to configure a `traceSampleRate` for many users. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options should their use case need it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
 

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -18,7 +18,11 @@ Reference implementations:
 
 This section describes the options SDKs should expose to configure tracing and performance monitoring.
 
-Tracing is enabled by setting either one of two new SDK config options, `tracesSampleRate` and `tracesSampler`. If not set, both default to `undefined`, making tracing opt-in.
+Tracing is enabled by setting any of three SDK config options, `enablePerformance`, `tracesSampleRate` and `tracesSampler`. If not set, both default to `undefined`, making tracing opt-in.
+
+### `enablePerformance`
+
+This option shall replace the need to configure a `traceSampleRate` for many users. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options should their use case need it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
 
 ### `tracesSampleRate`
 

--- a/src/docs/sdk/performance/index.mdx
+++ b/src/docs/sdk/performance/index.mdx
@@ -22,7 +22,7 @@ Tracing is enabled by setting any of three SDK config options, `enableTracing`, 
 
 ### `enableTracing`
 
-This option shall replace the need to configure a `traceSampleRate` for many users. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options should their use case need it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
+This option shall replace the need to configure a `tracesSampleRate` for many users. Sample rates shall be set at a default which is practical to the specific platform. Users may use the other options should their use case need it. The standard should be to set the default sample rate at 100%, and only working back if there are inherent concerns for that platform. Users should be able to send most if not all of their data and rely on Sentry server side processing of their data.
 
 ### `tracesSampleRate`
 


### PR DESCRIPTION
This PR is a proposal to resolve the discussion in https://github.com/getsentry/develop/issues/769. So that we may have a simpler option for turning performance and tracing on in Sentry SDKs.

Preview changes: [SDK Performance](https://develop-git-smeubank-enableperformance.sentry.dev/sdk/performance/)