### PR TITLE
Clarify authority handling in URL

### DIFF
--- a/src/docs/sdk/data-handling.mdx
+++ b/src/docs/sdk/data-handling.mdx
@@ -59,7 +59,7 @@ This helps Relay to know what kind of data it receives and this helps with scrub
 - `http` spans containing urls:
 
   The description of spans with `op` set to `http` must follow the format `HTTP_METHOD scheme://host/path` (ex. `GET https://example.com/foo`).
-  If an authority is present in the URL (`https://username:password@example.com`), the authority must be replaced with a placeholder regardless of `sendDefaultPii`, leading to a new URL of `https://[FILTERED]:[FILTERED]@example.com`.
+  If an authority is present in the URL (`https://username:password@example.com`), the authority must be replaced with a placeholder regardless of `sendDefaultPii`, leading to a new URL of `https://[Filtered]:[Filtered]@example.com`.
   If query strings or fragments are present in the URL, both are set into the data attribute of the span.
 
   ```js

--- a/src/docs/sdk/data-handling.mdx
+++ b/src/docs/sdk/data-handling.mdx
@@ -59,7 +59,7 @@ This helps Relay to know what kind of data it receives and this helps with scrub
 - `http` spans containing urls:
 
   The description of spans with `op` set to `http` must follow the format `HTTP_METHOD scheme://host/path` (ex. `GET https://example.com/foo`).
-  If an authority is present in the URL (`https://username:password@example.com`), the authority must be omitted completely.
+  If an authority is present in the URL (`https://username:password@example.com`), the authority must be replaced with a placeholder regardless of `sendDefaultPii`, leading to a new URL of `https://[FILTERED]:[FILTERED]@example.com`.
   If query strings or fragments are present in the URL, both are set into the data attribute of the span.
 
   ```js


### PR DESCRIPTION
Clarify that authority is replaced regardless of `sendDefaultPii` and it should be replaced with a placeholder instead of being omitted.