### PR TITLE
feat(unified-api): Define `includeLocalVariables` option

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -73,6 +73,8 @@ Lines of source code to provide context in stack traces. This is easier in inter
 
 Local variable names and values for each stack frame, where possible. Restrictions apply on some platforms, for example it’s may only be possible to collect the values of parameters passed into each function, or it may be completely impossible to collect this information at all.
 
+This functionality should be gated behind the `includeLocalVariables` option, which is `true` by default.
+
 ## Desymbolication
 
 Turn compiled or obfuscated code/method names in stack traces back into the original. Desymbolication always requires Sentry backend support. Not necessary for many languages.


### PR DESCRIPTION
Currently the PHP, Python, Ruby and NodeJS SDKs support local variables, but they all use inconsistent names for the option that gates this functionality.

- Ruby: [`capture_exception_frame_locals`](https://docs.sentry.io/platforms/ruby/configuration/options)
- Python: [`with_locals`](https://docs.sentry.io/platforms/python/configuration/options/#with-locals)
- PHP no option
- NodeJS [`_experiments.includeStackLocals`](https://docs.sentry.io/platforms/node/configuration/options/#_experiments.include-stack-locals)

I propose we rename this to `includeLocalVariables` / `include_local_variables`, unify these across the SDKs and add them when we get time

We also should decide if `sendDefaultPii` should have an affect on this.

cc @timfish 