### PR TITLE
feat(event): Add source to SDK payload

### DIFF
--- a/src/docs/sdk/event-payloads/sdk.mdx
+++ b/src/docs/sdk/event-payloads/sdk.mdx
@@ -11,39 +11,43 @@ and transmit an event.
 `name`
 
 : **Required**. The name of the SDK. The format is `entity.ecosystem[.flavor]`
-  where _entity_ identifies the developer of the SDK, _ecosystem_ refers to the
-  programming language or platform where the SDK is to be used and the optional
-  _flavor_ is used to identify standalone SDKs that are part of a major
-  ecosystem.  
-  Official Sentry SDKs use the _entity_ `sentry`. Examples:
-  - `sentry.python`
-  - `sentry.javascript.react-native`
+where _entity_ identifies the developer of the SDK, _ecosystem_ refers to the
+programming language or platform where the SDK is to be used and the optional
+_flavor_ is used to identify standalone SDKs that are part of a major
+ecosystem. Official Sentry SDKs use the _entity_ `sentry`. Examples:
+
+- `sentry.python`
+- `sentry.javascript.react-native`
 
 `version`
 
 : **Required**. The version of the SDK. It should have the [Semantic
-  Versioning](https://semver.org) format `MAJOR.MINOR.PATCH`, without any prefix
-  (no `v` or anything else in front of the major version number).  
-  Examples:
-  - `0.1.0`
-  - `1.0.0`
-  - `4.3.12`
+Versioning](https://semver.org) format `MAJOR.MINOR.PATCH`, without any prefix
+(no `v` or anything else in front of the major version number). Examples:
+
+- `0.1.0`
+- `1.0.0`
+- `4.3.12`
 
 `integrations`
 
 : _Optional_. A list of names identifying enabled integrations. The list should
-  have all enabled integrations, including default integrations. Default
-  integrations are included because different SDK releases may contain different
-  default integrations.
+have all enabled integrations, including default integrations. Default
+integrations are included because different SDK releases may contain different
+default integrations.
 
 `packages`
 
 : _Optional_. A list of packages that were installed as part of this SDK or the
-  activated integrations. Each package consists of a `name` in the format
-  `source:identifier` and `version`.  
-  If the source is a Git repository, the source should be `git`, the
-  `identifier` should be a checkout link and the `version` should be a Git
-  reference (branch, tag or SHA).
+activated integrations. Each package consists of a `name` in the format
+`source:identifier` and `version`. If the source is a Git repository, the source should be `git`, the
+`identifier` should be a checkout link and the `version` should be a Git
+reference (branch, tag or SHA).
+
+`source`
+
+: _Optional_. The installation mechanism for the SDK. This can be a package
+manager like `npm` or `cocoapods` or a custom installation mechanism like or `CDN`.
 
 ## Example
 
@@ -55,9 +59,7 @@ attributes for simplicity.
   "sdk": {
     "name": "sentry.javascript.react-native",
     "version": "1.0.0",
-    "integrations": [
-      "redux"
-    ],
+    "integrations": ["redux"],
     "packages": [
       {
         "name": "npm:@sentry/react-native",
@@ -67,7 +69,8 @@ attributes for simplicity.
         "name": "git:https://github.com/getsentry/sentry-cocoa.git",
         "version": "4.1.0"
       }
-    ]
+    ],
+    "source": "npm"
   }
 }
 ```


### PR DESCRIPTION
This change adds the `source` field to the SDK interface that is part of the event payload.

We can use this source field to list the installation source of the SDK. For most cases this will be a package repository like `npm` or `pypi`, but it can also be things like `cdn`.

Current uses cases:

Browser Web:
- `npm`
- `cdn`
- `loader`

Apple:
- `spm`
- `carthage`
- `cocoapods`