### PR TITLE
feat(perf): Add span data conventions

### DIFF
--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -32,6 +32,8 @@ import "./properties/tags.mdx";
 
 : _Optional_. Arbitrary data associated with this Span.
 
+The semantic conventions for the `data` field are described in <Link to="/sdk/performance/span-data-conventions/">Sentry's Span Convention Documentation</Link>.
+
 ```json
 {
   "data": {

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -8,15 +8,14 @@ The `data` field on the span is expected to follow [OpenTelemetry's semantic con
 
 Keys on the `data` field should be lower-case and use underscores instead of camel-case. There are some exceptions to this, but these exist because of backwards compatability.
 
-Below describes the conventions for the Span interface for the `data` field on the span and how they are currently used by the product.
+Below describes the conventions for the Span interface for the `data` field on the span that are currently used by the product or are important to bring up.
 
 ## Mobile
 
-| Attribute                                                                                             | Type              | Description                                                                                          | Examples |
-| ----------------------------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- | -------- |
-| `blocked_main_thread`                                                                                 | boolean           | Whether the main thread was blocked by the span.                                                     | `true`   |
-| `call_stack`                                                                                          | Array<StackFrame> | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the |
-| [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |                   |
+| Attribute             | Type              | Description                                                                                                                                                                                                | Examples |
+| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `blocked_main_thread` | boolean           | Whether the main thread was blocked by the span.                                                                                                                                                           | `true`   |
+| `call_stack`          | Array<StackFrame> | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |          |
 
 ## Browser
 

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Span Data Conventions'
+---
+
+The Span Interface specifies a series of _timed_ application events that have a start and end time. Below describes the conventions for the Span interface for the `data` field on the span.
+
+The `data` field on the span is expected to follow [OpenTelemetry's semantic conventions for attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/README.md) as much as possible.
+
+Keys on the `data` field should be lower-case and use underscores instead of camel-case. There are some exceptions to this, but these exist because of backwards compatability.
+
+Below describes the conventions for the Span interface for the `data` field on the span and how they are currently used by the product.
+
+## Mobile
+
+| Attribute                                                                                             | Type              | Description                                                                                          | Examples |
+| ----------------------------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- | -------- |
+| `blocked_main_thread`                                                                                 | boolean           | Whether the main thread was blocked by the span.                                                     | `true`   |
+| `call_stack`                                                                                          | Array<StackFrame> | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the |
+| [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |                   |
+
+## Browser
+
+| Attribute           | Type   | Description                                | Examples              |
+| ------------------- | ------ | ------------------------------------------ | --------------------- |
+| `url`               | string | The URL of the resource that was fetched.  | `https://example.com` |
+| `method`            | string | The HTTP method used.                      | `GET`                 |
+| `type`              | string | The type of the resource that was fetched. | `xhr`                 |
+| `Encoded Body Size` | string | The encoded body size of the request.      | `123 B`               |
+| `Decoded Body Size` | string | The decoded body size of the request.      | `456 B`               |
+| `Transfer Size`     | string | The transfer size of the request.          | `789 B`               |

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -12,10 +12,10 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Mobile
 
-| Attribute             | Type              | Description                                                                                                                                                                                                | Examples |
-| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `blocked_main_thread` | boolean           | Whether the main thread was blocked by the span.                                                                                                                                                           | `true`   |
-| `call_stack`          | Array<StackFrame> | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |          |
+| Attribute             | Type         | Description                                                                                                                                                                                                | Examples |
+| --------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `blocked_main_thread` | boolean      | Whether the main thread was blocked by the span.                                                                                                                                                           | `true`   |
+| `call_stack`          | StackFrame[] | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |          |
 
 ## Browser
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/develop/issues/816

I would like us to start tracking how we are setting/using keys and values on the span data field. Ideally we move toward using more of [OpenTelemetry's OOO semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/README.md) for this, but add our own values as appropriate.

This is important, as we should make sure our spans behave consistently across different sdks and platforms. In addition, it helps us make sure that changing fields in the SDK won't break product usage.

We can also then look to use OpenTelemetry's span attributes for some of Sentry's generated spans. For example, we currently store the `url` as a string value on `http.client` spans that are generated by the Browser JS SDK. We could move to using `http.url` instead, [which matches OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/24de67b3827a4e3ab2515cd8ab62d5bcf837c586/specification/trace/semantic_conventions/http.md#common-attributes).

This will help us more easily create performance detectors for OpenTelemetry data (as we have access to many different kind of spans and attributes), and this is also important for us to document moving forward so that we can iterate more efficiently.