### PR TITLE
feat(event): Remove sdk source

### DIFF
--- a/src/docs/sdk/event-payloads/sdk.mdx
+++ b/src/docs/sdk/event-payloads/sdk.mdx
@@ -44,11 +44,6 @@ activated integrations. Each package consists of a `name` in the format
 `identifier` should be a checkout link and the `version` should be a Git
 reference (branch, tag or SHA).
 
-`source`
-
-: _Optional_. The installation mechanism for the SDK. This can be a package
-manager like `npm` or `cocoapods` or a custom installation mechanism like `cdn`.
-
 ## Example
 
 The following example illustrates the SDK part of the <Link to="/sdk/event-payloads/">event payload</Link> and omits other


### PR DESCRIPTION
Reverts changes in https://github.com/getsentry/develop/pull/815

We do this because after some discussion, we can probably take advantage of the `packages` field in the sdk metadata to accomplish this.