### PR TITLE
docs: Add note how to enable metrics ingestion pipeline [TET-646]

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -297,8 +297,7 @@ Please refer to [Frontend Development Server](/frontend/development-server/) and
 
 Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. If you need
 a more production-like environment in development, you can set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. This will launch Relay
-as part of the `devserver` workflow. If you want to enable the entire metrics ingestion pipeline, you need set
-`SENTRY_USE_METRICS_DEV=True` and `SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"` in `~/.sentry/sentry.conf.py`.
+as part of the `devserver` workflow.
 
 Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
 command will not update Relay automatically in that case, to do this manually run:
@@ -307,6 +306,14 @@ command will not update Relay automatically in that case, to do this manually ru
 sentry devservices up --skip-only-if relay
 sentry devserver --workers --ingest
 ```
+
+If you want to enable the entire metrics ingestion pipeline, you need add
+
+```shell
+SENTRY_USE_METRICS_DEV=True
+SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
+```
+to your config `~/.sentry/sentry.conf.py`.
 
 ## Setting up Getsentry
 

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -307,7 +307,7 @@ sentry devservices up --skip-only-if relay
 sentry devserver --workers --ingest
 ```
 
-If you want to enable the entire metrics ingestion pipeline, you need add
+If you want to enable the entire metrics ingestion pipeline, you need to add
 
 ```shell
 SENTRY_USE_METRICS_DEV=True

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -297,9 +297,10 @@ Please refer to [Frontend Development Server](/frontend/development-server/) and
 
 Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. If you need
 a more production-like environment in development, you can set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. This will launch Relay
-as part of the `devserver` workflow.
+as part of the `devserver` workflow. If you want to enable the entire metrics ingestion pipeline, you need set
+`SENTRY_USE_METRICS_DEV=True` and `SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"` in `~/.sentry/sentry.conf.py`.
 
-Additionally you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
+Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
 command will not update Relay automatically in that case, to do this manually run:
 
 ```shell


### PR DESCRIPTION
This PR documents how to enable the metrics ingestion pipeline, as discussed in slack with @untitaker.