### PR TITLE
feat: Add client_report discard reasons `send_error` & `internal_sdk_error`

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -97,6 +97,8 @@ The following discard reasons are currently defined for `discarded_events`:
 - `sample_rate`: an event was dropped because of the configured sample rate.
 - `before_send`: an event was dropped in `before_send`
 - `event_processor`: an event was dropped by an event processor; may also be used for ignored exceptions / errors
+- `send_error`: an event was dropped because of an error when sending it (eg: 400 response)
+- `internal_sdk_error`: an event was dropped due to an internal SDK error (eg: web worker crash)
 
 In case a reason needs to be added,
 it also has to be added to the allowlist in [snuba](https://github.com/getsentry/snuba/blob/4e7cfdddcf7b93eacb762bc74ca2461cec9464e5/snuba/datasets/outcomes_processor.py#L24-L34).


### PR DESCRIPTION
See https://github.com/getsentry/snuba/pull/3694

Note that there may be existing SDK usages that could leverage these new categories, eg. https://github.com/getsentry/sentry-python/blob/1268e2a9df1fe1fe2d7fc761d4330a5055db0e8e/sentry_sdk/transport.py#L253-L260