### PR TITLE
sdk.name for hybrid sdks

### DIFF
--- a/src/docs/sdk/event-payloads/sdk.mdx
+++ b/src/docs/sdk/event-payloads/sdk.mdx
@@ -19,6 +19,24 @@ ecosystem. Official Sentry SDKs use the _entity_ `sentry`. Examples:
 - `sentry.python`
 - `sentry.javascript.react-native`
 
+For SDKs that are composed of more than one Sentry SDK. For example, [the Unity SDK](https://github.com/getsentry/sentry-unity/issues/616)
+which includes a .NET layer as well as different native layers. When events come out
+of the native layer, it's important to distinguish from the stand-alone native SDK.
+We do that by appending the top SDK to the end of the native SDK name. Eamples:
+
+Unity SDK
+
+- `sentry.dotnet.unity` on events coming from C#. As based on the base spec above.
+  - `sentry.java.android.unity` on for events of the Java layer on Android
+  - `sentry.native.android.unity` on for events of the Native layer on Android
+  - `sentry.cocoa.unity` on for events from iOS/macOS layer
+  - `sentry.native.unity` on for events coming from `sentry.native` directly. Such as on Windows and Linux.
+
+Android SDK
+
+- `sentry.java.android` on events from the Java layer. Since the Android SDK is based on the Java SDK.
+- `sentry.native.android` on events from NDK. It's `sentry.native` but it's bundled in the Android SDK with some customization.
+
 `version`
 
 : **Required**. The version of the SDK. It should have the [Semantic

--- a/src/docs/sdk/event-payloads/sdk.mdx
+++ b/src/docs/sdk/event-payloads/sdk.mdx
@@ -22,11 +22,11 @@ ecosystem. Official Sentry SDKs use the _entity_ `sentry`. Examples:
 For SDKs that are composed of more than one Sentry SDK. For example, [the Unity SDK](https://github.com/getsentry/sentry-unity/issues/616)
 which includes a .NET layer as well as different native layers. When events come out
 of the native layer, it's important to distinguish from the stand-alone native SDK.
-We do that by appending the top SDK to the end of the native SDK name. Eamples:
+We do that by appending the top SDK to the end of the native SDK name. Examples:
 
-Unity SDK
+Unity SDK:
 
-- `sentry.dotnet.unity` on events coming from C#. As based on the base spec above.
+- `sentry.dotnet.unity` on events coming from C#. As based on the spec above.
   - `sentry.java.android.unity` on for events of the Java layer on Android
   - `sentry.native.android.unity` on for events of the Native layer on Android
   - `sentry.cocoa.unity` on for events from iOS/macOS layer


### PR DESCRIPTION
This addresses the `sdk.name` and allows us to find out, for example: 

1. Events from React Native customers
2. Events from the Cocoa SDK (regardless of hybrid SDK that bundled it)
3. By looking at an event know exactly what SDK that is: It's cocoa version X but it was part of the Unity SDK

More importantly, this is simple, solves an actual problem we have right now. 
And we use this already on Unreal and Unity. Works as intended.