### PR TITLE
Add `debug_id` to stacktrace protocol

### DIFF
--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -97,6 +97,11 @@ in this stack trace. For example, the frames that might power the framework’s
 web server of your app are probably not relevant. However, calls to the
 framework’s library once you start handling code likely are relevant.
 
+`debug_id`
+
+: References a particular source map artifact that should be used to resolve the
+stack frame.
+
 `stack_start`
 
 : Marks this frame as the bottom of a chained stack trace. Stack traces from

--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -99,8 +99,9 @@ framework’s library once you start handling code likely are relevant.
 
 `debug_id`
 
-: References a particular source map artifact that should be used to resolve the
-stack frame.
+: Optional. References a particular source map artifact that should be used to resolve the
+stack frame. If defined, must be string that follows the
+[DebugId](https://docs.rs/debugid/latest/debugid/struct.DebugId.html) format.
 
 `stack_start`
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/team-webplatform-meta/issues/17

This PR adds the `debug_id` field to the stacktrace protocol as implemented in https://github.com/getsentry/relay/pull/1832.