### PR TITLE
docs(sdk): Update render blocking status.

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -19,12 +19,12 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Browser
 
-| Attribute                | Type   | Description                                 | Examples              |
-| ------------------------ | ------ | ------------------------------------------- | --------------------- |
-| `url`                    | string | The URL of the resource that was fetched.   | `https://example.com` |
-| `method`                 | string | The HTTP method used.                       | `GET`                 |
-| `type`                   | string | The type of the resource that was fetched.  | `xhr`                 |
-| `Encoded Body Size`      | number | The encoded body size of the request.       | `123`                 |
-| `Decoded Body Size`      | number | The decoded body size of the request.       | `456`                 |
-| `Transfer Size`          | number | The transfer size of the request.           | `789`                 |
-| `Render Blocking Status` | number | The render blocking status of the resource. | `non-blocking`        |
+| Attribute                          | Type   | Description                                 | Examples              |
+| ---------------------------------- | ------ | ------------------------------------------- | --------------------- |
+| `url`                              | string | The URL of the resource that was fetched.   | `https://example.com` |
+| `method`                           | string | The HTTP method used.                       | `GET`                 |
+| `type`                             | string | The type of the resource that was fetched.  | `xhr`                 |
+| `Encoded Body Size`                | number | The encoded body size of the request.       | `123`                 |
+| `Decoded Body Size`                | number | The decoded body size of the request.       | `456`                 |
+| `Transfer Size`                    | number | The transfer size of the request.           | `789`                 |
+| `resource.render_blocking_status`  | string | The render blocking status of the resource. | `non-blocking`        |

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -19,11 +19,12 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Browser
 
-| Attribute           | Type   | Description                                | Examples              |
-| ------------------- | ------ | ------------------------------------------ | --------------------- |
-| `url`               | string | The URL of the resource that was fetched.  | `https://example.com` |
-| `method`            | string | The HTTP method used.                      | `GET`                 |
-| `type`              | string | The type of the resource that was fetched. | `xhr`                 |
-| `Encoded Body Size` | number | The encoded body size of the request.      | `123`                 |
-| `Decoded Body Size` | number | The decoded body size of the request.      | `456`                 |
-| `Transfer Size`     | number | The transfer size of the request.          | `789`                 |
+| Attribute                | Type   | Description                                 | Examples              |
+| ------------------------ | ------ | ------------------------------------------- | --------------------- |
+| `url`                    | string | The URL of the resource that was fetched.   | `https://example.com` |
+| `method`                 | string | The HTTP method used.                       | `GET`                 |
+| `type`                   | string | The type of the resource that was fetched.  | `xhr`                 |
+| `Encoded Body Size`      | number | The encoded body size of the request.       | `123`                 |
+| `Decoded Body Size`      | number | The decoded body size of the request.       | `456`                 |
+| `Transfer Size`          | number | The transfer size of the request.           | `789`                 |
+| `Render Blocking Status` | number | The render blocking status of the resource. | `non-blocking`        |


### PR DESCRIPTION
Adds mention of new data on resource spans, see https://github.com/getsentry/sentry-javascript/pull/7127