### PR TITLE
Removed special case for GCP, because everything is

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -553,7 +553,7 @@ The `type` and default key is `"cloud_resource"`.
 
 `cloud.availability_zone`
 
-: _Optional_. Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. In Google Cloud this is called `cloud.zone`.
+: _Optional_. Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
 
 - Example: `us-east-1c`
 


### PR DESCRIPTION
Removed saving the availability zone in different variables depending on the cloud provider. This changes makes everything easier.