### PR TITLE
chore(dev env): Add troubleshooting entry for devservices being down

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -313,6 +313,7 @@ If you want to enable the entire metrics ingestion pipeline, you need to add
 SENTRY_USE_METRICS_DEV=True
 SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
 ```
+
 to your config `~/.sentry/sentry.conf.py`.
 
 ## Setting up Getsentry
@@ -474,6 +475,22 @@ pip install --no-cache-dir uwsgi
 
 **Solution:** Review the [bootstrap services](/environment/#bootstrap-services)
 section or spin up Docker services with:
+
+```shell
+sentry devservices up
+```
+
+---
+
+**Problem:** You see something like `Error 61 connecting to 127.0.0.1:6379. Connection refused.` when running your dev server.
+
+**Solution:** Make sure your Docker services are running:
+
+```shell
+docker ps
+```
+
+If you don't see `sentry_snuba`, `sentry_postgres`, `sentry_clickhouse`, and `sentry_redis` listed under `COMMAND NAMES`, you need to start up services with:
 
 ```shell
 sentry devservices up


### PR DESCRIPTION
This adds a troubleshooting entry to the dev env setup docs, explaining that a connection error when running the dev server may be because devservices haven't yet been started.

Note: When DEVINFRA-30 is addressed, this will likely need to be modified or possibly even deleted.