### PR TITLE
feat: add Time To Initial Display and Time To Full Display spans

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -176,6 +176,9 @@ export default () => {
             <SidebarLink to="/sdk/performance/ui-event-transactions/">
               UI Event Transactions
             </SidebarLink>
+            <SidebarLink to="/sdk/performance/time-to-initial-full-display/">
+              Time to Initial/Full Display
+            </SidebarLink>
             <SidebarLink to="/sdk/performance/dynamic-sampling-context/">
               Dynamic Sampling Context
             </SidebarLink>

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -22,7 +22,7 @@ require any manual intervention from the user.
 ## Time to Full Display
 
 Time to Full Display is a span with operation `ui.load.full_display` which is finished manually through
-the `Sentry.reportFullDisplayed` static API. This feature has to be enabled by setting the SDK config
+the `Sentry.reportFullyDisplayed` static API. This feature has to be enabled by setting the SDK config
 option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
 
@@ -34,7 +34,7 @@ The specification is written in the [Gherkin syntax](https://cucumber.io/docs/gh
 Scenario: Option disabled
     Given an ongoing screen load/navigation transaction
     Then the Full Display span is not started
-    When the user calls the manual API `reportFullDisplayed`
+    When the user calls the manual API `reportFullyDisplayed`
     Then the SDK ignores the call
 
 Scenario: Option enabled
@@ -44,19 +44,19 @@ Scenario: Option enabled
 
 Scenario: Activity displayed
     Given an ongoing Full Display span
-    When the user calls the API `reportFullDisplayed`
+    When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the span
     And sets the status to ok
 
 Scenario: API not called
     Given an ongoing Full Display span
-    When the user doesn't call the API `reportFullDisplayed` in 30 seconds
+    When the user doesn't call the API `reportFullyDisplayed` in 30 seconds
     Then the SDK finishes the span
     And sets the status to deadline_exceeded
 
 Scenario: API called too early
     Given an ongoing Full Display span and an ongoing Initial Display span
-    When the user calls the API `reportFullDisplayed`
+    When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the Full Display span
     And
     When the Initial Display span is finished
@@ -70,7 +70,7 @@ Scenario: Another screen load/navigation transaction occurs
 
 Scenario: No ongoing screen load transaction
     Given there is no active screen load transaction
-    When the user calls the manual API `reportFullDisplayed`
+    When the user calls the manual API `reportFullyDisplayed`
     Then the SDK ignores the call
 
 ```

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -8,7 +8,7 @@ The current screen load transactions timings are unreliable in understanding the
 This is because they wait for any span created, including any file I/O or network request.
 Time to Initial Display and Time to Full Display are spans added to the screen load transactions,
 which can be used to show more accurate information on the time spent in the screen creation.
-Being spans, they don't impact on user quota.
+Being spans, they don't impact user quota.
 
 The SDK starts them as soon as a new screen is created, as long as there is an active transaction for the screen load.
 
@@ -19,14 +19,15 @@ when the screen draws its first frame. It's controlled automatically by the SDK 
 require any manual intervention from the user.
 
 The SDKs set the time to initial display as a transaction measurement, with `time_to_initial_display` as the key and the span duration as the value.
-Note: The measurement should be set only if the span finishes with the status `OK`.
+Note: The measurement should be set only if the span finishes with the status `OK`. In case a screen is used just as a
+ router to start other screens, it could be finished before drawing a frame.
 
 
 ## Time to Full Display
 
 Time to Full Display is a span with operation `ui.load.full_display` which is finished manually through
 the `Sentry.reportFullyDisplayed` static API. This feature has to be enabled by setting the SDK config
-option `enableTimeToFullDisplay`. Remember that the screen load transactions wait for spans to finish,
+option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
 It's also set as a measurement of the transaction, with `time_to_full_display` as key and the span duration as value.
 
@@ -60,12 +61,14 @@ Scenario: API not called
     And sets the status to deadline_exceeded
     And sets the timestamp to the timestamp of the Initial Display span
 
-Scenario: API called too early
-    Given an ongoing Full Display span and an ongoing Initial Display span
+Scenario: API called
+    Given an ongoing Full Display span
     When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the Full Display span
     And set the status to ok
-    And
+
+Scenario: API called too early
+    Given an ongoing Initial Display span and the user calls the API `reportFullyDisplayed`
     When the Initial Display span is finished
     Then the SDK sets the status to ok
     And adjusts the Full Display span end timestamp to the Initial Display span end timestamp

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Time to Initial Display/Time to Full Display"
+title: "Time to Initial/Full Display"
 ---
 
 We recommend implementing this feature for mobile and desktop SDKs.
 
-The current screen load transactions timings are not reliable to understand the time spent in the screen creation.
-This is because they wait for any span created in the meantime, including any file I/O or network request.
+The current screen load transactions timings are unreliable in understanding the time spent in the screen creation.
+This is because they wait for any span created, including any file I/O or network request.
 Time to Initial Display and Time to Full Display are spans added to the screen load transactions,
 which can be used to show more accurate information on the time spent in the screen creation.
 Being spans, they don't impact on user quota.
@@ -14,12 +14,12 @@ They start as soon as a new screen is created, as long as the screen load auto-g
 
 ## Time to Initial Display
 
-Time to Initial Display is a span with operation `ui.load.initial_display` which finishes automatically
+Time to Initial Display is a span with the operation `ui.load.initial_display`, which finishes automatically
 when the screen draws its first frame. It's controlled automatically by the SDK and doesn't
 require any manual intervention from the user.
 
-It's also set as a measurement of the transaction, with `time_to_initial_display` as key and the span duration as value.
-Note: The measurement is should be set only if the span finishes with an `OK`  status.
+The SDKs set the time to initial display as a transaction measurement, with `time_to_initial_display` as the key and the span duration as the value.
+Note: The measurement should be set only if the span finishes with the status `OK`.
 
 
 ## Time to Full Display
@@ -30,14 +30,14 @@ option `enableTimeToFullDisplayTracing`. Remember that the screen load transacti
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
 It's also set as a measurement of the transaction, with `time_to_full_display` as key and the span duration as value.
 
-The following section explain the possible scenarios of the Time to Full Display.
+The following section explains the possible scenarios of the Time to Full Display.
 
 The specification is written in the [Gherkin syntax](https://cucumber.io/docs/gherkin/reference/).
 
 ```Gherkin
 Scenario: Option disabled
     Given an ongoing screen load/navigation transaction
-    Then the Full Display span is not started
+    Then the SDK doesn't start the Full Display span
     When the user calls the manual API `reportFullyDisplayed`
     Then the SDK ignores the call
 
@@ -46,7 +46,7 @@ Scenario: Option enabled
     When the SDK creates a new screen load transaction
     Then the Full Display span is started
 
-Scenario: Activity displayed
+Scenario: Screen displayed
     Given an ongoing Full Display span
     When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the span
@@ -57,6 +57,7 @@ Scenario: API not called
     When the user doesn't call the API `reportFullyDisplayed` in 30 seconds
     Then the SDK finishes the span
     And sets the status to deadline_exceeded
+    And sets the timestamp to the timestamp of the Initial Display span
 
 Scenario: API called too early
     Given an ongoing Full Display span and an ongoing Initial Display span

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -18,6 +18,9 @@ Time to Initial Display is a span with operation `ui.load.initial_display` which
 when the screen draws its first frame. It's controlled automatically by the SDK and doesn't
 require any manual intervention from the user.
 
+It's also set as a measurement of the transaction, with `time-to-initial-display` as key and the span duration as value.
+Note: The measurement is should be set only if the span finishes with an `OK`  status.
+
 
 ## Time to Full Display
 
@@ -25,6 +28,7 @@ Time to Full Display is a span with operation `ui.load.full_display` which is fi
 the `Sentry.reportFullyDisplayed` static API. This feature has to be enabled by setting the SDK config
 option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
+It's also set as a measurement of the transaction, with `time-to-full-display` as key and the span duration as value.
 
 The following section explain the possible scenarios of the Time to Full Display.
 

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -18,7 +18,7 @@ Time to Initial Display is a span with operation `ui.load.initial_display` which
 when the screen draws its first frame. It's controlled automatically by the SDK and doesn't
 require any manual intervention from the user.
 
-It's also set as a measurement of the transaction, with `time-to-initial-display` as key and the span duration as value.
+It's also set as a measurement of the transaction, with `time_to_initial_display` as key and the span duration as value.
 Note: The measurement is should be set only if the span finishes with an `OK`  status.
 
 
@@ -28,7 +28,7 @@ Time to Full Display is a span with operation `ui.load.full_display` which is fi
 the `Sentry.reportFullyDisplayed` static API. This feature has to be enabled by setting the SDK config
 option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
-It's also set as a measurement of the transaction, with `time-to-full-display` as key and the span duration as value.
+It's also set as a measurement of the transaction, with `time_to_full_display` as key and the span duration as value.
 
 The following section explain the possible scenarios of the Time to Full Display.
 

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -68,8 +68,9 @@ Scenario: API called
     And set the status to ok
 
 Scenario: API called too early
-    Given an ongoing Initial Display span and the user calls the API `reportFullyDisplayed`
-    When the Initial Display span is finished
+    Given an ongoing Initial Display span
+    And the user called the API `reportFullyDisplayed`
+    When the SDK finishes the Initial Display span
     Then the SDK sets the status to ok
     And adjusts the Full Display span end timestamp to the Initial Display span end timestamp
 

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -10,7 +10,7 @@ Time to Initial Display and Time to Full Display are spans added to the screen l
 which can be used to show more accurate information on the time spent in the screen creation.
 Being spans, they don't impact on user quota.
 
-They start as soon as a new screen is created, as long as the screen load auto-generated transactions are enabled.
+The SDK starts them as soon as a new screen is created, as long as there is an active transaction for the screen load.
 
 ## Time to Initial Display
 
@@ -26,7 +26,7 @@ Note: The measurement should be set only if the span finishes with the status `O
 
 Time to Full Display is a span with operation `ui.load.full_display` which is finished manually through
 the `Sentry.reportFullyDisplayed` static API. This feature has to be enabled by setting the SDK config
-option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
+option `enableTimeToFullDisplay`. Remember that the screen load transactions wait for spans to finish,
 so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
 It's also set as a measurement of the transaction, with `time_to_full_display` as key and the span duration as value.
 
@@ -64,15 +64,18 @@ Scenario: API called too early
     Given an ongoing Full Display span and an ongoing Initial Display span
     When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the Full Display span
+    And set the status to ok
     And
     When the Initial Display span is finished
-    Then the SDK adjusts the Full Display span end timestamp to the Initial Display span end timestamp
+    Then the SDK sets the status to ok
+    And adjusts the Full Display span end timestamp to the Initial Display span end timestamp
 
 Scenario: Another screen load/navigation transaction occurs
     Given an ongoing Full Display span
     When a new screen load/navigation transaction is started
     Then the SDK finishes the Full Display span
     And sets the status to deadline_exceeded
+    And sets the end timestamp to the Initial Display span end timestamp
 
 Scenario: No ongoing screen load transaction
     Given there is no active screen load transaction

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -1,0 +1,77 @@
+---
+title: "Time to Initial Display/Time to Full Display"
+---
+
+We recommend implementing this feature for mobile and desktop SDKs.
+
+The current screen load transactions timings are not reliable to understand the time spent in the screen creation.
+This is because they wait for any span created in the meantime, including any file I/O or network request.
+Time to Initial Display and Time to Full Display are spans added to screen load transactions,
+which can be used to show more accurate information on the time spent in the screen creation.
+Being spans, they don't impact on user quota.
+
+They start as soon as a new screen is created, as long as the screen load auto-generated transactions are enabled.
+
+## Time to Initial Display
+
+Time to Initial Display is a span with operation `ui.load.initial_display` which finishes automatically
+when the screen draws its first frame on the screen. It's controlled automatically by the SDK and doesn't
+require any manual intervention from the user.
+
+
+## Time to Full Display
+
+Time to Full Display is a span with operation `ui.load.full_display` which is finished manually through
+the `Sentry.reportFullDisplayed` static API. This feature has to be enabled by setting the SDK config
+option `enableTimeToFullDisplayTracing`. Remember that the screen load transactions wait for spans to finish,
+so the transaction will run until the user calls the API. So we recommend this feature to be disabled by default.
+
+The following section explain the possible scenarios of the Time to Full Display.
+
+The specification is written in the [Gherkin syntax](https://cucumber.io/docs/gherkin/reference/).
+
+```Gherkin
+Scenario: Option disabled
+    Given an ongoing screen load/navigation transaction
+    Then the Full Display span is not started
+    And
+    When the user calls the manual API `reportFullDisplayed`
+    Then the SDK ignores the call
+
+Scenario: Option enabled
+    Given an ongoing screen load/navigation transaction
+    When the SDK creates a new screen load transaction
+    Then the Full Display is started
+
+Scenario: Activity displayed
+    Given an ongoing Full Display span
+    When the user calls the manual API `reportFullDisplayed`
+    Then the SDK finishes the span
+    And sets the status to ok
+
+Scenario: API not called
+    Given an ongoing Full Display span
+    When the user doesn't call the manual API `reportFullDisplayed` in 30 seconds
+    Then the SDK finishes the span
+    And sets the status to deadline_exceeded
+
+Scenario: API called too early
+    Given an ongoing Full Display span and an ongoing Initial Display span
+    When the user calls the manual API `reportFullDisplayed`
+    Then the SDK finishes the Full Display span
+    And
+    When the Initial Display span is finished
+    Then the SDK adjusts the Full Display span end timestamp to the Initial Display span end timestamp
+
+Scenario: Another screen load/navigation transaction occurs
+    Given an ongoing Full Display span
+    When a new screen load/navigation transaction is started
+    Then the SDK finishes the Full Display span
+    And sets the status to deadline_exceeded
+
+Scenario: No ongoing screen load transaction
+    Given there is no active screen load transaction
+    When the user calls the manual API `reportFullDisplayed`
+    Then the SDK ignores the call
+
+```

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -42,12 +42,13 @@ Scenario: Option disabled
     Then the SDK ignores the call
 
 Scenario: Option enabled
-    Given the enableTimeToFullDisplayTracing option is enabled
+    Given the enableTimeToFullDisplay option is enabled
     When the SDK creates a new screen load transaction
     Then the Full Display span is started
 
 Scenario: Screen displayed
     Given an ongoing Full Display span
+    And the SDK finished the  Initial Display span
     When the user calls the API `reportFullyDisplayed`
     Then the SDK finishes the span
     And sets the status to ok

--- a/src/docs/sdk/performance/time-to-initial-full-display.mdx
+++ b/src/docs/sdk/performance/time-to-initial-full-display.mdx
@@ -6,7 +6,7 @@ We recommend implementing this feature for mobile and desktop SDKs.
 
 The current screen load transactions timings are not reliable to understand the time spent in the screen creation.
 This is because they wait for any span created in the meantime, including any file I/O or network request.
-Time to Initial Display and Time to Full Display are spans added to screen load transactions,
+Time to Initial Display and Time to Full Display are spans added to the screen load transactions,
 which can be used to show more accurate information on the time spent in the screen creation.
 Being spans, they don't impact on user quota.
 
@@ -15,7 +15,7 @@ They start as soon as a new screen is created, as long as the screen load auto-g
 ## Time to Initial Display
 
 Time to Initial Display is a span with operation `ui.load.initial_display` which finishes automatically
-when the screen draws its first frame on the screen. It's controlled automatically by the SDK and doesn't
+when the screen draws its first frame. It's controlled automatically by the SDK and doesn't
 require any manual intervention from the user.
 
 
@@ -34,30 +34,29 @@ The specification is written in the [Gherkin syntax](https://cucumber.io/docs/gh
 Scenario: Option disabled
     Given an ongoing screen load/navigation transaction
     Then the Full Display span is not started
-    And
     When the user calls the manual API `reportFullDisplayed`
     Then the SDK ignores the call
 
 Scenario: Option enabled
-    Given an ongoing screen load/navigation transaction
+    Given the enableTimeToFullDisplayTracing option is enabled
     When the SDK creates a new screen load transaction
-    Then the Full Display is started
+    Then the Full Display span is started
 
 Scenario: Activity displayed
     Given an ongoing Full Display span
-    When the user calls the manual API `reportFullDisplayed`
+    When the user calls the API `reportFullDisplayed`
     Then the SDK finishes the span
     And sets the status to ok
 
 Scenario: API not called
     Given an ongoing Full Display span
-    When the user doesn't call the manual API `reportFullDisplayed` in 30 seconds
+    When the user doesn't call the API `reportFullDisplayed` in 30 seconds
     Then the SDK finishes the span
     And sets the status to deadline_exceeded
 
 Scenario: API called too early
     Given an ongoing Full Display span and an ongoing Initial Display span
-    When the user calls the manual API `reportFullDisplayed`
+    When the user calls the API `reportFullDisplayed`
     Then the SDK finishes the Full Display span
     And
     When the Initial Display span is finished


### PR DESCRIPTION
This PR adds instructions on what Time To Initial Display and Time To Full Display spans are and how to set them up