### PR TITLE
Add tip for resolving unhealthy containers

### DIFF
--- a/src/docs/self-hosted/troubleshooting.mdx
+++ b/src/docs/self-hosted/troubleshooting.mdx
@@ -139,6 +139,13 @@ VACUUM FULL actively compacts tables by writing a complete new version of the ta
 
 There may be some circumstances which you may want to increase or decrease healthcheck interval, timeout or retries for your custom needs. This can be achieved by editing `HEALTHCHECK_INTERVAL`, `HEALTHCHECK_TIMEOUT`, `HEALTHCHECK_RETRIES` variables' values in `.env`.
 
+Occasionally, you might see an error like this
+```shell
+container for service "${servicename}" is unhealthy
+```
+
+This can usually be resolved by running `docker compose down` and `docker compose up -d` or rerunning the install script.
+
 ## Other
 
 If you are still stuck, you can always visit our [GitHub issues](https://github.com/getsentry/self-hosted/issues) to search for existing issues or create a new issue and ask for help. Please keep in mind that we expect the community to help itself, but Sentry employees also try to monitor and answer questions when they have time.


### PR DESCRIPTION
For self-hosted, users may experience unhealthy containers from time to time which can usually be fixed by bringing the containers down and back up again