### PR TITLE
Update UI Event Transaction the same event same ui element scenario

### DIFF
--- a/src/docs/sdk/performance/ui-event-transactions.mdx
+++ b/src/docs/sdk/performance/ui-event-transactions.mdx
@@ -85,23 +85,23 @@ Scenario: Don't overwrite existing status of UI event transactions
     Then it keeps the status 
     And doesn't overwrite it
 
-Scenario: Same UI element with same event
-    Given an ongoing UI event transaction
-    When the user triggers the same UI event with the same type for the same
-        UI element
-    Then the SDK reschedule the idle timeout
-    And doesn't create a new transaction
-
 # If your SDK binds auto-generated transactions to the scope see binding
 # to scope
-Scenario: Same UI element with different event
-    Given an ongoing UI event transaction
-    When the user triggers the same UI element with a different event
+Scenario: New event on same UI element
+    Given an ongoing UI event transaction with child spans
+    When the user triggers the same UI element with a new event (different or same)
     Or the user triggers a different UI element
     Then the SDK finishes the ongoing transaction
     And sets the status to OK
     And waits for the children to finish
     And cancels the idle timeout
+    And starts a new transaction
+
+Scenario: New event on same UI element
+    Given an ongoing UI event transaction without child spans
+    When the user triggers the same UI element with a new event (different or same)
+    Or the user triggers a different UI element
+    Then the SDK discards the transaction 
     And starts a new transaction
 ```
 

--- a/src/docs/sdk/performance/ui-event-transactions.mdx
+++ b/src/docs/sdk/performance/ui-event-transactions.mdx
@@ -88,7 +88,7 @@ Scenario: Don't overwrite existing status of UI event transactions
 # If your SDK binds auto-generated transactions to the scope see binding
 # to scope
 Scenario: Event on same UI element with child spans
-    Given an ongoing UI event transaction with child spans
+    Given an ongoing UI event transaction
     When the user triggers the same UI element with a new event
     Or the user triggers a different UI element
     Then the SDK finishes the ongoing transaction
@@ -97,8 +97,8 @@ Scenario: Event on same UI element with child spans
     And cancels the idle timeout
     And starts a new transaction
 
-Scenario: New event on same UI element
-    Given an ongoing UI event transaction without child spans
+Scenario: Event on same UI element without child spans
+    Given an ongoing UI event transaction
     When the user triggers the same UI element with a new event
     Or the user triggers a different UI element
     Then the SDK discards the transaction 

--- a/src/docs/sdk/performance/ui-event-transactions.mdx
+++ b/src/docs/sdk/performance/ui-event-transactions.mdx
@@ -87,9 +87,9 @@ Scenario: Don't overwrite existing status of UI event transactions
 
 # If your SDK binds auto-generated transactions to the scope see binding
 # to scope
-Scenario: New event on same UI element
+Scenario: Event on same UI element with child spans
     Given an ongoing UI event transaction with child spans
-    When the user triggers the same UI element with a new event (different or same)
+    When the user triggers the same UI element with a new event
     Or the user triggers a different UI element
     Then the SDK finishes the ongoing transaction
     And sets the status to OK
@@ -99,7 +99,7 @@ Scenario: New event on same UI element
 
 Scenario: New event on same UI element
     Given an ongoing UI event transaction without child spans
-    When the user triggers the same UI element with a new event (different or same)
+    When the user triggers the same UI element with a new event
     Or the user triggers a different UI element
     Then the SDK discards the transaction 
     And starts a new transaction


### PR DESCRIPTION
Based on the discussion [here](https://github.com/getsentry/sentry-javascript/pull/7236):
- https://github.com/getsentry/sentry-javascript/pull/7236

I think we should update the develop docs and open issues for SDKs that already implemented the current scenarios to update it.