### PR TITLE
doc: Rust development

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -55,6 +55,7 @@ export default () => {
           <SidebarLink to="/database-migrations/">Database Migrations</SidebarLink>
           <SidebarLink to="/testing/">Testing Tips</SidebarLink>
           <SidebarLink to="/analytics/">Analytics</SidebarLink>
+          <SidebarLink to="/rust/">Rust Development</SidebarLink>
         </ul>
       </li>
       <li className="mb-3" data-sidebar-branch>

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -1,0 +1,327 @@
+# How to code Rust at Sentry
+
+This is a document that contains a bunch of useful resources for getting started with Rust and adhering to our coding principles.
+
+## Getting Started
+
+- Join the `#discuss-rust` channel in Slack
+- A quick introduction into the Syntax for first-timers:
+[https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/](https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/)
+- The Rust Book, comprehensively documenting the language:
+[https://doc.rust-lang.org/book/](https://doc.rust-lang.org/book/)
+- We follow the Rust style (enforced by `rustfmt` and `clippy` where possible):
+[https://doc.rust-lang.org/1.0.0/style/README.html](https://doc.rust-lang.org/1.0.0/style/README.html)
+- The Async Book:
+[https://rust-lang.github.io/async-book/](https://rust-lang.github.io/async-book/)
+
+## Advanced Reading
+
+- The Little Book of Rust Macros
+[https://danielkeep.github.io/tlborm/book/index.html](https://danielkeep.github.io/tlborm/book/index.html)
+- Rust Nomicon: The Dark Arts of Unsafe Rust
+[https://doc.rust-lang.org/nomicon/](https://doc.rust-lang.org/nomicon/)
+- Rust by Example: A comprehensive list of examples
+[https://doc.rust-lang.org/stable/rust-by-example/](https://doc.rust-lang.org/stable/rust-by-example/)
+
+## Coding Principles
+
+<aside>
+ℹ️ This section is still under development and may be incomplete.
+
+</aside>
+
+- **Import order**
+
+    Imports must be declared before any other code in the file, and can only be preceded by module doc comments and module attributes (`#![...]`). We bundle imports in groups based on their origin, each separated by an empty line. The order of imports is:
+
+    1. Rust standard library, including `std`, `core` and `alloc`
+    2. External dependencies
+    3. Workspace dependencies
+    4. Crate modules
+    5. Re-exports (`pub use`)
+
+    **Example:**
+
+    ```rust
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::io::{self, Seek, Write};
+
+    use fnv::{FnvHashMap, FnvHashSet};
+    use num::FromPrimitive;
+
+    use symbolic_common::{Arch, DebugId, Language};
+    use symbolic_debuginfo::{DebugSession, Function, LineInfo};
+
+    use crate::error::{SymCacheError, SymCacheErrorKind, ValueKind};
+    use crate::format;
+
+    pub use gimli::RunTimeEndian as Endian;
+    ```
+
+- **Declaration order**
+
+    Within a file, the order of components should always be roughly the same:
+
+    1. Module-level documentation
+    2. Imports
+    3. Public re-exports
+    4. Modules and public modules
+    5. Constants
+    6. Error types
+    7. All other functions and structs
+    8. Unit tests
+
+    Always declare a type or function before using it. The only exceptions to this are:
+
+    - Public functions are always on top in `impl` blocks
+    - Circular calls or references. In this case place the more significant item first. For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
+
+    When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Place helper functions and helper types **above** the struct definition. Use the following order for the blocks:
+
+    1. The `struct` or `enum` definition
+    2. `impl` block
+    3. `impl` block with further constraints
+    4. Trait implementations of `std` traits
+    5. Trait implementations of other traits
+    6. Trait implementations of own traits
+
+    Inside an `impl` block, follow roughly this order:
+
+    1. Associated constants
+    2. Associated non-instance functions
+    3. Constructors
+    4. Getters / setters
+    5. Anything else
+
+- **Default Lints**
+
+    We use [clippy](https://github.com/rust-lang/rust-clippy) with the `clippy::all` preset for linting. See The *Configuring CI* section for how to invoke it.
+
+    In addition to that, every crate enable the following warnings in its top-level file after the doc block before imports (see the [list of all available lints](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)):
+
+    ```rust
+    #![warn(missing_docs)]
+    #![warn(missing_debug_implementations)]
+    ```
+
+    Note that we do not enable `unsafe_code`, since that should already stand out in code review. There are a few legitimate cases for unsafe code, and the `unsafe` keyword alone already marks them sufficiently.
+
+- **Field visibility**
+
+    By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
+
+    - Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
+    - Plain data types with a very stable signature.
+
+    Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
+
+    - `foo()`, `foo_mut()` and `set_foo()` for exposing the values
+    - `pub(crate)` or `pub(super)` accessor functions in corner cases
+    - A `Default` implementation and builder when incremental construction is required
+
+- **Naming**
+
+    We are strictly following the [Rust Naming Conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html). The entire conventions apply, although here are a few highlighted sections:
+
+    - [Avoid redundant prefixes](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356])
+    - [Getter and setter methods](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#getter/setter-methods-[rfc-344]) (`foo` instead of `get_foo`)
+    - [Conversions](https://doc.rust-lang.org/1.0.0/style/style/naming/conversions.html) (`as_foo` vs `to_foo` vs `into_foo`)
+    - [Iterators](https://doc.rust-lang.org/1.0.0/style/style/naming/iterators.html)
+    - [Constructors](https://rust-lang.github.io/api-guidelines/predictability.html#constructors-are-static-inherent-methods-c-ctor) (Structs generally have `fn new(...) -> Self`, which never returns Result)
+
+- **Writing Doc Comments**
+
+    We follow conventions from RFC 505 and RFC 1574 for writing doc comments. See the [full conventions text](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text). Particularly, this includes:
+
+    - A single-line short summary sentence written in American English using third-person.
+    - Use the default headers where applicable, but avoid custom sections outside of module-level docs.
+    - Link between types and methods where possible, especially within the crate.
+    - Write doc tests
+- **Writing Doc Tests**
+
+    If possible, prefer writing at least one doctest for the critical path of your methods or structs. Of course, this requires the interface to be public. This should even take precedence over an equal unit test, since it both tests and documents the API.
+
+    To format code in doc comments, you can temporarily [configure rustfmt](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#format_code_in_doc_comments) to do so. We might add this to our default configuration at some point:
+
+    ```rust
+    format_code_in_doc_comments = true
+    ```
+
+- **Writing Tests**
+
+    All test functions should start with `test_` and contain the function name + a simple condition in their name. The test name should be as concise as possible and avoid redundant words (such as "should", "that"). Examples:
+
+    - `test_parse_empty`
+    - `test_parse_null`
+
+    Write unit tests in a `tests` submodule in code
+
+    ```rust
+    fn foo() {}
+
+    #[cfg(test)]
+    mod tests {
+      use super::*;
+
+      #[test]
+      fn test_foo() { .. }
+    }
+    ```
+
+    Integration tests should go into the `tests/` folder, ideally into a file based on the functionality they test. Such tests can only use the public interface.
+
+    For libraries, consider providing examples in `examples/`.
+
+- **Iterators**
+
+    Prefer writing explicit iterator types over `impl Iterator`. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
+
+    In addition to the standard `Iterator` trait, always consider to implement additional traits from `std::iter`:
+
+    - `FusedIterator` in all cases unless there is a strong reason not to
+    - `DoubleEndedIterator` if reverse iteration is possible
+    - `ExactSizeIterator` if the size is known beforehand
+
+    If it is exceptionally hard to write a custom iterator, then it can also be a private [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) around a boxed iterator:
+
+    ```rust
+    pub struct FooIter(Box<dyn Iterator<Item = Foo>>);
+
+    impl Iterator for FooIter {
+    	type Item = Foo;
+
+      fn next(&mut self) -> Option<Self::Item> {
+    		self.0.next()
+      }
+    }
+    ```
+
+- **Async-await**
+
+    In general we like to migrate to async-await using code, though much code exists which does not yet do this.  During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types.  This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not.  Pinning should only be done explicitly when part of fields in structs or similar.
+
+    In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`.  This allows seamless use in async-await code or in code dealing directly with futures.  Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
+
+- **Discourage unwrap()**
+
+    This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
+
+    This was actually the root cause of incident [[INC-202] Local Queue overflow in `pop-europe`](https://www.notion.so/INC-202-Local-Queue-overflow-in-pop-europe-889dc5de37c146159dbf8f71094ff0cb) : A function compiling a regex from a string used `unwrap()` because it assumed to be called only on constant patterns, but then was used to compile user input received via project configs.
+
+
+**Useful Resources**
+
+- [https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html](https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html)
+
+## Development Environment
+
+We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to "*Install the Recommended Extensions"*, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
+
+- *Rust Analyzer:* A fast and feature-packed language server integration that has been developed as successor to RLS.
+- *CodeLLDB:* Debugger based on LLDB, required to debug with the Rust Analyzer extension
+- *Better TOML and Crates:* Support for `Cargo.toml` files and bumping dependency versions
+
+At the time of writing, Rust Analyzer is still under development. Updates are published frequently, so make sure to confirm the update prompt. Some of its default settings may not be ideal, so we recommend the following settings in your User's `settings.json`:
+
+```jsx
+{
+  // Run full clippy lints instead of just cargo check
+  "rust-analyzer.checkOnSave.command": "clippy",
+
+  // If you don't like inline type annotations, this disables it
+  "rust-analyzer.inlayHints.enable": false,
+
+	// To run automatic updates, if preferred
+  "rust-analyzer.updates.askBeforeDownload": false
+}
+```
+
+For testing, we often use the snapshot library `[insta](https://github.com/mitsuhiko/insta)` written by the one and only Armin. By default, when running tests with Cargo, insta will compare snapshots and pretty-print diffs on standard out. However, to get most out of insta, install `cargo-insta` and use the cargo command instead:
+
+```bash
+# Install insta. This will upgrade outdated versions.
+$ cargo install cargo-insta
+
+# To review snapshot diffs interactively:
+$ cargo insta review --all
+
+# To run all tests skipping failures:
+$ cargo insta test --review
+
+# To quickly reject all pending diffs:
+$ cargo insta reject --all
+```
+
+## Configuring CI
+
+We use `Makefiles` to collect the most standard actions. A full Makefile for a workspace comprising multiple crates should roughly look like this (can be simplified):
+
+```jsx
+all: check test
+.PHONY: all
+
+check: style lint
+.PHONY: check
+
+test: test-default test-all
+.PHONY: test
+
+test-default:
+	cargo test --all
+.PHONY: test-default
+
+test-all:
+	cargo test --all --all-features
+.PHONY: test-all
+
+style:
+	@rustup component add rustfmt --toolchain stable 2> /dev/null
+	cargo +stable fmt -- --check
+.PHONY: style
+
+lint:
+	@rustup component add clippy --toolchain stable 2> /dev/null
+	cargo +stable clippy --all-features --all --tests --examples -- -D clippy::all
+.PHONY: lint
+
+format:
+	@rustup component add rustfmt --toolchain stable 2> /dev/null
+	cargo +stable fmt
+.PHONY: format
+```
+
+To run this in CI, we generally configure the following tasks. Note that we **do not configure caches**, since those keep growing and are generally slower to download than just rebuilding.
+
+```jsx
+os: linux
+language: rust
+
+script: make $SUITE
+
+matrix:
+  include:
+    - env: SUITE=style
+    - env: SUITE=lint
+    - env: SUITE=test
+```
+
+## Cargo Version Numbers
+
+Cargo follows [Semantic Versioning](https://semver.org/), which uses X.Y.Z which are respectively called *major*, *minor* and *patch* version numbers.  There are two major cases:
+
+### After 1.0
+
+Once a 1.0 release is reached following SemVer is easy:
+
+- Breaking changes require bumping the major version.
+- New features bump the minor version.
+- Bugfix-only releases bump the patch version.
+
+### Before 1.0
+
+Before a 1.0 release is reached [anything goes according to the spec](https://semver.org/#spec-item-4).  However Cargo has [strictly defined update rules for caret requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) (caret requirements are the default if plain version numbers are used).  So in order to make `cargo update` behave well we adopt the following:
+
+- Breaking changes require bumping the minor (Y) version.
+- New features bump the patch (Z) version.
+- Bugfix-only releases bump the patch (Z) version.

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -156,7 +156,7 @@ All test functions should start with `test_` and contain the function name + a s
 - `test_parse_empty`
 - `test_parse_null`
 
-Write unit tests in a `tests` submodule in code
+Write unit tests in a `tests` submodule in code.
 
 ```rust
 fn foo() {}
@@ -208,7 +208,6 @@ In **traits** you can not yet use `async fn` ([see this blog post](https://small
 
 This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
 
-This was actually the root cause of incident [[INC-202] Local Queue overflow in `pop-europe`](https://www.notion.so/INC-202-Local-Queue-overflow-in-pop-europe-889dc5de37c146159dbf8f71094ff0cb) : A function compiling a regex from a string used `unwrap()` because it assumed to be called only on constant patterns, but then was used to compile user input received via project configs.
 
 
 ## Development Environment
@@ -229,12 +228,12 @@ At the time of writing, Rust Analyzer is still under development. Updates are pu
   // If you don't like inline type annotations, this disables it
   "rust-analyzer.inlayHints.enable": false,
 
-	// To run automatic updates, if preferred
+  // To run automatic updates, if preferred
   "rust-analyzer.updates.askBeforeDownload": false
 }
 ```
 
-For testing, we often use the snapshot library `[insta](https://github.com/mitsuhiko/insta)` written by the one and only Armin. By default, when running tests with Cargo, insta will compare snapshots and pretty-print diffs on standard out. However, to get most out of insta, install `cargo-insta` and use the cargo command instead:
+For testing, we often use the snapshot library `[insta](https://github.com/mitsuhiko/insta)`. By default, when running tests with Cargo, insta will compare snapshots and pretty-print diffs on standard out. However, to get most out of insta, install `cargo-insta` and use the cargo command instead:
 
 ```bash
 # Install insta. This will upgrade outdated versions.

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -1,4 +1,6 @@
-# How to code Rust at Sentry
+---
+title: Rust Development at Sentry
+---
 
 This is a document that contains a bunch of useful resources for getting started with Rust and adhering to our coding principles.
 
@@ -22,197 +24,192 @@ This is a document that contains a bunch of useful resources for getting started
 [https://doc.rust-lang.org/nomicon/](https://doc.rust-lang.org/nomicon/)
 - Rust by Example: A comprehensive list of examples
 [https://doc.rust-lang.org/stable/rust-by-example/](https://doc.rust-lang.org/stable/rust-by-example/)
+- [https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html](https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html)
+
 
 ## Coding Principles
 
-<aside>
-ℹ️ This section is still under development and may be incomplete.
 
-</aside>
+### Import order
 
-- **Import order**
+Imports must be declared before any other code in the file, and can only be preceded by module doc comments and module attributes (`#![...]`). We bundle imports in groups based on their origin, each separated by an empty line. The order of imports is:
 
-    Imports must be declared before any other code in the file, and can only be preceded by module doc comments and module attributes (`#![...]`). We bundle imports in groups based on their origin, each separated by an empty line. The order of imports is:
+1. Rust standard library, including `std`, `core` and `alloc`
+2. External dependencies
+3. Workspace dependencies
+4. Crate modules
+5. Re-exports (`pub use`)
 
-    1. Rust standard library, including `std`, `core` and `alloc`
-    2. External dependencies
-    3. Workspace dependencies
-    4. Crate modules
-    5. Re-exports (`pub use`)
+**Example:**
 
-    **Example:**
+```rust
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::{self, Seek, Write};
 
-    ```rust
-    use std::borrow::Cow;
-    use std::collections::HashMap;
-    use std::io::{self, Seek, Write};
+use fnv::{FnvHashMap, FnvHashSet};
+use num::FromPrimitive;
 
-    use fnv::{FnvHashMap, FnvHashSet};
-    use num::FromPrimitive;
+use symbolic_common::{Arch, DebugId, Language};
+use symbolic_debuginfo::{DebugSession, Function, LineInfo};
 
-    use symbolic_common::{Arch, DebugId, Language};
-    use symbolic_debuginfo::{DebugSession, Function, LineInfo};
+use crate::error::{SymCacheError, SymCacheErrorKind, ValueKind};
+use crate::format;
 
-    use crate::error::{SymCacheError, SymCacheErrorKind, ValueKind};
-    use crate::format;
+pub use gimli::RunTimeEndian as Endian;
+```
 
-    pub use gimli::RunTimeEndian as Endian;
-    ```
+### Declaration order
 
-- **Declaration order**
+Within a file, the order of components should always be roughly the same:
 
-    Within a file, the order of components should always be roughly the same:
+1. Module-level documentation
+2. Imports
+3. Public re-exports
+4. Modules and public modules
+5. Constants
+6. Error types
+7. All other functions and structs
+8. Unit tests
 
-    1. Module-level documentation
-    2. Imports
-    3. Public re-exports
-    4. Modules and public modules
-    5. Constants
-    6. Error types
-    7. All other functions and structs
-    8. Unit tests
+Always declare a type or function before using it. The only exceptions to this are:
 
-    Always declare a type or function before using it. The only exceptions to this are:
+- Public functions are always on top in `impl` blocks
+- Circular calls or references. In this case place the more significant item first. For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
 
-    - Public functions are always on top in `impl` blocks
-    - Circular calls or references. In this case place the more significant item first. For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
+When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Place helper functions and helper types **above** the struct definition. Use the following order for the blocks:
 
-    When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Place helper functions and helper types **above** the struct definition. Use the following order for the blocks:
+1. The `struct` or `enum` definition
+2. `impl` block
+3. `impl` block with further constraints
+4. Trait implementations of `std` traits
+5. Trait implementations of other traits
+6. Trait implementations of own traits
 
-    1. The `struct` or `enum` definition
-    2. `impl` block
-    3. `impl` block with further constraints
-    4. Trait implementations of `std` traits
-    5. Trait implementations of other traits
-    6. Trait implementations of own traits
+Inside an `impl` block, follow roughly this order:
 
-    Inside an `impl` block, follow roughly this order:
+1. Associated constants
+2. Associated non-instance functions
+3. Constructors
+4. Getters / setters
+5. Anything else
 
-    1. Associated constants
-    2. Associated non-instance functions
-    3. Constructors
-    4. Getters / setters
-    5. Anything else
+### Default lints
 
-- **Default Lints**
+We use [clippy](https://github.com/rust-lang/rust-clippy) with the `clippy::all` preset for linting. See The *Configuring CI* section for how to invoke it.
 
-    We use [clippy](https://github.com/rust-lang/rust-clippy) with the `clippy::all` preset for linting. See The *Configuring CI* section for how to invoke it.
+In addition to that, every crate enable the following warnings in its top-level file after the doc block before imports (see the [list of all available lints](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)):
 
-    In addition to that, every crate enable the following warnings in its top-level file after the doc block before imports (see the [list of all available lints](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)):
+```rust
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+```
 
-    ```rust
-    #![warn(missing_docs)]
-    #![warn(missing_debug_implementations)]
-    ```
+Note that we do not enable `unsafe_code`, since that should already stand out in code review. There are a few legitimate cases for unsafe code, and the `unsafe` keyword alone already marks them sufficiently.
 
-    Note that we do not enable `unsafe_code`, since that should already stand out in code review. There are a few legitimate cases for unsafe code, and the `unsafe` keyword alone already marks them sufficiently.
+### Field visibility
 
-- **Field visibility**
+By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
 
-    By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
+- Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
+- Plain data types with a very stable signature.
 
-    - Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
-    - Plain data types with a very stable signature.
+Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
 
-    Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
+- `foo()`, `foo_mut()` and `set_foo()` for exposing the values
+- `pub(crate)` or `pub(super)` accessor functions in corner cases
+- A `Default` implementation and builder when incremental construction is required
 
-    - `foo()`, `foo_mut()` and `set_foo()` for exposing the values
-    - `pub(crate)` or `pub(super)` accessor functions in corner cases
-    - A `Default` implementation and builder when incremental construction is required
+### Naming
 
-- **Naming**
+We are strictly following the [Rust Naming Conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html). The entire conventions apply, although here are a few highlighted sections:
 
-    We are strictly following the [Rust Naming Conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html). The entire conventions apply, although here are a few highlighted sections:
+- [Avoid redundant prefixes](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356])
+- [Getter and setter methods](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#getter/setter-methods-[rfc-344]) (`foo` instead of `get_foo`)
+- [Conversions](https://doc.rust-lang.org/1.0.0/style/style/naming/conversions.html) (`as_foo` vs `to_foo` vs `into_foo`)
+- [Iterators](https://doc.rust-lang.org/1.0.0/style/style/naming/iterators.html)
+- [Constructors](https://rust-lang.github.io/api-guidelines/predictability.html#constructors-are-static-inherent-methods-c-ctor) (Structs generally have `fn new(...) -> Self`, which never returns Result)
 
-    - [Avoid redundant prefixes](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356])
-    - [Getter and setter methods](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#getter/setter-methods-[rfc-344]) (`foo` instead of `get_foo`)
-    - [Conversions](https://doc.rust-lang.org/1.0.0/style/style/naming/conversions.html) (`as_foo` vs `to_foo` vs `into_foo`)
-    - [Iterators](https://doc.rust-lang.org/1.0.0/style/style/naming/iterators.html)
-    - [Constructors](https://rust-lang.github.io/api-guidelines/predictability.html#constructors-are-static-inherent-methods-c-ctor) (Structs generally have `fn new(...) -> Self`, which never returns Result)
+### Writing Doc Comments
 
-- **Writing Doc Comments**
+We follow conventions from RFC 505 and RFC 1574 for writing doc comments. See the [full conventions text](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text). Particularly, this includes:
 
-    We follow conventions from RFC 505 and RFC 1574 for writing doc comments. See the [full conventions text](https://github.com/rust-lang/rfcs/blob/master/text/1574-more-api-documentation-conventions.md#appendix-a-full-conventions-text). Particularly, this includes:
+- A single-line short summary sentence written in American English using third-person.
+- Use the default headers where applicable, but avoid custom sections outside of module-level docs.
+- Link between types and methods where possible, especially within the crate.
+- Write doc tests
 
-    - A single-line short summary sentence written in American English using third-person.
-    - Use the default headers where applicable, but avoid custom sections outside of module-level docs.
-    - Link between types and methods where possible, especially within the crate.
-    - Write doc tests
-- **Writing Doc Tests**
+### Writing Doc Tests
 
-    If possible, prefer writing at least one doctest for the critical path of your methods or structs. Of course, this requires the interface to be public. This should even take precedence over an equal unit test, since it both tests and documents the API.
+If possible, prefer writing at least one doctest for the critical path of your methods or structs. Of course, this requires the interface to be public. This should even take precedence over an equal unit test, since it both tests and documents the API.
 
-    To format code in doc comments, you can temporarily [configure rustfmt](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#format_code_in_doc_comments) to do so. We might add this to our default configuration at some point:
+To format code in doc comments, you can temporarily [configure rustfmt](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#format_code_in_doc_comments) to do so. We might add this to our default configuration at some point:
 
-    ```rust
-    format_code_in_doc_comments = true
-    ```
+```rust
+format_code_in_doc_comments = true
+```
 
-- **Writing Tests**
+### Writing Tests
 
-    All test functions should start with `test_` and contain the function name + a simple condition in their name. The test name should be as concise as possible and avoid redundant words (such as "should", "that"). Examples:
+All test functions should start with `test_` and contain the function name + a simple condition in their name. The test name should be as concise as possible and avoid redundant words (such as "should", "that"). Examples:
 
-    - `test_parse_empty`
-    - `test_parse_null`
+- `test_parse_empty`
+- `test_parse_null`
 
-    Write unit tests in a `tests` submodule in code
+Write unit tests in a `tests` submodule in code
 
-    ```rust
-    fn foo() {}
+```rust
+fn foo() {}
 
-    #[cfg(test)]
-    mod tests {
-      use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-      #[test]
-      fn test_foo() { .. }
+    #[test]
+    fn test_foo() { .. }
+}
+```
+
+Integration tests should go into the `tests/` folder, ideally into a file based on the functionality they test. Such tests can only use the public interface.
+
+For libraries, consider providing examples in `examples/`.
+
+### Iterators
+
+Prefer writing explicit iterator types over `impl Iterator`. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
+
+In addition to the standard `Iterator` trait, always consider to implement additional traits from `std::iter`:
+
+- `FusedIterator` in all cases unless there is a strong reason not to
+- `DoubleEndedIterator` if reverse iteration is possible
+- `ExactSizeIterator` if the size is known beforehand
+
+If it is exceptionally hard to write a custom iterator, then it can also be a private [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) around a boxed iterator:
+
+```rust
+pub struct FooIter(Box<dyn Iterator<Item = Foo>>);
+
+impl Iterator for FooIter {
+    type Item = Foo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
     }
-    ```
+}
+```
 
-    Integration tests should go into the `tests/` folder, ideally into a file based on the functionality they test. Such tests can only use the public interface.
+### Async-await
 
-    For libraries, consider providing examples in `examples/`.
+In general we like to migrate to async-await using code, though much code exists which does not yet do this.  During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types.  This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not.  Pinning should only be done explicitly when part of fields in structs or similar.
 
-- **Iterators**
+In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`.  This allows seamless use in async-await code or in code dealing directly with futures.  Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
 
-    Prefer writing explicit iterator types over `impl Iterator`. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
+### Discourage unwrap()
 
-    In addition to the standard `Iterator` trait, always consider to implement additional traits from `std::iter`:
+This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
 
-    - `FusedIterator` in all cases unless there is a strong reason not to
-    - `DoubleEndedIterator` if reverse iteration is possible
-    - `ExactSizeIterator` if the size is known beforehand
+This was actually the root cause of incident [[INC-202] Local Queue overflow in `pop-europe`](https://www.notion.so/INC-202-Local-Queue-overflow-in-pop-europe-889dc5de37c146159dbf8f71094ff0cb) : A function compiling a regex from a string used `unwrap()` because it assumed to be called only on constant patterns, but then was used to compile user input received via project configs.
 
-    If it is exceptionally hard to write a custom iterator, then it can also be a private [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) around a boxed iterator:
-
-    ```rust
-    pub struct FooIter(Box<dyn Iterator<Item = Foo>>);
-
-    impl Iterator for FooIter {
-    	type Item = Foo;
-
-      fn next(&mut self) -> Option<Self::Item> {
-    		self.0.next()
-      }
-    }
-    ```
-
-- **Async-await**
-
-    In general we like to migrate to async-await using code, though much code exists which does not yet do this.  During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types.  This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not.  Pinning should only be done explicitly when part of fields in structs or similar.
-
-    In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`.  This allows seamless use in async-await code or in code dealing directly with futures.  Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
-
-- **Discourage unwrap()**
-
-    This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
-
-    This was actually the root cause of incident [[INC-202] Local Queue overflow in `pop-europe`](https://www.notion.so/INC-202-Local-Queue-overflow-in-pop-europe-889dc5de37c146159dbf8f71094ff0cb) : A function compiling a regex from a string used `unwrap()` because it assumed to be called only on constant patterns, but then was used to compile user input received via project configs.
-
-
-**Useful Resources**
-
-- [https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html](https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html)
 
 ## Development Environment
 

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -154,7 +154,7 @@ All test functions should start with `test_` and contain the function name + a s
 - `test_parse_empty`
 - `test_parse_null`
 
-Write unit tests in a `tests` submodule in code. Depending on the editor, `rust-analyzer` will auto-expand `tmod` to an appropriate snippet.
+Place unit tests in a `tests` submodule annotated with `#[cfg(test)]`. This way, imports and helper functions for tests are only compiled before running tests. Depending on the editor, `rust-analyzer` will auto-expand `tmod` to an appropriate snippet.
 
 ```rust
 fn foo() {}

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -77,7 +77,7 @@ Always declare a type or function before using it. The only exceptions to this a
 - Public functions are always on top in `impl` blocks
 - Circular calls or references. In this case place the more significant item first. For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
 
-When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Place helper functions and helper types **above** the struct definition. Use the following order for the blocks:
+When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Use the following order for the blocks:
 
 1. The `struct` or `enum` definition
 2. `impl` block
@@ -112,7 +112,7 @@ Note that we do not enable `unsafe_code`, since that should already stand out in
 By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
 
 - Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
-- Plain data types with a very stable signature.
+- Plain data types with a very stable signature. For example, schema definitions such as the Sentry `Event` protocol.
 
 Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
 
@@ -156,7 +156,7 @@ All test functions should start with `test_` and contain the function name + a s
 - `test_parse_empty`
 - `test_parse_null`
 
-Write unit tests in a `tests` submodule in code.
+Write unit tests in a `tests` submodule in code. Depending on the editor, `rust-analyzer` will auto-expand `tmod` to an appropriate snippet.
 
 ```rust
 fn foo() {}
@@ -178,7 +178,7 @@ For libraries, consider providing examples in `examples/`.
 
 Prefer writing explicit iterator types over `impl Iterator`. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
 
-In addition to the standard `Iterator` trait, always consider to implement additional traits from `std::iter`:
+In addition to the standard `Iterator` trait, always consider implementing additional traits from `std::iter`:
 
 - `FusedIterator` in all cases unless there is a strong reason not to
 - `DoubleEndedIterator` if reverse iteration is possible
@@ -208,17 +208,24 @@ In **traits** you can not yet use `async fn` ([see this blog post](https://small
 
 This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
 
+### Use `.get()` instead of slice syntax
 
+Slice syntax (`&foo[a..b]`) will panic if the indices are out of bounds or out of order. Especially when dealing with untrusted input, it is better to use `.get(a..b)` and an `if let Some(...) =` expression.
+
+### Use checked math
+
+Arithmetic under/overflows will panic in debug builds, but will lead to wrong results or panics in other parts of the code (like slice syntax mentioned above) in release builds.
+It is a good idea to always use checked math, such as `checked_sub` or `saturating_sub`. The `saturating` variants will be capped at the appropriate `MIN/MAX` of the underlying data type.
 
 ## Development Environment
 
-We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to "*Install the Recommended Extensions"*, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
+We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to *"Install the Recommended Extensions"*, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
 
 - *Rust Analyzer:* A fast and feature-packed language server integration that has been developed as successor to RLS.
 - *CodeLLDB:* Debugger based on LLDB, required to debug with the Rust Analyzer extension
 - *Better TOML and Crates:* Support for `Cargo.toml` files and bumping dependency versions
 
-At the time of writing, Rust Analyzer is still under development. Updates are published frequently, so make sure to confirm the update prompt. Some of its default settings may not be ideal, so we recommend the following settings in your User's `settings.json`:
+Recommended Rust Analyzer settings in your User's `settings.json`:
 
 ```jsx
 {

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -8,27 +8,24 @@ This is a document that contains a bunch of useful resources for getting started
 
 - Join the `#discuss-rust` channel in Slack
 - A quick introduction into the Syntax for first-timers:
-[https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/](https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/)
+  [A half-hour to learn Rust](https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/)
 - The Rust Book, comprehensively documenting the language:
-[https://doc.rust-lang.org/book/](https://doc.rust-lang.org/book/)
+  [The Rust Programming Language](https://doc.rust-lang.org/book/)
 - We follow the Rust style (enforced by `rustfmt` and `clippy` where possible):
-[https://doc.rust-lang.org/1.0.0/style/README.html](https://doc.rust-lang.org/1.0.0/style/README.html)
-- The Async Book:
-[https://rust-lang.github.io/async-book/](https://rust-lang.github.io/async-book/)
+  [Style Guidelines](https://doc.rust-lang.org/1.0.0/style/README.html)
+- [The Async Book](https://rust-lang.github.io/async-book/)
 
 ## Advanced Reading
 
-- The Little Book of Rust Macros
-[https://danielkeep.github.io/tlborm/book/index.html](https://danielkeep.github.io/tlborm/book/index.html)
-- Rust Nomicon: The Dark Arts of Unsafe Rust
-[https://doc.rust-lang.org/nomicon/](https://doc.rust-lang.org/nomicon/)
-- Rust by Example: A comprehensive list of examples
-[https://doc.rust-lang.org/stable/rust-by-example/](https://doc.rust-lang.org/stable/rust-by-example/)
-- [https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html](https://doc.rust-lang.org/1.15.1/book/choosing-your-guarantees.html)
-
+- [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html)
+- [Rust Nomicon: The Dark Arts of Unsafe Rust](https://doc.rust-lang.org/nomicon/)
+- [Rust by Example: A comprehensive list of examples](https://doc.rust-lang.org/stable/rust-by-example/)
+- [Rust for Rustaceans: Idiomatic Programming for Experienced Developers](https://rust-for-rustaceans.com/)
+- [Rust in Action: Systems programming concepts and techniques](https://www.rustinaction.com/)
+- [Zero To Production In Rust: An introduction to backend development](https://www.zero2prod.com/index.html?country=Austria&discount_code=VAT20)
+- [Rust Atomics and Locks](https://marabos.nl/atomics/)
 
 ## Coding Principles
-
 
 ### Import order
 
@@ -80,23 +77,24 @@ Always declare a type or function before using it. The only exceptions to this a
 When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Use the following order for the blocks:
 
 1. The `struct` or `enum` definition
-2. `impl` block
-3. `impl` block with further constraints
-4. Trait implementations of `std` traits
-5. Trait implementations of other traits
-6. Trait implementations of own traits
+1. `impl` block
+1. `impl` block with further constraints
+1. Trait implementations of `std` traits
+1. Trait implementations of other traits
+1. Trait implementations of own traits
 
 Inside an `impl` block, follow roughly this order:
 
+1. Public before private
 1. Associated constants
-2. Associated non-instance functions
-3. Constructors
-4. Getters / setters
-5. Anything else
+1. Associated non-instance functions
+1. Constructors
+1. Getters / setters
+1. Anything else
 
 ### Default lints
 
-We use [clippy](https://github.com/rust-lang/rust-clippy) with the `clippy::all` preset for linting. See The *Configuring CI* section for how to invoke it.
+We use [clippy](https://github.com/rust-lang/rust-clippy) with the `clippy::all` preset for linting. See The _Configuring CI_ section for how to invoke it.
 
 In addition to that, every crate enable the following warnings in its top-level file after the doc block before imports (see the [list of all available lints](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html)):
 
@@ -171,12 +169,13 @@ mod tests {
 ```
 
 Integration tests should go into the `tests/` folder, ideally into a file based on the functionality they test. Such tests can only use the public interface.
+See [this blog post](https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Rules-of-Thumb) for tips on how to structure integration tests.
 
 For libraries, consider providing examples in `examples/`.
 
 ### Iterators
 
-Prefer writing explicit iterator types over `impl Iterator`. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
+Prefer explicit iterator types over `impl Iterator` in public interfaces. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
 
 In addition to the standard `Iterator` trait, always consider implementing additional traits from `std::iter`:
 
@@ -200,13 +199,13 @@ impl Iterator for FooIter {
 
 ### Async-await
 
-In general we like to migrate to async-await using code, though much code exists which does not yet do this.  During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types.  This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not.  Pinning should only be done explicitly when part of fields in structs or similar.
+In general we like to migrate to async-await using code, though much code exists which does not yet do this. During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types. This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not. Pinning should only be done explicitly when part of fields in structs or similar.
 
-In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`.  This allows seamless use in async-await code or in code dealing directly with futures.  Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
+In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`. This allows seamless use in async-await code or in code dealing directly with futures. Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
 
-### Discourage unwrap()
+### Discourage `.unwrap()`
 
-This may seem obvious, but *almost always* discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
+This may seem obvious, but _almost always_ discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
 
 ### Use `.get()` instead of slice syntax
 
@@ -219,11 +218,11 @@ It is a good idea to always use checked math, such as `checked_sub` or `saturati
 
 ## Development Environment
 
-We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to *"Install the Recommended Extensions"*, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
+We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to _"Install the Recommended Extensions"_, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
 
-- *Rust Analyzer:* A fast and feature-packed language server integration that has been developed as successor to RLS.
-- *CodeLLDB:* Debugger based on LLDB, required to debug with the Rust Analyzer extension
-- *Better TOML and Crates:* Support for `Cargo.toml` files and bumping dependency versions
+- _Rust Analyzer:_ A fast and feature-packed language server integration that has been developed as successor to RLS.
+- _CodeLLDB:_ Debugger based on LLDB, required to debug with the Rust Analyzer extension
+- _Better TOML and Crates:_ Support for `Cargo.toml` files and bumping dependency versions
 
 Recommended Rust Analyzer settings in your User's `settings.json`:
 
@@ -260,7 +259,7 @@ $ cargo insta reject --all
 
 We use `Makefiles` to collect the most standard actions. A full Makefile for a workspace comprising multiple crates should roughly look like this (can be simplified):
 
-```jsx
+```Makefile
 all: check test
 .PHONY: all
 
@@ -294,24 +293,11 @@ format:
 .PHONY: format
 ```
 
-To run this in CI, we generally configure the following tasks. Note that we **do not configure caches**, since those keep growing and are generally slower to download than just rebuilding.
-
-```jsx
-os: linux
-language: rust
-
-script: make $SUITE
-
-matrix:
-  include:
-    - env: SUITE=style
-    - env: SUITE=lint
-    - env: SUITE=test
-```
+Note that in CI, we **do not configure caches**, since those keep growing and are generally slower to download than just rebuilding.
 
 ## Cargo Version Numbers
 
-Cargo follows [Semantic Versioning](https://semver.org/), which uses X.Y.Z which are respectively called *major*, *minor* and *patch* version numbers.  There are two major cases:
+Cargo follows [Semantic Versioning](https://semver.org/), which uses X.Y.Z which are respectively called _major_, _minor_ and _patch_ version numbers. There are two major cases:
 
 ### After 1.0
 
@@ -323,7 +309,7 @@ Once a 1.0 release is reached following SemVer is easy:
 
 ### Before 1.0
 
-Before a 1.0 release is reached [anything goes according to the spec](https://semver.org/#spec-item-4).  However Cargo has [strictly defined update rules for caret requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) (caret requirements are the default if plain version numbers are used).  So in order to make `cargo update` behave well we adopt the following:
+Before a 1.0 release is reached [anything goes according to the spec](https://semver.org/#spec-item-4). However Cargo has [strictly defined update rules for caret requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) (caret requirements are the default if plain version numbers are used). So in order to make `cargo update` behave well we adopt the following:
 
 - Breaking changes require bumping the minor (Y) version.
 - New features bump the patch (Z) version.

--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -6,36 +6,109 @@ This is a document that contains a bunch of useful resources for getting started
 
 ## Getting Started
 
-- Join the `#discuss-rust` channel in Slack
 - A quick introduction into the Syntax for first-timers:
   [A half-hour to learn Rust](https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/)
 - The Rust Book, comprehensively documenting the language:
   [The Rust Programming Language](https://doc.rust-lang.org/book/)
-- We follow the Rust style (enforced by `rustfmt` and `clippy` where possible):
-  [Style Guidelines](https://doc.rust-lang.org/1.0.0/style/README.html)
 - [The Async Book](https://rust-lang.github.io/async-book/)
-
-## Advanced Reading
-
-- [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html)
-- [Rust Nomicon: The Dark Arts of Unsafe Rust](https://doc.rust-lang.org/nomicon/)
-- [Rust by Example: A comprehensive list of examples](https://doc.rust-lang.org/stable/rust-by-example/)
-- [Rust for Rustaceans: Idiomatic Programming for Experienced Developers](https://rust-for-rustaceans.com/)
-- [Rust in Action: Systems programming concepts and techniques](https://www.rustinaction.com/)
-- [Zero To Production In Rust: An introduction to backend development](https://www.zero2prod.com/index.html?country=Austria&discount_code=VAT20)
-- [Rust Atomics and Locks](https://marabos.nl/atomics/)
+- Sentry employees: Join the `#discuss-rust` channel in Slack
 
 ## Coding Principles
 
-### Import order
+### Iterators
+
+Prefer explicit iterator types over `impl Iterator` in stable, public interfaces of published crates.
+This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
+
+In addition to the standard `Iterator` trait, always consider implementing additional traits from `std::iter`:
+
+- `FusedIterator` in all cases unless there is a strong reason not to
+- `DoubleEndedIterator` if reverse iteration is possible
+- `ExactSizeIterator` if the size is known beforehand
+
+If it is exceptionally hard to write a custom iterator, then it can also be a private [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) around a boxed iterator:
+
+```rust
+pub struct FooIter(Box<dyn Iterator<Item = Foo>>);
+
+impl Iterator for FooIter {
+    type Item = Foo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+```
+
+<!-- ### Async-await
+
+In general we like to migrate to async-await using code, though much code exists which does not yet do this.
+Use
+During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types. This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not. Pinning should only be done explicitly when part of fields in structs or similar. -->
+
+### Async Traits
+
+In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)).
+In this case, functions should return `-> Pin<Box<dyn Future<Output = ...> + Send>>`:
+
+```rust
+trait Database {
+    fn get_user(&self) -> Pin<Box<dyn Future<Output = User> + Send + '_>>;
+}
+
+impl Database for MyDB {
+  fn get_user(&self) -> Pin<Box<dyn Future<Output = User> + Send + '_>> {
+    Box::pin(async {
+      // ...
+    })
+  }
+}
+```
+
+Note that the returned future type is `Send`, to ensure that it can run on a multi-threaded runtime.
+
+This corresponds to what the [async-trait crate](https://crates.io/crates/async-trait) does.
+
+### Avoid `.unwrap()`
+
+This may seem obvious, but _almost always_ avoid the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
+
+Instead, refactor your code and function signatures to use `match`, etc.
+
+### Use `.get()` Instead of Slice Syntax
+
+Slice syntax (`&foo[a..b]`) will panic if the indices are out of bounds or out of order. Especially when dealing with untrusted input, it is better to use `.get(a..b)` and an `if let Some(...) =` expression.
+
+### Checked Math
+
+Arithmetic under/overflows will panic in debug builds, but will lead to wrong results or panics in other parts of the code (like slice syntax mentioned above) in release builds.
+It is a good idea to always use checked math, such as `checked_sub` or `saturating_sub`. The `saturating` variants will be capped at the appropriate `MIN/MAX` of the underlying data type.
+
+### Field visibility
+
+By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
+
+- Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
+- Plain data types with a very stable signature. For example, schema definitions such as the Sentry `Event` protocol.
+
+Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
+
+- `foo()`, `foo_mut()` and `set_foo()` for exposing the values
+- `pub(crate)` or `pub(super)` accessor functions in corner cases
+- A `Default` implementation and builder when incremental construction is required
+
+## Style Guidelines
+
+In general, we follow the official Rust [Style Guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
+
+### Import Order
 
 Imports must be declared before any other code in the file, and can only be preceded by module doc comments and module attributes (`#![...]`). We bundle imports in groups based on their origin, each separated by an empty line. The order of imports is:
 
 1. Rust standard library, including `std`, `core` and `alloc`
-2. External dependencies
-3. Workspace dependencies
-4. Crate modules
-5. Re-exports (`pub use`)
+2. External & workspace dependencies
+3. Crate modules
+4. Re-exports (`pub use`)
 
 **Example:**
 
@@ -46,7 +119,6 @@ use std::io::{self, Seek, Write};
 
 use fnv::{FnvHashMap, FnvHashSet};
 use num::FromPrimitive;
-
 use symbolic_common::{Arch, DebugId, Language};
 use symbolic_debuginfo::{DebugSession, Function, LineInfo};
 
@@ -69,10 +141,8 @@ Within a file, the order of components should always be roughly the same:
 7. All other functions and structs
 8. Unit tests
 
-Always declare a type or function before using it. The only exceptions to this are:
-
-- Public functions are always on top in `impl` blocks
-- Circular calls or references. In this case place the more significant item first. For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
+There is no hard rule on declaration order, but we suggest to place the more significant item first.
+For example, for types that expose an iterator, declare the type and its impl block (including `fn iter`) first, then below define the corresponding iterator.
 
 When declaring a structure with an implementation, always ensure that the struct and its impl blocks are consecutive. Use the following order for the blocks:
 
@@ -83,9 +153,8 @@ When declaring a structure with an implementation, always ensure that the struct
 1. Trait implementations of other traits
 1. Trait implementations of own traits
 
-Inside an `impl` block, follow roughly this order:
+Inside an `impl` block, follow roughly this order (public before private):
 
-1. Public before private
 1. Associated constants
 1. Associated non-instance functions
 1. Constructors
@@ -103,24 +172,13 @@ In addition to that, every crate enable the following warnings in its top-level 
 #![warn(missing_debug_implementations)]
 ```
 
-Note that we do not enable `unsafe_code`, since that should already stand out in code review. There are a few legitimate cases for unsafe code, and the `unsafe` keyword alone already marks them sufficiently.
-
-### Field visibility
-
-By default, fields of structs (including tuple-structs) should be fully private. The only exception to this are:
-
-- Newtypes (1-tuple structs) where direct access to the inner type is desired. This is to annotate semantics of a type where accessing the inner type is required.
-- Plain data types with a very stable signature. For example, schema definitions such as the Sentry `Event` protocol.
-
-Mixed visibility is never allowed, not even between private and `pub(crate)` or `pub(super)`. Instead, provide accessors:
-
-- `foo()`, `foo_mut()` and `set_foo()` for exposing the values
-- `pub(crate)` or `pub(super)` accessor functions in corner cases
-- A `Default` implementation and builder when incremental construction is required
+Note that we do not enable `unsafe_code`, since that should already stand out in code review.
+There are a few legitimate cases for unsafe code, and the `unsafe` keyword alone already marks them sufficiently.
 
 ### Naming
 
-We are strictly following the [Rust Naming Conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html). The entire conventions apply, although here are a few highlighted sections:
+We are strictly following the [Rust Naming Conventions](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html).
+The entire conventions apply, although here are a few highlighted sections:
 
 - [Avoid redundant prefixes](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356])
 - [Getter and setter methods](https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#getter/setter-methods-[rfc-344]) (`foo` instead of `get_foo`)
@@ -139,7 +197,8 @@ We follow conventions from RFC 505 and RFC 1574 for writing doc comments. See th
 
 ### Writing Doc Tests
 
-If possible, prefer writing at least one doctest for the critical path of your methods or structs. Of course, this requires the interface to be public. This should even take precedence over an equal unit test, since it both tests and documents the API.
+For crate-public utilities and SDKs, prefer writing at least one doctest for the critical path of your methods or structs.
+Of course, this requires the interface to be public. This should even take precedence over an equal unit test, since it both tests and documents the API.
 
 To format code in doc comments, you can temporarily [configure rustfmt](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#format_code_in_doc_comments) to do so. We might add this to our default configuration at some point:
 
@@ -149,10 +208,10 @@ format_code_in_doc_comments = true
 
 ### Writing Tests
 
-All test functions should start with `test_` and contain the function name + a simple condition in their name. The test name should be as concise as possible and avoid redundant words (such as "should", "that"). Examples:
+All test functions should contain the function name + a simple condition in their name. The test name should be as concise as possible and avoid redundant words (such as "should", "that"). Examples:
 
-- `test_parse_empty`
-- `test_parse_null`
+- `tests::parse_empty`
+- `tests::parse_null`
 
 Place unit tests in a `tests` submodule annotated with `#[cfg(test)]`. This way, imports and helper functions for tests are only compiled before running tests. Depending on the editor, `rust-analyzer` will auto-expand `tmod` to an appropriate snippet.
 
@@ -164,7 +223,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_foo() { .. }
+    fn foo_works() { .. }
 }
 ```
 
@@ -173,69 +232,28 @@ See [this blog post](https://matklad.github.io/2021/02/27/delete-cargo-integrati
 
 For libraries, consider providing examples in `examples/`.
 
-### Iterators
-
-Prefer explicit iterator types over `impl Iterator` in public interfaces. This allows to name the type in places like associated types or globals. The type name should end with `Iter` per naming convention.
-
-In addition to the standard `Iterator` trait, always consider implementing additional traits from `std::iter`:
-
-- `FusedIterator` in all cases unless there is a strong reason not to
-- `DoubleEndedIterator` if reverse iteration is possible
-- `ExactSizeIterator` if the size is known beforehand
-
-If it is exceptionally hard to write a custom iterator, then it can also be a private [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) around a boxed iterator:
-
-```rust
-pub struct FooIter(Box<dyn Iterator<Item = Foo>>);
-
-impl Iterator for FooIter {
-    type Item = Foo;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-```
-
-### Async-await
-
-In general we like to migrate to async-await using code, though much code exists which does not yet do this. During migration you may need normal functions which return futures, for their signature you should generally prefer `-> impl Future<Output = ...>` over other return types. This allows the compiler to figure out the details for callsites and avoids having to force things to be pinned or not. Pinning should only be done explicitly when part of fields in structs or similar.
-
-In **traits** you can not yet use `async fn` ([see this blog post](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/)), in this case we have an exception and do the same as the [async-trait crate](https://crates.io/crates/async-trait) does and functions return `-> Pin<Box<dyn Future<Output = ...>>>`. This allows seamless use in async-await code or in code dealing directly with futures. Explicitly writing out the signatures is preferable over pulling in the macro syntactic sugar.
-
-### Discourage `.unwrap()`
-
-This may seem obvious, but _almost always_ discourage the use of `.unwrap()`. Even if a piece of code is guaranteed not to panic in its current form (because some precondition is met), it might be reused or refactored in a future situation where the precondition does not hold anymore.
-
-### Use `.get()` instead of slice syntax
-
-Slice syntax (`&foo[a..b]`) will panic if the indices are out of bounds or out of order. Especially when dealing with untrusted input, it is better to use `.get(a..b)` and an `if let Some(...) =` expression.
-
-### Use checked math
-
-Arithmetic under/overflows will panic in debug builds, but will lead to wrong results or panics in other parts of the code (like slice syntax mentioned above) in release builds.
-It is a good idea to always use checked math, such as `checked_sub` or `saturating_sub`. The `saturating` variants will be capped at the appropriate `MIN/MAX` of the underlying data type.
-
 ## Development Environment
 
 We use VSCode for development. Each repository contains settings files configuring code style, linters, and useful features. When opening the project for the first time, make sure to _"Install the Recommended Extensions"_, as they will allow editor assist during coding. The probably most up-to-date example can always be found in the [Relay repository](https://github.com/getsentry/relay/blob/master/.vscode/extensions.json):
 
-- _Rust Analyzer:_ A fast and feature-packed language server integration that has been developed as successor to RLS.
+- _Rust Analyzer:_ A fast and feature-packed language server integration.
 - _CodeLLDB:_ Debugger based on LLDB, required to debug with the Rust Analyzer extension
 - _Better TOML and Crates:_ Support for `Cargo.toml` files and bumping dependency versions
 
-Recommended Rust Analyzer settings in your User's `settings.json`:
+Recommended Rust Analyzer settings in your project's `.vscode/settings.json`:
 
 ```jsx
 {
-  // Run full clippy lints instead of just cargo check
-  "rust-analyzer.checkOnSave.command": "clippy",
+  // Enable all features
+  "rust-analyzer.cargo.features": "all",
 
-  // If you don't like inline type annotations, this disables it
-  "rust-analyzer.inlayHints.enable": false,
+  // If you don't like inline type annotations, this disables it unless Ctrl + Alt is pressed.
+ "editor.inlayHints.enabled": "offUnlessPressed",
 
-  // To run automatic updates, if preferred
-  "rust-analyzer.updates.askBeforeDownload": false
+  // Import rules
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.prefix": "crate"
+}
 }
 ```
 
@@ -255,7 +273,7 @@ $ cargo insta test --review
 $ cargo insta reject --all
 ```
 
-## Configuring CI
+## Makefiles
 
 We use `Makefiles` to collect the most standard actions. A full Makefile for a workspace comprising multiple crates should roughly look like this (can be simplified):
 
@@ -279,7 +297,7 @@ test-all:
 
 style:
 	@rustup component add rustfmt --toolchain stable 2> /dev/null
-	cargo +stable fmt -- --check
+	cargo +stable fmt --all -- --check
 .PHONY: style
 
 lint:
@@ -289,11 +307,14 @@ lint:
 
 format:
 	@rustup component add rustfmt --toolchain stable 2> /dev/null
-	cargo +stable fmt
+	cargo +stable fmt --all
 .PHONY: format
-```
 
-Note that in CI, we **do not configure caches**, since those keep growing and are generally slower to download than just rebuilding.
+doc:
+	cargo doc --workspace --all-features --no-deps
+.PHONY: doc
+
+```
 
 ## Cargo Version Numbers
 
@@ -314,3 +335,13 @@ Before a 1.0 release is reached [anything goes according to the spec](https://se
 - Breaking changes require bumping the minor (Y) version.
 - New features bump the patch (Z) version.
 - Bugfix-only releases bump the patch (Z) version.
+
+## Further Reading
+
+- [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html)
+- [Rust Nomicon: The Dark Arts of Unsafe Rust](https://doc.rust-lang.org/nomicon/)
+- [Rust by Example: A comprehensive list of examples](https://doc.rust-lang.org/stable/rust-by-example/)
+- [Rust for Rustaceans: Idiomatic Programming for Experienced Developers](https://rust-for-rustaceans.com/)
+- [Rust in Action: Systems programming concepts and techniques](https://www.rustinaction.com/)
+- [Zero To Production In Rust: An introduction to backend development](https://www.zero2prod.com/)
+- [Rust Atomics and Locks](https://marabos.nl/atomics/)


### PR DESCRIPTION
Document Rust best practices at Sentry.

Note: This is an updated version of https://www.notion.so/sentry/HOWTO-Code-Rust-at-Sentry-7b35f165b10b4492bb95ebe1471a9ada.

The PR serves as a starting point to discuss which guidelines we want to keep and which ones we want to add.