### PR TITLE
feat(rust): Tweak imports for tooling

### DIFF
--- a/src/docs/rust.mdx
+++ b/src/docs/rust.mdx
@@ -105,10 +105,16 @@ In general, we follow the official Rust [Style Guidelines](https://doc.rust-lang
 
 Imports must be declared before any other code in the file, and can only be preceded by module doc comments and module attributes (`#![...]`). We bundle imports in groups based on their origin, each separated by an empty line. The order of imports is:
 
-1. Rust standard library, including `std`, `core` and `alloc`
-2. External & workspace dependencies
-3. Crate modules
-4. Re-exports (`pub use`)
+1. Rust standard library, comprising `std`, `core` and `alloc`
+2. External & workspace dependencies, including `pub use`
+3. Crate modules, comprising `self`, `super`, and `crate`
+
+This is equivalent to the following `rustfmt` configuration, which requires nightly:
+
+```toml
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"  # nightly only
+```
 
 **Example:**
 


### PR DESCRIPTION
Move public re-exports (`pub use`) to the group of external and workspace
dependencies. This makes it easier to auto-format imports with tooling, as this
is how `cargo fmt` would format imports with available options.

---

<img width="746" alt="image" src="https://user-images.githubusercontent.com/1433023/224658193-64f8b047-14f9-4749-bdfa-e790f3bd5bcd.png">

