### PR TITLE
Change `Cookies` to `Cookie` header

### DIFF
--- a/src/docs/sdk/data-handling.mdx
+++ b/src/docs/sdk/data-handling.mdx
@@ -17,7 +17,7 @@ Some examples of data guarded by this flag:
 
 - When attaching data of HTTP requests and/or responses to events
   - Request Body: "raw" HTTP bodies (bodies which cannot be parsed as JSON or formdata) are removed
-  - HTTP Headers: known sensitive headers such as `Authorization` or `Cookies` are removed too.
+  - HTTP Headers: known sensitive headers such as `Authorization` or `Cookie` are removed too.
   - _Note_ that if a user explicitly sets a request on the scope, nothing is stripped from that request. The above rules only apply to integrations that come with the SDK.
 - User-specific information (e.g. the current user ID according to the used web-framework) is not sent at all.
 - On desktop applications


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie the header is called `Cookie`.