### PR TITLE
feat: add source_link to stack trace frame

### DIFF
--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -90,6 +90,10 @@ Sentry shows the raw function when clicking on the shortened one in the UI.
 : A list of source code lines after `context_line` (in order) – usually
 `[lineno + 1:lineno + 5]`.
 
+`source_link`
+
+: An URL representing the source code, e.g. commit-specific GitHub raw source link.
+
 `in_app`
 
 : Signals whether this frame is related to the execution of the relevant code

--- a/src/docs/sdk/event-payloads/stacktrace.mdx
+++ b/src/docs/sdk/event-payloads/stacktrace.mdx
@@ -92,7 +92,8 @@ Sentry shows the raw function when clicking on the shortened one in the UI.
 
 `source_link`
 
-: An URL representing the source code, e.g. commit-specific GitHub raw source link.
+: A URL representing the source code, e.g. commit-specific GitHub raw source link:
+`https://raw.githubusercontent.com/getsentry/symbolicator/706d879a426a54230d91799a46a79376ffc86cf3/crates/symbolicator-service/src/types/mod.rs`
 
 `in_app`
 


### PR DESCRIPTION
Follows up on:

* https://github.com/getsentry/rfcs/pull/74
* https://github.com/getsentry/symbolicator/pull/1103