### PR TITLE
fix(config docs): Clarify description of default loggers

### DIFF
--- a/src/docs/config.mdx
+++ b/src/docs/config.mdx
@@ -68,7 +68,7 @@ sentry config generate-secret-key
 
 ## Logging
 
-Sentry logs to two major places — `stdout`, and its internal project. To disable logging to the internal project, add a logger whose only handler is `'console'` and disable propagating upwards.
+Sentry logs to two major places — `stdout`, and its internal project in Sentry. By default, all levels of logs are printed to the console, but only `error` level logs are captured and sent to Sentry. To disable logging to the internal project (in other words, to prevent the server's built-in SDK instance from sending events to Sentry), add a logger whose only handler is `'console'` and which has `propagate` set to `False`.
 
 <Alert level="warning">
 You will find the CLI flag and the environment variables related to logging below. They override the


### PR DESCRIPTION
Along with https://github.com/getsentry/sentry/pull/46149, this attempts to clarify some points which weren't obvious to me as I was learning about our logging setup.