### PR TITLE
Define ignore_errors & ignore_transactions

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -55,7 +55,7 @@ if random() < sample_rate:
     transport.capture_event(event)
 ```
 
-To further simplfiy ignoring certain events from being sent to sentry, it is also suggested to provide `ignoreTransactions` and `ignoreErrors` (or exception, choose terminology which is best for the platform). This option should provide a simple way to allow users to discard events (ignore) from before they are sent to sentry. Prevents sending data which is is undesired and may consume quota or resources on the Sentry server.
+To further simplfiy ignoring certain events from being sent to sentry, it is also suggested to provide `ignoreTransactions` and `ignoreErrors` (or exception, choose terminology which is best for the platform). The array for `ignoreTransactions` specifically should contain an array of transaction names, as is stored in the transcation event schema (ie `GET /info`). These options should provide a simple way to allow users to discard events (ignore) from before they are sent to sentry. Prevents sending data which is is undesired and may consume quota or resources on the Sentry server.
 
 ```python
 ignore_transactions = ['GET /api/health','/api/v1/*']

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -55,7 +55,7 @@ if random() < sample_rate:
     transport.capture_event(event)
 ```
 
-To further simplfiy ignoring certain events from being sent to sentry, it is also sugggested to provide `ignoreTransactions` and `ignoreErrors` (or exception, choose terminology which is best for the platform). This option should provide a simple way to allow users to discard events (ignore) from before they are sent to sentry. Prevents sending data which is is undesired and may consume quota or resources on the Sentry server.
+To further simplfiy ignoring certain events from being sent to sentry, it is also suggested to provide `ignoreTransactions` and `ignoreErrors` (or exception, choose terminology which is best for the platform). This option should provide a simple way to allow users to discard events (ignore) from before they are sent to sentry. Prevents sending data which is is undesired and may consume quota or resources on the Sentry server.
 
 ```python
 ignore_transactions = ['GET /api/health','/api/v1/*']

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -55,6 +55,12 @@ if random() < sample_rate:
     transport.capture_event(event)
 ```
 
+To further simplfiy ignoring certain events from being sent to sentry, it is also sugggested to provide `ignoreTransactions` and `ignoreErrors` (or exception, choose terminology which is best for the platform). This option should provide a simple way to allow users to discard events (ignore) from before they are sent to sentry. Prevents sending data which is is undesired and may consume quota or resources on the Sentry server.
+
+```python
+ignore_transactions = ['GET /api/health','/api/v1/*']
+```
+
 ## Rate Limiting
 
 Respect Sentry’s HTTP 429 `Retry-After` header, or, if the SDK supports multiple payload types (e.g. errors and transactions), the `X-Sentry-Rate-Limits` header. Outgoing SDK requests should be dropped during the backoff period.


### PR DESCRIPTION
### Background
With improved server side sampling Sentry attempts to already remove some transactions which do not provide value to the user. However this is a known case for many users for a long time. There is the traces sampler function, but the UX for this is bulky when you have a simple use case.

**Use case:** There transcations and errors which a users never wants sent to sentry, to appear in a feed or count against their quota.

**Proposal:** provide simple options which is a list of errors/exceptions and transactions, respectively, which the SDK will then always discard and never send to Sentry

**Preview:** [Event Sampling 
](https://develop-git-smeubank-define-ignore-options.sentry.dev/sdk/features/#event-sampling)
Similar implementations:
https://github.com/getsentry/sentry-php/pull/1503

JS `ignoreErrors`: [Manage Your Error Quota](https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#inboundfilters)