### PR TITLE
Add trace origin

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -175,7 +175,7 @@ export default () => {
             <SidebarLink to="/sdk/performance/span-data-conventions/">
               Span Data Conventions
             </SidebarLink>
-            <SidebarLink to="/sdk/performance/trace-and-span-origin/">
+            <SidebarLink to="/sdk/performance/trace-origin/">
               Trace and Span Origin
             </SidebarLink>
             <SidebarLink to="/sdk/performance/ui-event-transactions/">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -176,7 +176,7 @@ export default () => {
               Span Data Conventions
             </SidebarLink>
             <SidebarLink to="/sdk/performance/trace-origin/">
-              Trace and Span Origin
+              Trace Origin
             </SidebarLink>
             <SidebarLink to="/sdk/performance/ui-event-transactions/">
               UI Event Transactions

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -175,6 +175,9 @@ export default () => {
             <SidebarLink to="/sdk/performance/span-data-conventions/">
               Span Data Conventions
             </SidebarLink>
+            <SidebarLink to="/sdk/performance/trace-and-span-origin/">
+              Trace and Span Origin
+            </SidebarLink>
             <SidebarLink to="/sdk/performance/ui-event-transactions/">
               UI Event Transactions
             </SidebarLink>

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -677,7 +677,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 `origin`
 
-: _Optional_. The origin of the trace indicates what created the trace. For more details, see <Link to="/sdk/performance/trace-and-span-origin">trace and span origin</Link>.
+: _Optional_. The origin of the trace indicates what created the trace. For more details, see <Link to="/sdk/performance/trace-origin">trace origin</Link>.
 
 
 ### Example Trace Context

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -675,6 +675,11 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 - Example: `{ "trace_id": "12312012123120121231201212312012", "sample_rate": "1.0", "public_key": "93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316" },`
 
+`origin`
+
+: _Optional_. The origin of the trace indicates what created the trace. For more details, see <Link to="/sdk/performance/trace-and-span-origin">trace and span origin</Link>.
+
+
 ### Example Trace Context
 
 ```json
@@ -695,7 +700,8 @@ Additional information that allows Sentry to connect multiple transactions, span
         "trace_id": "12312012123120121231201212312012",
         "sample_rate": "1.0",
         "public_key": "93D0D1125146288EAEE2A9B3AF4F96CCBE3CB316"
-      }
+      },
+      "origin": "auto.http.http_client_5"
     }
   }
 }

--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -47,7 +47,7 @@ The semantic conventions for the `data` field are described in <Link to="/sdk/pe
 
 `origin`
 
-: _Optional_. The origin of the span indicates what created the span. For more details, see <Link to="/sdk/performance/trace-and-span-origin">trace and span origin</Link>.
+: _Optional_. The origin of the span indicates what created the span. For more details, see <Link to="/sdk/performance/trace-origin">trace origin</Link>.
 
 ## Examples
 

--- a/src/docs/sdk/event-payloads/span.mdx
+++ b/src/docs/sdk/event-payloads/span.mdx
@@ -45,6 +45,10 @@ The semantic conventions for the `data` field are described in <Link to="/sdk/pe
 }
 ```
 
+`origin`
+
+: _Optional_. The origin of the span indicates what created the span. For more details, see <Link to="/sdk/performance/trace-and-span-origin">trace and span origin</Link>.
+
 ## Examples
 
 The following example illustrates the Span as part of the [Transaction](/sdk/event-payloads/transaction/) and omits other attributes for simplicity.
@@ -69,7 +73,8 @@ The following example illustrates the Span as part of the [Transaction](/sdk/eve
         "status_code": 200,
         "type": "xhr",
         "method": "GET"
-      }
+      },
+      "origin": "auto.http"
     },
     {
       "trace_id": "1e57b752bc6e4544bbaa246cd1d05dee",

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -7,7 +7,7 @@ to tell whether the user or what precisely in the SDK created it. Origin solves 
 the <Link to="sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="sdk/event-payloads/span/">spans</Link>.
 
 
-The origin consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`
+The origin consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`.
 Only the first is mandatory. The parts build upon each other, meaning it is forbidden
 to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
 

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -55,6 +55,6 @@ Examples:
 
 ## See also:
 
-- <Link to="sdk/event-payloads/span/">Span Interface</Link>
-- <Link to="sdk/event-payloads/contexts/#trace-context">Trace Context</Link>
+- <Link to="/sdk/event-payloads/span/">Span Interface</Link>
+- <Link to="/sdk/event-payloads/contexts/#trace-context">Trace Context</Link>
 - Related [RFC](https://github.com/getsentry/rfcs/pull/73/);

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -7,23 +7,26 @@ to tell whether the user or what precisely in the SDK created it. Origin solves 
 the <Link to="sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="sdk/event-payloads/span/">spans</Link>.
 
 
-The origin consists of four parts.
-
-```
-<type>.<category>.<integration-name>.<integration-part>
-```
-
+The origin consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`
 Only the first is mandatory. The parts build upon each other, meaning it is forbidden
 to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
 
-`type`: _Required_: Can be either `manual` or `auto`. `manual` indicates that the user created the trace or span, `auto` indicates
+`type`
+
+: _Required_. Can be either `manual` or `auto`. `manual` indicates that the user created the trace or span, `auto` indicates
 that the SDK or some integration created it.
 
-`category`: _Optional_: Is the category of the trace or span, and it must be a category of <Link to="/sdk/performance/span-operations/#currently-used-categories">span operations</Link>. For example, `http`, `db`, `ui`, `navigation`, `file`, `browser`, `rpc`, etc.
+`category` 
 
-`integration-name`: _Optional_: Is the name of the integration of the SDK that created the trace or span. 
+: _Optional_. Is the category of the trace or span, and it must be a category of <Link to="/sdk/performance/span-operations/#currently-used-categories">span operations</Link>. For example, `http`, `db`, `ui`, `navigation`, `file`, `browser`, `rpc`, etc.
 
-`integration-part`: _Optional_: Is the part of the integration of the SDK that created the trace or span.
+`integration-name` 
+
+: _Optional_. Is the name of the integration of the SDK that created the trace or span. 
+
+`integration-part`
+
+: _Optional_. Is the part of the integration of the SDK that created the trace or span.
 
 
 All parts can only contain:

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -4,7 +4,7 @@ title: "Trace / Span Origin"
 
 Trace and span origin indicate what created a trace or a span. Not all traces and spans contain enough information
 to tell whether the user or what precisely in the SDK created it. Origin solves this problem. Origin can be sent with
-the <Link to="sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="sdk/event-payloads/span/">spans</Link>.
+the <Link to="/sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="/sdk/event-payloads/span/">spans</Link>.
 
 
 The origin consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`.

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Trace / Span Origin"
+title: "Trace and Span Origin"
 ---
 
 Trace and span origin indicate what created a trace or a span. Not all traces and spans contain enough information
@@ -7,7 +7,7 @@ to tell whether the user or what precisely in the SDK created it. Origin solves 
 the <Link to="/sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="/sdk/event-payloads/span/">spans</Link>.
 
 
-The origin consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`.
+The origin is of type `string` and consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`.
 Only the first is mandatory. The parts build upon each other, meaning it is forbidden
 to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
 
@@ -31,7 +31,7 @@ that the SDK or some integration created it.
 
 All parts can only contain:
 
-* Alphanumeric characters: `a - z` , `A - Z` , and `0 - 9`.
+* Alphanumeric characters: `a-z` , `A-Z` , and `0-9`.
 * Underscores: `_`
 
 

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -1,0 +1,55 @@
+---
+title: "Trace / Span Origin"
+---
+
+Trace and span origin indicate what created a trace or a span. Not all traces and spans contain enough information
+to tell whether the user or what precisely in the SDK created it. Origin solves this problem. Origin can be sent with
+the <Link to="sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="sdk/event-payloads/span/">spans</Link>.
+
+
+The origin consists of four parts. Only the first is mandatory. The parts build upon each other, meaning it is forbidden
+to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
+
+All parts can only contain:
+
+* Alphanumeric characters: `a - z` , `A - Z` , and `0 - 9`.
+* Underscores: `_`
+
+```
+<type>.<category>.<integration-name>.<integration-part>
+```
+
+`type`: _Required_: Can be either `manual` or `auto`. `manual` indicates that the user created the trace or span, `auto` indicates
+that the SDK or some integration created it.
+
+`category`: _Optional_: Is the category of the trace or span, and it must be a category of
+<Link to="/sdk/performance/span-operations/#currently-used-categories">span operations</Link>. For example, `http`, `db`, `ui`, `navigation`, `file`, `browser`, `rpc`, etc.
+
+`integration-name`: _Optional_: Is the name of the integration of the SDK that created the trace or span. 
+
+`integration-part`: _Optional_: Is the part of the integration of the SDK that created the trace or span.
+
+
+Examples:
+
+- `manual`
+- `auto`
+- `auto.file`
+- `auto.navigation`
+- `auto.app.start`
+- `auto.ui.swift_ui`
+- `auto.ui.view_controller`
+- `auto.ui.jetpack_compose`
+- `auto.ui.activity`
+- `auto.navigation.jetpack_compose`
+- `auto.http.okhttp`
+- `auto.http.http_client_5`
+- `auto.http.client.stream`
+- `auto.db.core_data`
+- `auto.db.graphql`
+
+## See also:
+
+- <Link to="sdk/event-payloads/span/">Span Interface</Link>
+- <Link to="sdk/event-payloads/contexts/#trace-context">Trace Context</Link>
+- Related [RFC](https://github.com/getsentry/rfcs/pull/73/);

--- a/src/docs/sdk/performance/trace-and-span-origin.mdx
+++ b/src/docs/sdk/performance/trace-and-span-origin.mdx
@@ -7,27 +7,29 @@ to tell whether the user or what precisely in the SDK created it. Origin solves 
 the <Link to="sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="sdk/event-payloads/span/">spans</Link>.
 
 
-The origin consists of four parts. Only the first is mandatory. The parts build upon each other, meaning it is forbidden
-to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
-
-All parts can only contain:
-
-* Alphanumeric characters: `a - z` , `A - Z` , and `0 - 9`.
-* Underscores: `_`
+The origin consists of four parts.
 
 ```
 <type>.<category>.<integration-name>.<integration-part>
 ```
 
+Only the first is mandatory. The parts build upon each other, meaning it is forbidden
+to skip one part. For example, you may send parts one and two but aren't allowed to send parts one and three without part two.
+
 `type`: _Required_: Can be either `manual` or `auto`. `manual` indicates that the user created the trace or span, `auto` indicates
 that the SDK or some integration created it.
 
-`category`: _Optional_: Is the category of the trace or span, and it must be a category of
-<Link to="/sdk/performance/span-operations/#currently-used-categories">span operations</Link>. For example, `http`, `db`, `ui`, `navigation`, `file`, `browser`, `rpc`, etc.
+`category`: _Optional_: Is the category of the trace or span, and it must be a category of <Link to="/sdk/performance/span-operations/#currently-used-categories">span operations</Link>. For example, `http`, `db`, `ui`, `navigation`, `file`, `browser`, `rpc`, etc.
 
 `integration-name`: _Optional_: Is the name of the integration of the SDK that created the trace or span. 
 
 `integration-part`: _Optional_: Is the part of the integration of the SDK that created the trace or span.
+
+
+All parts can only contain:
+
+* Alphanumeric characters: `a - z` , `A - Z` , and `0 - 9`.
+* Underscores: `_`
 
 
 Examples:

--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -35,7 +35,7 @@ All parts can only contain:
 * Underscores: `_`
 
 
-Examples:
+### Examples
 
 - `manual`
 - `auto`

--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Trace and Span Origin"
+title: "Trace Origin"
 ---
 
-Trace and span origin indicate what created a trace or a span. Not all traces and spans contain enough information
+Trace origin indicates what created a trace or a span. Not all traces and spans contain enough information
 to tell whether the user or what precisely in the SDK created it. Origin solves this problem. Origin can be sent with
 the <Link to="/sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="/sdk/event-payloads/span/">spans</Link>.
 


### PR DESCRIPTION
Add docs for trace origin being used for trace context and spans. Trace origin indicates what created a trace or a span.
Every SDK will benefit from trace origin. Therefore, I tagged also @getsentry/team-web-sdk-backend and @getsentry/team-web-sdk-frontend.

Related [RFC](https://github.com/getsentry/rfcs/pull/73)

[Visit docs preview](https://develop-git-feat-trace-and-span-origin.sentry.dev/sdk/performance/trace-origin/)