### PR TITLE
ref(integrations): Update instructions for installing Jira integration

### DIFF
--- a/src/docs/integrations/jira/index.mdx
+++ b/src/docs/integrations/jira/index.mdx
@@ -1,17 +1,26 @@
 ---
-title: "Jira Integration"
+title: 'Jira Integration'
 ---
 
-Create an [Atlassian Cloud Instance](http://go.atlassian.com/cloud-dev)
+Create an [Atlassian Cloud Developer Instance](http://go.atlassian.com/cloud-dev)
 
-Configure Jira settings.
-  1. Navigate to Jira settings (cog icon) > Apps > Manage apps.
-  2. Scroll to the bottom of the Manage apps page, and click Settings (1).
-  3. Select Enable development mode and Enable private listings (2), and click Apply.
+Atlassian offers a development-specific org option, different from simply having a personal Jira organization. Even if you already have a personal Jira org, it's worth creating a development org, because it will correctly set a number of necessary options for you automatically.
+
+Set Up ngrok
+
+(This is only necessary if you're developing locally.) [Download](https://ngrok.com/download) and [set up](https://ngrok.com/docs/getting-started/) ngrok, then start an ngrok server.
+
+Configure Jira Settings
+
+1. If you don't have any projects in your Jira org yet, create a new project.
+2. In the navigation bar at the top of the screen, go to Apps > Manage Your Apps.
+3. At the bottom of the Manage Apps page, click Settings (1).
+4. Select Enable Development Mode and Enable Private Listings (2), and click Apply.
 
 ![Jira Settings](./configure-jira.png)
 
-Upload the Atlassian Connect descriptor to Jira. It can be found at `{YOUR_DOMAIN}/extensions/jira/descriptor/`
+5. Reload the page, and Upload App should appear next to Build a New App.
+6. Click Upload App and upload the Atlassian Connect descriptor by using the URL  `https://{YOUR_SENTRY_DOMAIN}/extensions/jira/descriptor/`. Note that if you are running a local devserver, `YOUR_SENTRY_DOMAIN` will be your ngrok (or other tunneling service) domain.
 
 ![Upload Descriptor to Jira](./upload-descriptor.png)
 


### PR DESCRIPTION
This clarifies and expands upon the instructions for installing our Jira integration in the following ways:
- Explain that the Atlassian cloud instance is development-specific.
- Add section about installing ngrok, for folks developing locally.
- Clarify that the domain to use for the descriptor is the sentry domain, not the jira domain.

Note that the ngrok section is incomplete, insofar as it doesn't mention any of the changes you need to make to `sentry.conf.py`, but really that should probably go on its own page, which will have to be a separate PR. For the moment, the info is available in Notion.

Ref: WOR-2912