### PR TITLE
fix: Add dots to allowed chars for trace origins

### DIFF
--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -33,6 +33,7 @@ All parts can only contain:
 
 * Alphanumeric characters: `a-z` , `A-Z` , and `0-9`.
 * Underscores: `_`
+* Dots: `.`
 
 
 ### Examples


### PR DESCRIPTION
Dots are allowed for trace origins.

Came up when opening PR to Relay https://github.com/getsentry/relay/pull/1984.