### PR TITLE
ref(feature flags): Fix broken Flagr images and hover text

### DIFF
--- a/src/docs/feature-flags/index.mdx
+++ b/src/docs/feature-flags/index.mdx
@@ -214,7 +214,7 @@ right of the **Create New Flag** button and select **Create Simple Boolean
 Flag**. The flag's description is only used for easy finding of your flag on the
 Flagr homepage, but it is the `Flag Key` that the API uses to find your flag.
 
-![img/flagrNewFlag.png](img/flagrNewFlag.png)
+![create a new feature flag](../img/flagrNewFlag.png)
 
 You should then see your newly created flag in the list below, click your flag
 and enter your feature name as the flag key, optionally enter notes about your
@@ -226,7 +226,7 @@ up.
 Each flag defaults to disabled, and your feature will not appear until you
 enable it, this is done via the toggle at the top right of the flag page.
 
-![img/flagrDescription.png](img/flagrDescription.png)
+![fill out the flag description](../img/flagrDescription.png)
 
 In Flagr your feature needs a Variant and at least one Segment.
 
@@ -335,7 +335,7 @@ the condition property to `organization_slug`, the operator to `IN`, and the
 value to an array of organizations, using square brackets `[]` for the array, and
 double quotes `"` for each organization.
 
-![img/flagrOrganizationSubset.png](img/flagrOrganizationSubset.png)
+![enable organization subset](../img/flagrOrganizationSubset.png)
 
 ### Releasing a feature to a specific team
 
@@ -346,7 +346,7 @@ by setting the condition property to `team_slugs`, the operator to
 `organization_slug` or `organization_id`. If this isn't included, any org that has the same team name will get the
 feature.
 
-![img/flagrTeamSubset.png](img/flagrTeamSubset.png)
+![enable team subset](../img/flagrTeamSubset.png)
 
 ### Releasing a feature to Early Adopters
 
@@ -354,7 +354,7 @@ You can enable a feature to organizations that have opted in to be early
 adopters. To do this set the constraint property to
 `organization_is-early-adopter`, the operator to `==`, and the value to `true`.
 
-![img/flagrEarlyAdopterSubset.png](img/flagrEarlyAdopterSubset.png)
+![enable early adopter subset](../img/flagrEarlyAdopterSubset.png)
 
 ### Releasing a feature to organizations with specific plans
 
@@ -371,7 +371,7 @@ use:
 * `subscription_plan` This property is deprecated and should not be used in new
   feature flags.
 
-![img/flagrPlanSubset.png](img/flagrPlanSubset.png)
+![enable plan subset](../img/flagrPlanSubset.png)
 
 ### Releasing to organizations incrementally
 


### PR DESCRIPTION
Fix the image path for all the images on the Flagr docs, plus put hover text where it is supposed to be.