### PR TITLE
Clarify SDKs set trace origin automatically

### DIFF
--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -5,6 +5,7 @@ title: "Trace Origin"
 Trace origin indicates what created a trace or a span. Not all traces and spans contain enough information
 to tell whether the user or what precisely in the SDK created it. Origin solves this problem. Origin can be sent with
 the <Link to="/sdk/event-payloads/contexts/#trace-context">trace context</Link> or <Link to="/sdk/event-payloads/span/">spans</Link>.
+The SDKs should set this value automatically. It is not expected to be set manually by users.
 
 
 The origin is of type `string` and consists of four parts: `<type>.<category>.<integration-name>.<integration-part>`.


### PR DESCRIPTION
The SDKs should set this trace origin automatically. It is not expected to be set manually by users.