### PR TITLE
chore(docs): Remove comment about github app already configured in ge…

### DIFF
--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -4,7 +4,7 @@ title: "GitHub Integration"
 
 ## Create a GitHub App
 
-To configure the GitHub integration you'll need to create a GitHub app and obtain credentials. If you're developing within `getsentry` a set of development credentials are already configured.
+To configure the GitHub integration you'll need to create a GitHub app and obtain credentials.
 
 <Alert level="warning">
   The GitHub App name must not contain any spaces.


### PR DESCRIPTION
…tsentry

This does not work, you need to configure your own github app for this.