### PR TITLE
Fix programming language for sentry.conf.py block

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -309,7 +309,7 @@ sentry devserver --workers --ingest
 
 If you want to enable the entire metrics ingestion pipeline, you need to add
 
-```shell
+```python
 SENTRY_USE_METRICS_DEV=True
 SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
 ```


### PR DESCRIPTION
Code block for ingest settings used `shell` and was therefore highlighted incorrectly - this block is actually Python code (goes into ~/.sentry/sentry.conf.py).