### PR TITLE
Clarify manual trace origins

### DIFF
--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -54,6 +54,14 @@ All parts can only contain:
 - `auto.db.core_data`
 - `auto.db.graphql`
 
+Origins of type `manual` can also have categories and integration names. For example, for the
+<Link to="/sdk/performance/time-to-initial-full-display/">time to display feature</Link>, the user manually calls an API  of the SDK,
+creating a span. In this case, the SDK can tell what created the span, but the user did it manually. On the other hand, the SDK also
+automatically creates a span. In this case we end up with the following origins:
+
+- `manual.ui.time_to_display`
+- `auto.ui.time_to_display`
+
 ## See also:
 
 - <Link to="/sdk/event-payloads/span/">Span Interface</Link>


### PR DESCRIPTION
Add an example for manual trace origins having a category and an integration name.