### PR TITLE
feat(perf-issues): Convert Body Size params into snake_case forms

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -26,12 +26,12 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Browser
 
-| Attribute                          | Type   | Description                                 | Examples              |
-| ---------------------------------- | ------ | ------------------------------------------- | --------------------- |
-| `url`                              | string | The URL of the resource that was fetched.   | `https://example.com` |
-| `method`                           | string | The HTTP method used.                       | `GET`                 |
-| `type`                             | string | The type of the resource that was fetched.  | `xhr`                 |
-| `Encoded Body Size`                | number | The encoded body size of the request.       | `123`                 |
-| `Decoded Body Size`                | number | The decoded body size of the request.       | `456`                 |
-| `Transfer Size`                    | number | The transfer size of the request.           | `789`                 |
-| `resource.render_blocking_status`  | string | The render blocking status of the resource. | `non-blocking`        |
+| Attribute                              | Type   | Description                                 | Examples              |
+| -------------------------------------- | ------ | ------------------------------------------- | --------------------- |
+| `url`                                  | string | The URL of the resource that was fetched.   | `https://example.com` |
+| `method`                               | string | The HTTP method used.                       | `GET`                 |
+| `type`                                 | string | The type of the resource that was fetched.  | `xhr`                 |
+| `http.encoded_response_content_length` | number | The encoded body size of the request.       | `123`                 |
+| `http.decoded_response_content_length` | number | The decoded body size of the request.       | `456`                 |
+| `http.transfer_size`                   | number | The transfer size of the request.           | `789`                 |
+| `resource.render_blocking_status`      | string | The render blocking status of the resource. | `non-blocking`        |

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -31,7 +31,8 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `url`                                  | string | The URL of the resource that was fetched.   | `https://example.com` |
 | `method`                               | string | The HTTP method used.                       | `GET`                 |
 | `type`                                 | string | The type of the resource that was fetched.  | `xhr`                 |
-| `http.encoded_response_content_length` | number | The encoded body size of the request.       | `123`                 |
-| `http.decoded_response_content_length` | number | The decoded body size of the request.       | `456`                 |
-| `http.transfer_size`                   | number | The transfer size of the request.           | `789`                 |
+| `http.response_content_length`         | number | The content length of the response.         | `123`                 |   
+| `resource.encoded_body_size`           | number | The encoded body size of the request.       | `123`                 |
+| `resource.decoded_body_size`           | number | The decoded body size of the request.       | `456`                 |
+| `resource.transfer_size`               | number | The transfer size of the request.           | `789`                 |
 | `resource.render_blocking_status`      | string | The render blocking status of the resource. | `non-blocking`        |


### PR DESCRIPTION
We're proposing to change the names of these non-standard keys ("Encoded Body Size", "Decoded Body Size", and "Transfer Size") to be more aligned with OTel's standards. A [spec doc here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes) references `http.response_content_length`, which I am adding for the Giant Payload detector, but I am using `resource.encoded_body_size` and `resource.decoded_body_size` for the old values.