### PR TITLE
Remove dots from trace origin allowed chars

### DIFF
--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -34,7 +34,6 @@ All parts can only contain:
 
 * Alphanumeric characters: `a-z` , `A-Z` , and `0-9`.
 * Underscores: `_`
-* Dots: `.`
 
 
 ### Examples


### PR DESCRIPTION
Remove dots from allowed chars for the parts of trace origins, so we can split up the trace origin into it's original parts.