### PR TITLE
feat: Add conventions for http.method and db.operation

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -12,11 +12,14 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## HTTP
 
-| Attribute       | Type   | Description                          | Examples           |
-| --------------- | ------ | ------------------------------------ | ------------------ |
-| `http.query`    | string | The Query string present in the URL. | `?foo=bar&bar=baz` |
-| `http.fragment` | string | The Fragments present in the URL.    | `#foo=bar`         |
-| `http.method`   | string | The HTTP method used.                | `GET`              |
+| Attribute                          | Type   | Description                                                          | Examples           |
+| ---------------------------------- | ------ | -------------------------------------------------------------------- | ------------------ |
+| `http.query`                       | string | The Query string present in the URL.                                 | `?foo=bar&bar=baz` |
+| `http.fragment`                    | string | The Fragments present in the URL.                                    | `#foo=bar`         |
+| `http.method`                      | string | The HTTP method used. (formerly was called `method`)                 | `GET`              |
+| `http.request_content_length`      | number | The encoded body size of the request. (Formerly `Encoded Body Size`) | `123`              |
+| `http.decoded_request_body_length` | number | The decoded body size of the request. (Formerly `Decoded Body Size`) | `456`              |
+| `http.transfer_size`               | number | The transfer size of the request. (Formerly `Transfer Size`)         | `789`              |
 
 ## Mobile
 
@@ -27,15 +30,11 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Browser
 
-| Attribute                           | Type   | Description                                                          | Examples              |
-| ----------------------------------- | ------ | -------------------------------------------------------------------- | --------------------- |
-| `url`                               | string | The URL of the resource that was fetched.                            | `https://example.com` |
-| `method`                            | string | The HTTP method used.                                                | `GET`                 |
-| `type`                              | string | The type of the resource that was fetched.                           | `xhr`                 |
-| `http.request_content_length`       | number | The encoded body size of the request. (Formerly `Encoded Body Size`) | `123`                 |
-| `http.decoded_request_body_length`  | number | The decoded body size of the request. (Formerly `Decoded Body Size`) | `456`                 |
-| `http.transfer_size`                | number | The transfer size of the request.     (Formerly `Transfer Size`)     | `789`                 |
-| `resource.render_blocking_status`   | string | The render blocking status of the resource.                          | `non-blocking`        |
+| Attribute                         | Type   | Description                                 | Examples              |
+| --------------------------------- | ------ | ------------------------------------------- | --------------------- |
+| `url`                             | string | The URL of the resource that was fetched.   | `https://example.com` |
+| `type`                            | string | The type of the resource that was fetched.  | `xhr`                 |
+| `resource.render_blocking_status` | string | The render blocking status of the resource. | `non-blocking`        |
 
 ## Database
 

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -16,6 +16,7 @@ Below describes the conventions for the Span interface for the `data` field on t
 | --------------- | ------ | ------------------------------------ | ------------------ |
 | `http.query`    | string | The Query string present in the URL. | `?foo=bar&bar=baz` |
 | `http.fragment` | string | The Fragments present in the URL.    | `#foo=bar`         |
+| `http.method`   | string | The HTTP method used.                | `GET`              |
 
 ## Mobile
 
@@ -38,9 +39,10 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Database
 
-| Attribute   | Type   | Description                                                                                                                                                                                                                                                                                                            | Examples     |
-| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `db.system` | string | An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs for a list of well-known identifiers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem). | `postgresql` |
+| Attribute      | Type   | Description                                                                                                                                                                                                                                                                                                                | Examples     |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `db.system`    | string | An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs for a list of well-known identifiers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).     | `postgresql` |
+| `db.operation` | string | The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword. Based on [OpenTelemetry's call level db attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes) | `SELECT`     |
 
 ## Web Server
 

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -12,14 +12,14 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## HTTP
 
-| Attribute                          | Type   | Description                                                          | Examples           |
-| ---------------------------------- | ------ | -------------------------------------------------------------------- | ------------------ |
-| `http.query`                       | string | The Query string present in the URL.                                 | `?foo=bar&bar=baz` |
-| `http.fragment`                    | string | The Fragments present in the URL.                                    | `#foo=bar`         |
-| `http.method`                      | string | The HTTP method used. (formerly was called `method`)                 | `GET`              |
-| `http.request_content_length`      | number | The encoded body size of the request. (Formerly `Encoded Body Size`) | `123`              |
-| `http.decoded_request_body_length` | number | The decoded body size of the request. (Formerly `Decoded Body Size`) | `456`              |
-| `http.transfer_size`               | number | The transfer size of the request. (Formerly `Transfer Size`)         | `789`              |
+| Attribute                          | Type   | Description                           | Examples           |
+| ---------------------------------- | ------ | ------------------------------------- | ------------------ |
+| `http.query`                       | string | The Query string present in the URL.  | `?foo=bar&bar=baz` |
+| `http.fragment`                    | string | The Fragments present in the URL.     | `#foo=bar`         |
+| `http.method`                      | string | The HTTP method used.                 | `GET`              |
+| `http.request_content_length`      | number | The encoded body size of the request. | `123`              |
+| `http.decoded_request_body_length` | number | The decoded body size of the request. | `456`              |
+| `http.transfer_size`               | number | The transfer size of the request.     | `789`              |
 
 ## Mobile
 
@@ -48,3 +48,14 @@ Below describes the conventions for the Span interface for the `data` field on t
 | Attribute   | Type    | Description                            | Examples |
 | ----------- | ------- | -------------------------------------- | -------- |
 | `cache.hit` | boolean | If the cache was hit during this span. | `true`   |
+
+### Deprecated
+
+Names that SDKs are still sending so we cannot remove them yet, but should not be used in new code.
+
+| Attribute           | New name                           |
+| ------------------- | ---------------------------------- |
+| `method`            | `http.method`                      |
+| `Encoded Body Size` | `http.request_content_length`      |
+| `Decoded Body Size` | `http.decoded_request_body_length` |
+| `Transfer Size`     | `http.transfer_size `              |


### PR DESCRIPTION
- Add `http.method`
- Add `db.operation`
- Re-organize sections
- Explicitly add deprecated conventions (need to list since SDKs still send).