### PR TITLE
Add SDK field to check-ins

### DIFF
--- a/src/docs/sdk/check-ins.mdx
+++ b/src/docs/sdk/check-ins.mdx
@@ -15,7 +15,11 @@ of a JSON payload that looks roughly like this:
   "status": "in_progress",
   "duration": 10.0,
   "release": "1.0.0",
-  "environment": "production"
+  "environment": "production",
+  "sdk": {
+    "name": "sentry.javascript.node",
+    "version": "7.52.0"
+  }
 }
 ```
 The following fields exist:
@@ -47,6 +51,12 @@ The following fields exist:
 `environment`
 
 : _String, optional_. The environment.
+
+`sdk`
+
+: _Object, optional_. Information about the SDK that sent this check-in.
+
+Contains two required string values: `name` and `version`. See the [SDK Interface documentation](./event-payloads/sdk.mdx) for more details. Unlike the SDK interface that events use, the `integrations` and `packages` fields should not be set.
 
 ## Monitor upsert support
 


### PR DESCRIPTION
Aligns docs with Relay.

See https://github.com/getsentry/relay/blob/dd93441bbb607dba806c6f1ca0c03783e348f048/relay-monitors/src/lib.rs#L129