### PR TITLE
Update span-data-conventions for HTTP.status_code

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -17,7 +17,7 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `http.query`                        | string | The Query string present in the URL.   | `?foo=bar&bar=baz` |
 | `http.fragment`                     | string | The Fragments present in the URL.      | `#foo=bar`         |
 | `http.method`                       | string | The HTTP method used.                  | `GET`              |
-| `http.status_code`                  | string | The status HTTP resposne.              | `404`              |
+| `http.status_code`                  | string | The status HTTP response.              | `404`              |
 | `http.response_content_length`      | number | The encoded body size of the response. | `123`              |
 | `http.decoded_response_body_length` | number | The decoded body size of the response. | `456`              |
 | `http.response_transfer_size`       | number | The transfer size of the response.     | `789`              |

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -17,6 +17,7 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `http.query`                        | string | The Query string present in the URL.   | `?foo=bar&bar=baz` |
 | `http.fragment`                     | string | The Fragments present in the URL.      | `#foo=bar`         |
 | `http.method`                       | string | The HTTP method used.                  | `GET`              |
+| `http.status_code`                  | string | The status HTTP resposne.              | `404`              |
 | `http.response_content_length`      | number | The encoded body size of the response. | `123`              |
 | `http.decoded_response_body_length` | number | The decoded body size of the response. | `456`              |
 | `http.response_transfer_size`       | number | The transfer size of the response.     | `789`              |


### PR DESCRIPTION
Per https://github.com/getsentry/team-webplatform-meta/issues/65 we want to define where HTTP status codes should be stored in events (200, 404, 500, etc)

Reasoning for why it is a problem, is that SDKs generally should not set tags "for" users on events.