### PR TITLE
OTel Semantic convention

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -17,7 +17,7 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `http.query`                        | string | The Query string present in the URL.   | `?foo=bar&bar=baz` |
 | `http.fragment`                     | string | The Fragments present in the URL.      | `#foo=bar`         |
 | `http.method`                       | string | The HTTP method used.                  | `GET`              |
-| `http.status_code`                  | string | The status HTTP response.              | `404`              |
+| `http.response.status_code`         | int    | The status HTTP response.              | `404`              |
 | `http.response_content_length`      | number | The encoded body size of the response. | `123`              |
 | `http.decoded_response_body_length` | number | The decoded body size of the response. | `456`              |
 | `http.response_transfer_size`       | number | The transfer size of the response.     | `789`              |


### PR DESCRIPTION
https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#status