### PR TITLE
`App ID` placeholder cause confusion.

### DIFF
--- a/src/docs/self-hosted/sso.mdx
+++ b/src/docs/self-hosted/sso.mdx
@@ -85,7 +85,7 @@ You will then need to set the following configuration values:
 In [`sentry/sentry.conf.py`](https://github.com/getsentry/self-hosted/blob/master/sentry/sentry.conf.example.py)
 
 ```python
-GITHUB_APP_ID="<App ID>"
+GITHUB_APP_ID="<Client ID>"
 GITHUB_API_SECRET="<Client secret>"
 GITHUB_REQUIRE_VERIFIED_EMAIL = True  # Optional but recommended
 


### PR DESCRIPTION
It works with Client ID for me (latest `self-hosted` commit)