### PR TITLE
ref(integrations): Add Heroku docs to sidebar

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -252,6 +252,7 @@ export default () => {
           <SidebarLink to="/integrations/bitbucket/">Bitbucket</SidebarLink>
           <SidebarLink to="/integrations/github/">GitHub</SidebarLink>
           <SidebarLink to="/integrations/gitlab/">GitLab</SidebarLink>
+          <SidebarLink to="/integrations/heroku/">Heroku</SidebarLink>
           <SidebarLink to="/integrations/jira/">Jira</SidebarLink>
           <SidebarLink to="/integrations/jira-server/">Jira Server</SidebarLink>
           <SidebarLink to="/integrations/msteams/">Microsoft Teams</SidebarLink>


### PR DESCRIPTION
Realized I forgot to add the Heroku docs to the sidebar in https://github.com/getsentry/develop/pull/827