### PR TITLE
docs(api): Update api instructions

### DIFF
--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -127,7 +127,10 @@ Specify the parameters using a list, and a serializer if needed.
 Specify the request and response serializers.
 
 - Request serializers, since they use DRF serializers, can generally just be the serializer itself. There is plenty of customization and if needed can be overriden with `inline_serializer`. These will be passed to the `request` parameter in `extend_schema`.
-- For our response serializers, you must type the `serialize` function's return with a `TypedDict` pass the serializer as a parameter in `extend_schema`. See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/organization_member/scim.py) for an example of this.
+- For our response serializers, you must type the `serialize` function's return with a `TypedDict`
+  and pass the serializer as a parameter in `extend_schema`. See
+  [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/organization_member/scim.py)
+  for an example of this.
 - If the response is a wrapper or you need more customization, you can use the `inline_sentry_response_serializer` function.
 
 ```python
@@ -142,7 +145,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
   }
 )
 ```
-
+ Updating one request and you must update both of them in the same PR
 - Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
 Examples can be directly inserted using `OpenApiExample`, and multiple can be provided. If needed,

--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -103,22 +103,20 @@ For the rest of the documentation, we'll use `@extend_schema` on the various end
 
 ```python
 @extend_schema(
-  operation_id="Retrieve an Organization's details", # What goes in the doc sidebar for the name of the API page
-  parameters=[GLOBAL_PARAMS.ORG_SLUG, SCIMQueryParamSerializer], # use the global params, and/or a DRF Serializer
-  request=None, # this will usually be a DRF Serializer if the endpoint takes a body
+  operation_id="Create a New Team", # What goes in the doc sidebar for the name of the API page
+  parameters=[GlobalParams.ORG_SLUG, SCIMQueryParamSerializer], # use the global params, and/or a DRF Serializer
+  request=TeamPostSerializer, # this will usually be a DRF Serializer if the endpoint takes a body
   responses={
-            200: OrganizationSerializer, # The Sentry response serializer
-            401: RESPONSE_UNAUTHORIZED,
-            403: RESPONSE_FORBIDDEN,
-            404: RESPONSE_NOTFOUND,
-        },
-  examples=[OpenApiExample()], # see the link to an existing documented endpoint below for how to define an example
+      201: TeamSerializer, # the Sentry Response Serializer
+      400: RESPONSE_BAD_REQUEST,
+      403: RESPONSE_FORBIDDEN,
+      404: OpenApiResponse(description="A team with this slug already exists."),
+  },
+  examples=TeamExamples.CREATE_TEAM, # use examples defined in `src/sentry/apidocs/examples`
 )
-def get(self,request, organization):
+def post(self, request: Request, organization, member, team_slug: str,) -> Response:
   pass
 ```
-
-Examples can be directly inserted using `OpenApiExample`, and multiple can be provided.
 
 Specify an `operation_id` (this is what is shown as the title under the docs site sidebar).
 
@@ -142,13 +140,34 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
       List[OrganizationSerializerResponse])
       # A common use case is to return a list of serialized items
   }
+)
 ```
-
 - Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
-See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/scim/endpoints/members.py) for an example of an endpoint documented using drf-spectacular, and the [drf-spectacular docs here](https://drf-spectacular.readthedocs.io/en/latest/) to learn more.
 
-**Note that if the endpoint you're modifying previously had JSON documentation, you will need to delete the old documentation found in [this file](https://github.com/getsentry/sentry/blob/master/api-docs/openapi.json)**
+Examples can be directly inserted using `OpenApiExample`, and multiple can be provided. If needed,
+create new examples in `src/sentry/apidocs/examples/**` under the appropriate folder.
+```python
+from drf_spectacular.types import OpenApiExample
+
+class TeamExamples:
+  CREATE_TEAM = [
+      OpenApiExample(
+          "Create a new team", # description of example
+          value={"slug": "my-team", "name": "My Team"}, # response body, can be a dict or list
+          status_codes=["201"], # the status code(s) this example applies to
+          response_only=True, # You MUST include this for all examples!!!
+      )
+  ]
+```
+
+See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_teams.py) for an example of an endpoint documented using drf-spectacular, and the [drf-spectacular docs here](https://drf-spectacular.readthedocs.io/en/latest/) to learn more.
+
+**Note that if the endpoint you're modifying previously had JSON documentation, you will need to
+delete the old documentation path found in [this
+file](https://github.com/getsentry/sentry/blob/master/api-docs/openapi.json) along with its
+corresponding JSON build in [this
+folder](https://github.com/getsentry/sentry/blob/master/api-docs/paths)**
 
 Write a test [here](https://github.com/getsentry/sentry/tree/master/tests/apidocs).
 

--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Making an API Public"
+title: 'Making an API Public'
 ---
 
 ## Introduction
@@ -127,7 +127,7 @@ Specify the parameters using a list, and a serializer if needed.
 Specify the request and response serializers.
 
 - Request serializers, since they use DRF serializers, can generally just be the serializer itself. There is plenty of customization and if needed can be overriden with `inline_serializer`. These will be passed to the `request` parameter in `extend_schema`.
-- For our response serializers, you must type the `serialize` function's return with a `TypedDict` and pass the serializer as a parameter in `extend_schema`. See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/organization_member/scim.py) for an example of this.
+- For our response serializers, you must type the `serialize` function's return with a `TypedDict` pass the serializer as a parameter in `extend_schema`. See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/organization_member/scim.py) for an example of this.
 - If the response is a wrapper or you need more customization, you can use the `inline_sentry_response_serializer` function.
 
 ```python
@@ -142,11 +142,12 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
   }
 )
 ```
-- Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
+- Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
 Examples can be directly inserted using `OpenApiExample`, and multiple can be provided. If needed,
 create new examples in `src/sentry/apidocs/examples/**` under the appropriate folder.
+
 ```python
 from drf_spectacular.types import OpenApiExample
 
@@ -154,9 +155,9 @@ class TeamExamples:
   CREATE_TEAM = [
       OpenApiExample(
           "Create a new team", # description of example
-          value={"slug": "my-team", "name": "My Team"}, # response body, can be a dict or list
+          value={"slug": "my-team", "name": "My Team"}, # response body
           status_codes=["201"], # the status code(s) this example applies to
-          response_only=True, # You MUST include this for all examples!!!
+          response_only=True, # You MUST INCLUDE this for all examples!!!
       )
   ]
 ```
@@ -167,9 +168,12 @@ See [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoi
 delete the old documentation path found in [this
 file](https://github.com/getsentry/sentry/blob/master/api-docs/openapi.json) along with its
 corresponding JSON build in [this
-folder](https://github.com/getsentry/sentry/blob/master/api-docs/paths)**
+folder](https://github.com/getsentry/sentry/blob/master/api-docs/paths).**
 
-Write a test [here](https://github.com/getsentry/sentry/tree/master/tests/apidocs).
+**Additionally if there are multiple request types in the same endpoint using the old documentation
+(eg: both `GET`+`POST`), you must update both of them in the same PR. Updating only one request and
+deleting the documentation path/JSON will cause the other unedited request to disappear from the
+docs.**
 
 **Tips**:
 

--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -149,7 +149,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 - Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
 Examples can be directly inserted using `OpenApiExample`, and multiple can be provided. If needed,
-create new examples in `src/sentry/apidocs/examples/**` under the appropriate folder.
+create new examples in `src/sentry/apidocs/examples/*.py` in the appropriate file.
 
 ```python
 from drf_spectacular.types import OpenApiExample
@@ -173,8 +173,8 @@ file](https://github.com/getsentry/sentry/blob/master/api-docs/openapi.json) alo
 corresponding JSON build in [this
 folder](https://github.com/getsentry/sentry/blob/master/api-docs/paths).**
 
-**Additionally if there are multiple request types in the same endpoint using the old documentation
-(eg: both `GET`+`POST`), you must update both of them in the same PR. Updating only one request and
+**Additionally if there are multiple request types in the same endpoint using the old JSON
+documentation, you must update both of them in the same PR. Updating only one request and
 deleting the documentation path/JSON will cause the other unedited request to disappear from the
 docs.**
 

--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -145,7 +145,6 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
   }
 )
 ```
- Updating one request and you must update both of them in the same PR
 - Note that you can instead provide OpenAPI JSON, so you can fall back to this if you are running into issues.
 
 Examples can be directly inserted using `OpenApiExample`, and multiple can be provided. If needed,


### PR DESCRIPTION
Update `Making an API Public` section with more recent `@extend_schema` example, new `OpenApiExample` that includes `request_only=True` addition, and warning to update all requests in one endpoint in the same PR if multiple requests in the endpoint previously used manual JSON build.