### PR TITLE
feat: Add more Mobile Span Data Conventions

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -24,10 +24,12 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 ## Mobile
 
-| Attribute             | Type         | Description                                                                                                                                                                                                | Examples |
-| --------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `blocked_main_thread` | boolean      | Whether the main thread was blocked by the span.                                                                                                                                                           | `true`   |
-| `call_stack`          | StackFrame[] | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |          |
+| Attribute             | Type         | Description                                                                                                                                                                                                | Examples              |
+| --------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `blocked_main_thread` | boolean      | Whether the main thread was blocked by the span.                                                                                                                                                           | `true`                |
+| `call_stack`          | StackFrame[] | The most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. |                       |
+| `url`                 | string       | The URL of the resource that was fetched.                                                                                                                                                                  | `https://example.com` |
+| `type`                | string       | More granular type of the operation happening.                                                                                                                                                             | `fetch`               |
 
 ## Browser
 


### PR DESCRIPTION
Added `url` and `type` for Span Data Conventions under mobile group.

Related to https://github.com/getsentry/sentry-cocoa/issues/2393