### PR TITLE
Mention default value for op can be usesd in SDKs as well

### DIFF
--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -16,7 +16,7 @@ It's important to keep categories consistent between SDKs and integrations as th
 
 The following tables contain examples of operations used by the SDKs and Sentry product. The usage column in the table contains examples of using that operation category, but are not hard recommendations for operation usage. As long as categories stay consistent, SDK developers are free to choose actions and identifiers that best match the use case they are instrumenting.
 
-If a span operation is not provided, the value of `default` is set by Relay. The value `default` can also be set by SDKs, for example to avoid breaking code when no longer requiring `op` to be set on `TransactionContext`.
+If a span operation is not provided, the value of `default` is set by Relay. The value `default` can also be set by SDKs, for example, to avoid breaking changes when no longer requiring `op` to be set on `TransactionContext`.
 
 ## General
 

--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -16,7 +16,7 @@ It's important to keep categories consistent between SDKs and integrations as th
 
 The following tables contain examples of operations used by the SDKs and Sentry product. The usage column in the table contains examples of using that operation category, but are not hard recommendations for operation usage. As long as categories stay consistent, SDK developers are free to choose actions and identifiers that best match the use case they are instrumenting.
 
-If a span operation is not provided, the value of `default` is set by Relay.
+If a span operation is not provided, the value of `default` is set by Relay. The value `default` can also be set by SDKs, for example to avoid breaking code when no longer requiring `op` to be set on `TransactionContext`.
 
 ## General
 


### PR DESCRIPTION
When implementing Tracing without Performance we may need to get rid of a required `op` when creating a `TransactionContext` in `Sentry.continueTrace` in some SDKs (e.g. Java). This mentions that we can use an `op` of `default` in such cases.