### PR TITLE
Fix typo: Removed an extra 'the' in index.mdx file

### DIFF
--- a/src/docs/frontend/index.mdx
+++ b/src/docs/frontend/index.mdx
@@ -12,7 +12,7 @@ The frontend codebase is currently located under `static/app` in sentry and `sta
 
 ### File Naming
 
-- Name a file meaningfully, based on the how the module's functions, or classes are used or the application section they are used in.
+- Name a file meaningfully, based on how the module's functions, or classes are used or the application section they are used in.
 - Unless necessary, don't use prefixes or suffixes (ie. `dataScrubbingEditModal`, `dataScrubbingAddModal`) instead favor names like `dataScrubbing/editModal`.
 
 ### Using `index.(j|t)sx?$`


### PR DESCRIPTION
![Screenshot 2023-06-24 155152](https://github.com/getsentry/develop/assets/30874952/7ac47a34-eb5e-4cb6-a7c4-454c17541303)
