### PR TITLE
docs(sdk): Add insufficient_data reason for client discard

### DIFF
--- a/src/docs/sdk/client-reports.mdx
+++ b/src/docs/sdk/client-reports.mdx
@@ -100,6 +100,7 @@ The following discard reasons are currently defined for `discarded_events`:
 - `event_processor`: an event was dropped by an event processor; may also be used for ignored exceptions / errors
 - `send_error`: an event was dropped because of an error when sending it (eg: 400 response)
 - `internal_sdk_error`: an event was dropped due to an internal SDK error (eg: web worker crash)
+- `insufficient_data`: an event was dropped due to a lack of data in the event (eg: not enough samples in a profile)
 
 In case a reason needs to be added,
 it also has to be added to the allowlist in [snuba](https://github.com/getsentry/snuba/blob/4e7cfdddcf7b93eacb762bc74ca2461cec9464e5/snuba/datasets/outcomes_processor.py#L24-L34).


### PR DESCRIPTION
Mention new insufficient_data reason for client discard introduced in getsentry/snuba#4407.