### PR TITLE
feat(crons): Add trace_id and config to check-in payload

### DIFF
--- a/src/docs/sdk/check-ins.mdx
+++ b/src/docs/sdk/check-ins.mdx
@@ -16,15 +16,6 @@ of a JSON payload that looks roughly like this:
   "duration": 10.0,
   "release": "1.0.0",
   "environment": "production",
-  "monitor_config": {
-    "schedule": {
-      "type": "crontab",
-      "value": "0 * * * *"
-    },
-    "checkin_margin": 5,
-    "max_runtime": 30,
-    "timezone": "America/Los_Angeles"
-  },
   "contexts": {
     "trace": {
       "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe"

--- a/src/docs/sdk/check-ins.mdx
+++ b/src/docs/sdk/check-ins.mdx
@@ -15,7 +15,21 @@ of a JSON payload that looks roughly like this:
   "status": "in_progress",
   "duration": 10.0,
   "release": "1.0.0",
-  "environment": "production"
+  "environment": "production",
+  "monitor_config": {
+    "schedule": {
+      "type": "crontab",
+      "value": "0 * * * *"
+    },
+    "checkin_margin": 5,
+    "max_runtime": 30,
+    "timezone": "America/Los_Angeles"
+  },
+  "contexts": {
+    "trace": {
+      "trace_id": "8f431b7aa08441bbbd5a0100fd91f9fe"
+    }
+  }
 }
 ```
 The following fields exist:
@@ -52,6 +66,14 @@ The following fields exist:
 `environment`
 
 : _String, optional_. The environment.
+
+`monitor_config`
+
+: _Object, optional_. A monitor configuration (defined below) that is stored with the check-in in order to verify the state of the monitor at the time of the check-in.
+
+`contexts`
+
+: _Object, optional_. A dictionary of contextual information about the environment running the check-in. Right now we only support the [trace context](https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context) and use the `trace_id` in order to link check-ins to associated errors.
 
 ## Monitor upsert support
 

--- a/src/docs/sdk/check-ins.mdx
+++ b/src/docs/sdk/check-ins.mdx
@@ -69,11 +69,14 @@ The following fields exist:
 
 `monitor_config`
 
-: _Object, optional_. A monitor configuration (defined below) that is stored with the check-in in order to verify the state of the monitor at the time of the check-in.
+: _Object, optional_. A monitor configuration (defined below) that is stored with the
+ check-in in order to verify the state of the monitor at the time of the check-in.
 
 `contexts`
 
-: _Object, optional_. A dictionary of contextual information about the environment running the check-in. Right now we only support the [trace context](https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context) and use the `trace_id` in order to link check-ins to associated errors.
+: _Object, optional_. A dictionary of contextual information about the environment running
+ the check-in. Right now we only support the [trace context](https://develop.sentry.dev/sdk/event-payloads/contexts/#trace-context)
+  and use the `trace_id` in order to link check-ins to associated errors.
 
 ## Monitor upsert support
 


### PR DESCRIPTION
Adds the optional `monitor_config` and `contexts` to the check-in payload