### PR TITLE
Trace Origin: Clarify integration part

### DIFF
--- a/src/docs/sdk/performance/trace-origin.mdx
+++ b/src/docs/sdk/performance/trace-origin.mdx
@@ -27,7 +27,7 @@ that the SDK or some integration created it.
 
 `integration-part`
 
-: _Optional_. Is the part of the integration of the SDK that created the trace or span.
+: _Optional_. Is the part of the integration of the SDK that created the trace or span. This is only useful when one integration creates multiple traces or spans, and you'd like to differentiate. Therefore, most of the time, this will be omitted.
 
 
 All parts can only contain:


### PR DESCRIPTION
Clarify that the integration part is omitted most of the time.