### PR TITLE
Mention request/response bodies for GraphQL should be guarded by a flag

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -400,6 +400,8 @@ The `fingerprints` field should be set to `["$operationName", "$operationType", 
 
 Ability for the SDK to attach request body to events and triggered during the execution of request.
 
+Attaching request and response bodies should be guarded by `sendDefaultPii` or another flag  to opt-in (whichever makes more sense for the specific SDK).
+
 User should be able to set a configuration option `maxRequestBodySize` to instruct SDK how big requests bodies should be attached.
 SDK controls what is an actual size in bytes for each option:
 

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -384,7 +384,7 @@ Required fields for the Response interface:
 }
 ```
 
-The `data` field is a JSON object that contains the GraphQL response payload. Attaching request and response bodies should be guarded by `sendDefaultPii` or another flag  to opt-in (whichever makes more sense for the specific SDK).
+The `data` field is a JSON object that contains the GraphQL response payload. Attaching request and response bodies should be guarded by `sendDefaultPii` and/or another flag to opt-in (e.g. `captureFailedRequests`).
 
 Required fields for the Event interface:
 

--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -384,7 +384,7 @@ Required fields for the Response interface:
 }
 ```
 
-The `data` field is a JSON object that contains the GraphQL response payload.
+The `data` field is a JSON object that contains the GraphQL response payload. Attaching request and response bodies should be guarded by `sendDefaultPii` or another flag  to opt-in (whichever makes more sense for the specific SDK).
 
 Required fields for the Event interface:
 
@@ -399,8 +399,6 @@ The `fingerprints` field should be set to `["$operationName", "$operationType", 
 ## Attaching Request Body in Server SDKs
 
 Ability for the SDK to attach request body to events and triggered during the execution of request.
-
-Attaching request and response bodies should be guarded by `sendDefaultPii` or another flag  to opt-in (whichever makes more sense for the specific SDK).
 
 User should be able to set a configuration option `maxRequestBodySize` to instruct SDK how big requests bodies should be attached.
 SDK controls what is an actual size in bytes for each option:


### PR DESCRIPTION
Either `sendDefaultPii` or another opt-in flag.