### PR TITLE
Add hard stop for 23.6.2 due to django upgrade

### DIFF
--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -38,18 +38,22 @@ We have three hards stops that you need to go through in order to pick up signif
 
 1. If you are coming from a version prior to `9.1.2`, you first need to upgrade to `9.1.2` and follow the next steps:
    ```
-   <your.sentry.version> -> 9.1.2 -> 21.5.0 -> 21.6.3 -> latest
+   <your.sentry.version> -> 9.1.2 -> 21.5.0 -> 21.6.3 -> 23.6.2 -> latest
    ```
 1. If you are coming from `9.1.2`, you first need to upgrade to `21.5.0` and follow the next steps:
    ```
-   <your.sentry.version> -> 21.5.0 -> 21.6.3 -> latest
+   <your.sentry.version> -> 21.5.0 -> 21.6.3 -> 23.6.2 -> latest
    ```
 1. If you are coming from a version prior to `21.6.3`, you first need to upgrade to `21.6.3`:
    ```
-   <your.sentry.version> -> 21.6.3 -> latest
+   <your.sentry.version> -> 21.6.3 -> 23.6.2 -> latest
+   ```
+1. If you are coming from a version prior to `23.6.2`, you first need to upgrade to `23.6.2`:
+  ```
+   <your.sentry.version> -> 23.6.2 -> latest
    ```
 
-Any other case (`21.6.3+`), you should be able to upgrade to the latest version directly.
+Any other case (`23.6.2+`), you should be able to upgrade to the latest version directly.
 
 ## Nightly Builds
 

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -53,7 +53,7 @@ We have three hards stops that you need to go through in order to pick up signif
    <your.sentry.version> -> 23.6.2 -> latest
    ```
 
-Any other case (`23.6.2+`), you should be able to upgrade to the latest version directly. We'd recommend you skip `23.7.0` to avoid issues around db migrations and the django 3 upgrade.
+Any other case (`23.6.2+`), you should be able to upgrade to the latest version directly. We'd recommend you skip `23.7.0` to avoid issues around database migrations and the django 3 upgrade.
 
 ## Nightly Builds
 

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -53,7 +53,7 @@ We have three hards stops that you need to go through in order to pick up signif
    <your.sentry.version> -> 23.6.2 -> latest
    ```
 
-Any other case (`23.6.2+`), you should be able to upgrade to the latest version directly.
+Any other case (`23.6.2+`), you should be able to upgrade to the latest version directly. We'd recommend you skip `23.7.0` to avoid issues around db migrations and the django 3 upgrade.
 
 ## Nightly Builds
 


### PR DESCRIPTION
To avoid db migration errors before upgrade to 23.7.0+