### PR TITLE
Update github.mdx: Update permissions table 

### DIFF
--- a/src/docs/integrations/github.mdx
+++ b/src/docs/integrations/github.mdx
@@ -27,15 +27,15 @@ You'll need to come up with come up with your own webhook secret:
 
 When prompted for permissions, choose the following:
 
-| Permission                                    | Setting      |
-| --------------------------------------------- | ------------ |
-| Repository administration                     | Read-only    |
-| Repository contents                           | Read-only    |
-| Organization permissions / members (optional) | Read-only    |
-| User permissions / Email addresses (optional) | Read-only    |
-| Issues                                        | Read & write |
-| Pull requests                                 | Read & write |
-| Repository webhooks                           | Read & write |
+| Permission                                       | Setting      |
+| ------------------------------------------------ | ------------ |
+| Repository / Administration                      | Read-only    |
+| Repository / Contents                            | Read-only    |
+| Organization permissions / members (optional)    | Read-only    |
+| Account permissions / Email addresses (optional) | Read-only    |
+| Repository / Issues                              | Read & write |
+| Repository / Pull requests                       | Read & write |
+| Repository / Webhooks                            | Read & write |
 
 When prompted to subscribe to events, choose the following:
 


### PR DESCRIPTION
This patch adopts the permissions table to actual GitHub's
- wording
- and section naming