### PR TITLE
fix: 1MB limit is after decompression

### DIFF
--- a/src/docs/sdk/event-payloads/index.mdx
+++ b/src/docs/sdk/event-payloads/index.mdx
@@ -3,7 +3,7 @@ title: Event Payloads
 ---
 
 Events are the fundamental data that clients, often through the use of an SDK, send
-to the Sentry server. Event payload size limit is 1 MiB.
+to the Sentry server. Event payload size limit is 200KB compressed and 1 MB decompressed.
 
 The API endpoint on the Sentry server where event payloads are sent is
 `/api/{PROJECT_ID}/store/`.


### PR DESCRIPTION
This clarifies the current payload size limit for the `/api/PROJECT_ID/store/` endpoint, and makes it more like how the limit is described at https://develop.sentry.dev/sdk/store/#size-limits.