### PR TITLE
Added response context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -732,3 +732,30 @@ envelope endpoint.
   }
 }
 ```
+
+
+## Response Context
+
+Response context contains information about the HTTP response associated with the event.
+
+The only and required field is `status_code`.
+
+This is mostly set on transactions in a web server environment where one transaction represents a HTTP request/response cycle. 
+
+`status_code`
+
+: **Required.** The integer status code from the HTTP response associated with the event.
+- Example: `200`
+
+
+### Example Response Context
+
+```json
+{
+  "contexts": {
+    "response": {
+      "status_code": 404
+    }
+  }
+}
+```


### PR DESCRIPTION
For normalizing where we store the HTTP response code in our events we invented the `response` context: https://github.com/getsentry/team-sdks/issues/9

This PR adds documentation on how this `response` context should look like.