### PR TITLE
Update features.mdx to fix the link to the data-handling

### DIFF
--- a/src/docs/sdk/features.mdx
+++ b/src/docs/sdk/features.mdx
@@ -27,7 +27,7 @@ What scope means depends on the application, for a web framework it is most like
 
 ## Automatic Context Data
 
-Automatic addition of useful attributes such as `tags` or `extra` or specific `contexts`. Typically means the SDK hooks into a framework so that it can set attributes that are known to be useful for most users. Please check [Data Handling](data-handling) for considerations.
+Automatic addition of useful attributes such as `tags` or `extra` or specific `contexts`. Typically means the SDK hooks into a framework so that it can set attributes that are known to be useful for most users. Please check [Data Handling](https://develop.sentry.dev/sdk/data-handling/) for considerations.
 
 ## Breadcrumbs
 


### PR DESCRIPTION
You may well have a better way of providing a relative link to the data handling material. I've simply added the full URL, partly as I've seen that you've already got full URLs elsewhere in this page.