### PR TITLE
ref(discord): Add OAuth2 redirect URI

### DIFF
--- a/src/docs/integrations/discord/index.mdx
+++ b/src/docs/integrations/discord/index.mdx
@@ -35,7 +35,7 @@ After you update the <code>config.yml</code>, restart you Sentry server to conti
 
 Now that Sentry is running and it knows your Discord credentials, we need to set up a way for Discord to interact with Sentry.
 
-Head back to your Discord application setttings, navigate to __General Information__ and look for __Interactions Endpoint URL__.
+Head back to your Discord application settings, navigate to __General Information__ and look for __Interactions Endpoint URL__.
 
 ![Interactions Endpoint URL](./interactions_endpoint_url.png)
 
@@ -49,6 +49,18 @@ Click __Save Changes__.
 <Alert level="info">
 When you enter the Interactions Endpoint URL, Discord will try to verify it. The verification will fail if you haven't configured the bot credentials properly, haven't restarted your server since adding them, or don't have your server properly exposed to the internet.
 </Alert>
+
+## Configure your Discord OAuth2 Redirect URI
+
+Navigate to __OAuth2__ > __General__ and look for __Redirects__.
+
+Here you'll need to enter the Discord setup endpoint:
+```
+Oauth2 Redirect URI: {YOUR_DOMAIN}/extensions/discord/setup/
+```
+
+Click __Save Changes__. 
+
 
 You're now all set to use the Discord integration in Sentry! See our [documentation on installing and configuring the Discord integration](https://docs.sentry.io/product/integrations/notification-incidents/discord/) for some next steps.
 


### PR DESCRIPTION
You can't actually install the Discord integration locally without setting a redirect URI, but this was missing from the docs.