### PR TITLE
docs: Document how to setup hook tests that rely on useApiQuery

### DIFF
--- a/src/docs/frontend/network-requests.mdx
+++ b/src/docs/frontend/network-requests.mdx
@@ -278,8 +278,15 @@ We use `MockApiClient` to mock API responses. This is a globally-available class
 ```tsx
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-...
-render(<MyComponentThatFetches />);
+describe('useFetchSomeData', () => {
+  it('should fetch', () => {
+    const request = MockApiClient.addMockResponse(...);
+
+    render(<MyComponentThatFetches />);
+
+    expect(request).toHaveBeenCalled();
+  });
+});
 ```
 
 ### Test setup for hooks
@@ -297,12 +304,14 @@ function wrapper({children}: {children?: ReactNode}) {
 
 describe('useFetchSomeData', () => {
   it('should fetch', () => {
+    const request = MockApiClient.addMockResponse(...);
+
     const {result, waitFor} = reactHooks.renderHook(useFetchSomeData, {
       wrapper,
       initialProps: {organization},
     });
     
-    expect(...);
+    expect(request).toHaveBeenCalled();
   });
 });
 ```

--- a/src/docs/frontend/network-requests.mdx
+++ b/src/docs/frontend/network-requests.mdx
@@ -269,9 +269,43 @@ function useUpdateProjectNameOptimistic(incomingOptions: UpdateProjectOptions) {
 }
 ```
 
-## Testing components with network requests
+## Testing components & hooks with network requests
 
 We use `MockApiClient` to mock API responses. This is a globally-available class in tests that reimplements `Client` in the test environment. You can read up on the logic [here](https://github.com/getsentry/sentry/blob/master/static/app/__mocks__/api.tsx).
+
+### Test setup for components
+
+```tsx
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+...
+render(<MyComponentThatFetches />);
+```
+
+### Test setup for hooks
+
+```tsx
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+
+function wrapper({children}: {children?: ReactNode}) {
+  return (
+    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useFetchSomeData', () => {
+  it('should fetch', () => {
+    const {result, waitFor} = reactHooks.renderHook(useFetchSomeData, {
+      wrapper,
+      initialProps: {organization},
+    });
+    
+    expect(...);
+  });
+});
+```
 
 ### Mocking successful responses
 


### PR DESCRIPTION
Direct link to the example is: https://develop-git-ryan953-doc-useapiquery-with-hooks.sentry.dev/frontend/network-requests/

See also: https://github.com/getsentry/sentry/pull/56288 where we fix all the examples in the app, so it's easier to copy+paste your way to success!

![SCR-20230914-lzzw](https://github.com/getsentry/develop/assets/187460/fcd2ae95-f801-4d0f-a012-182cf2f49f17)
