### PR TITLE
docs(dev env): Add note about `.zshrc` to `make setup-pyenv` section

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -88,8 +88,11 @@ for instructions on how to set up Bash.
 ```shell {filename: ~/.zprofile} {tabTitle: Zsh}
 
 # It is assumed that pyenv is installed via Brew, so this is all we need to do.
-
 eval "\$(pyenv init --path)"
+
+# NOTE: If you use a startup script other than .zprofile (.zshrc, for example)
+# or your startup script lives somewhere besides your home folder, you'll need
+# to add the above line manually.
 
 ```
 


### PR DESCRIPTION
The `pyenv_setup.sh` script which runs when you call `make setup-pyenv` in the `sentry` repo only considers the case for zsh wherein the user has their zsh config in `~/.zprofile`. For anyone who doesn't, the script therefore doesn't work. This adds a note to the `zsh` tab of the code snippet telling people to do that part of the setup manually in that case.