### PR TITLE
chore(docs): Clarify private fields on response schema

### DIFF
--- a/src/docs/api/public.mdx
+++ b/src/docs/api/public.mdx
@@ -276,8 +276,9 @@ validate any included example responses. There are three ways to do this:
 
   `*`Similar to the request serializer, use the
     [extend_schema_serializer](https://drf-spectacular.readthedocs.io/en/latest/drf_spectacular.html#drf_spectacular.utils.extend_schema_serializer)
-    to exclude any private fields from the response schema. The TypedDict must
-    also exclude this field.
+    directly on the TypedDict to exclude any private fields from the response schema.
+    See [here](https://github.com/getsentry/sentry/blob/4828c60fd7f9fce5e32769054b9a7b10dc795aaa/src/sentry/replays/post_process.py#L43-L44)
+    for an example of this.
 
 2. To return a list of objects or for more customization, use the
   [inline_sentry_response_serializer](https://github.com/getsentry/sentry/blob/aa61724035370a47fdc112c14d1467be2609d9a2/src/sentry/apidocs/utils.py#L24).


### PR DESCRIPTION
`here` links to [this example](https://github.com/getsentry/sentry/blob/4828c60fd7f9fce5e32769054b9a7b10dc795aaa/src/sentry/replays/post_process.py#L43-L44)

![Screenshot 2023-09-28 at 1 16 45 PM](https://github.com/getsentry/develop/assets/67301797/819b5c88-e9b5-446b-b45e-219b0410e8cb)
