### PR TITLE
context entry `state` too deeply nested

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -479,13 +479,11 @@ The `type` and default key is `"state"`.
 {
   "contexts": {
     "state": {
-      "state": {
-        "type": "MobX",
-        "value": {
-          "flights": [],
-          "airports": [],
-          "showModal": false
-        }
+      "type": "MobX",
+      "value": {
+        "flights": [],
+        "airports": [],
+        "showModal": false
       }
     }
   }


### PR DESCRIPTION
The `state` entry of the context seems to be too deeply nested here. If that's not the case it really isn't clear why this level of nesting is required.