### PR TITLE
nit(docs): Update migration instructions w/ github action to generate sql

### DIFF
--- a/src/docs/database-migrations.mdx
+++ b/src/docs/database-migrations.mdx
@@ -26,7 +26,8 @@ This can be used to roll a migration back as well. Useful in dev if you make a m
 
 ### Produce SQL for a migration
 
-This is helpful for people reviewing your code, since it's not always clear exactly what a Django migration is actually going to do.
+A GitHub action will automatically comment on your PR with the SQL for your migration, and the comment will stay updated with any future changes.
+You can also manually generate SQL with this command.
 
 `sentry django sqlmigrate <app_name> <migration_name>`
 
@@ -43,8 +44,6 @@ or
 `sentry django makemigrations <app_name>` for a specific app.
 
 eg `sentry django makemigrations sentry`
-
-When you include a migration in a pr, also generate the sql for the migration and include it as a comment so that your reviewers can more easily understand what Django is doing.
 
 You can also generate an empty migration with `sentry django makemigrations <app_name> --empty`. This is useful for data migrations and other custom work.
 


### PR DESCRIPTION
I remember when I first made a migration I followed the instructions and commented the SQL, only to have the action comment the same thing 😔

This should help people making their first migration avoid that mistake.

<img width="908" alt="Screenshot 2023-10-02 at 3 46 58 PM" src="https://github.com/getsentry/develop/assets/67301797/b2f59d96-5f99-482e-a85e-b3a6ed049f94">