### PR TITLE
Add more GraphQL span ops

### DIFF
--- a/src/docs/sdk/performance/span-operations.mdx
+++ b/src/docs/sdk/performance/span-operations.mdx
@@ -99,11 +99,13 @@ Web server related spans should aim to follow OpenTelemetry's [HTTP](https://git
 | grpc            |                                       | Usage of the [gRPC framework](https://grpc.io/)                    |
 | graphql         |                                       | a GraphQL operation                                                |
 |                 | graphql.execute                       |                                                                    |
+|                 | graphql.parse                         |                                                                    |
 |                 | graphql.resolve                       |                                                                    |
 |                 | graphql.request                       |                                                                    |
 |                 | graphql.query                         |                                                                    |
 |                 | graphql.mutation                      |                                                                    |
 |                 | graphql.subscription                  |                                                                    |
+|                 | graphql.validate                      |                                                                    |
 | subprocess      |                                       | Creating new processes                                             |
 |                 | subprocess.wait                       |                                                                    |
 |                 | subprocess.communicate                |                                                                    |


### PR DESCRIPTION
The [Strawberry GraphQL server integration](https://github.com/getsentry/sentry-python/pull/2393) in the Python SDK creates spans for parsing and validation. 

Preview: https://develop-git-sentrivana-patch-1.sentry.dev/sdk/performance/span-operations/