### PR TITLE
ref(docs): add units to PerformanceResourceTiming resource size properties

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -18,9 +18,9 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `http.fragment`                     | string | The Fragments present in the URI (Browser SDKs only). | `#foo=bar`         |
 | `http.request.method`               | string | The HTTP method used.                                 | `GET`              |
 | `http.response.status_code`         | int    | The status HTTP response.                             | `404`              |
-| `http.response_content_length`      | number | The encoded body size of the response.                | `123`              |
-| `http.decoded_response_body_length` | number | The decoded body size of the response.                | `456`              |
-| `http.response_transfer_size`       | number | The transfer size of the response.                    | `789`              |
+| `http.response_content_length`      | number | The encoded body size of the response (in bytes).     | `123`              |
+| `http.decoded_response_body_length` | number | The decoded body size of the response (in bytes).     | `456`              |
+| `http.response_transfer_size`       | number | The transfer size of the response (in bytes).         | `789`              |
 
 ## Mobile
 


### PR DESCRIPTION
We didn't specify units in our docs, I added them to remove any ambiguity.