### PR TITLE
docs: Add note to restart snuba after enabling relay

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -280,6 +280,13 @@ SENTRY_FEATURES['organizations:metrics-extraction'] = True  # Enables session me
 SENTRY_FEATURES['organizations:transaction-metrics-extraction'] = True  # Enables transaction metrics
 ```
 
+After enabling relay the `snuba` service has to be reset to pickup the new configuration:
+
+```shell
+sentry devservices rm snuba
+sentry devservices up snuba
+```
+
 ## Setting up Getsentry
 
 <Alert title="Employees Only" level="warning">

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -280,7 +280,7 @@ SENTRY_FEATURES['organizations:metrics-extraction'] = True  # Enables session me
 SENTRY_FEATURES['organizations:transaction-metrics-extraction'] = True  # Enables transaction metrics
 ```
 
-After enabling relay the `snuba` service has to be reset to pickup the new configuration:
+After enabling `KafkaEventStream` the `snuba` service has to be reset to pick up the new configuration:
 
 ```shell
 sentry devservices rm snuba


### PR DESCRIPTION
After enabling Relay and Kafka, the snuba container configuration needs to be updated, this only happens when re-creating the container.

Container creation is conditional on `SENTRY_EVENTSTREAM`:
https://github.com/getsentry/sentry/blob/9c487382d459203ebe4109f6b677507f03ca0891/src/sentry/conf/server.py#L2747-L2778
