### PR TITLE
feat: Replace docker-compose with "docker compose"

### DIFF
--- a/src/docs/self-hosted/backup.mdx
+++ b/src/docs/self-hosted/backup.mdx
@@ -39,12 +39,12 @@ If you're running on a version of self-hosted Sentry that is below 23.3.1, you'l
 
 #### Backup
 ```shell
-docker-compose run -v $(pwd)/sentry:/sentry-data/backup  --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
+docker compose run -v $(pwd)/sentry:/sentry-data/backup  --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
 ```
 
 #### Restore
 ```shell
-docker-compose run --rm -T web import /etc/sentry/backup.json
+docker compose run --rm -T web import /etc/sentry/backup.json
 ```
 
 ## Full Backup
@@ -60,7 +60,7 @@ The ideal way to backup and restore Sentry is to backup and restore all Docker v
 - `sentry-symbolicator`
 
 <Alert title="Note" level="info">
-Only backing up and restoring these volumes should bring back all persisted data. If you also need to back up in-flight data, we recommend backing up any project-specific volumes that <code>docker-compose</code> automatically creates, typically with the <code>sentry_self_hosted_sentry-</code> prefix.
+Only backing up and restoring these volumes should bring back all persisted data. If you also need to back up in-flight data, we recommend backing up any project-specific volumes that <code>docker compose</code> automatically creates, typically with the <code>sentry_self_hosted_sentry-</code> prefix.
 </Alert>
 
 Docker documents [how to backup and restore volumes](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes) on their documentation. You may use different methods as long as the volumes can be read back without issues.

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -6,7 +6,7 @@ In addition to making its source code available publicly, Sentry offers and main
 
 ## Getting Started
 
-Our recommendation is to download the [latest release of the self-hosted repository](https://github.com/getsentry/self-hosted/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker-compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
+Our recommendation is to download the [latest release of the self-hosted repository](https://github.com/getsentry/self-hosted/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
 
 ### Self-Hosted Monitoring
 
@@ -92,14 +92,14 @@ You very likely will want to adjust the default configuration for your Sentry in
 
 1. **`sentry/enhance-image.sh`**—To install plugins and their dependencies or make other modifications to the Sentry base image, copy `sentry/enhance-image.example.sh` to `sentry/enhance-image.sh` and add necessary steps there. For example, you can use `apt-get` to install dependencies and use `pip` to install plugins. After making modifications to `sentry/enhance-image.sh`, run `./install.sh` again to apply them.
 
-1. **Environment variables**—The available keys are defined in [.env](https://github.com/getsentry/self-hosted/blob/master/.env). Use some system-dependent means of setting environment variables if you need to override any of them. To avoid Git changes, simply create a file called `.env.custom` and insert your system-dependent environment variables there. In order to use this, please use `docker-compose --env-file /path/to/.env.custom up -d`.
+1. **Environment variables**—The available keys are defined in [.env](https://github.com/getsentry/self-hosted/blob/master/.env). Use some system-dependent means of setting environment variables if you need to override any of them. To avoid Git changes, simply create a file called `.env.custom` and insert your system-dependent environment variables there. In order to use this, please use `docker compose --env-file /path/to/.env.custom up -d`.
 
 1. [Geolocation](/self-hosted/geolocation/) uses **a custom configuration file** to conform to the underlying technology.
 
 You can find more about configuring Sentry at [the configuration section of our developer documentation](/config/).
 
 <Alert title="Note" level="info">
-  Once you change your configuration, you'll need to restart all Sentry services by running <code>docker-compose restart web worker cron sentry-cleanup</code> (or just <code>docker-compose restart</code> to restart everything).
+  Once you change your configuration, you'll need to restart all Sentry services by running <code>docker compose restart web worker cron sentry-cleanup</code> (or just <code>docker compose restart</code> to restart everything).
 </Alert>
 
 ### Configuration Topics


### PR DESCRIPTION
Figured out install script showed "docker compose" but docs mentionned "docker-compose"