### PR TITLE
Link /event-payloads is dead, changing to /sdk/event-payloads

### DIFF
--- a/src/docs/issue-platform.mdx
+++ b/src/docs/issue-platform.mdx
@@ -5,9 +5,9 @@ title: "Issue Platform"
 The Issue Platform allows developers to create new issue types from arbitrary data sources. If you have data about something that you want to track via an issue, you can build it on the issue platform. For example, building profiling issues on the issue platform allowed us to turn things like “JSON decoding on the main thread” into their own issue types.
 
 To use the Issue Platform you need to:
-1. <Link to="#writing-a-detector">Write a Detector</Link> 
-2. <Link to="#register-an-issue-type">Register an Issue Type</Link> 
-3. <Link to="#send-occurrences-to-the-issue-platform">Send Occurrences to the Issue Platform</Link> 
+1. <Link to="#writing-a-detector">Write a Detector</Link>
+2. <Link to="#register-an-issue-type">Register an Issue Type</Link>
+3. <Link to="#send-occurrences-to-the-issue-platform">Send Occurrences to the Issue Platform</Link>
 4. <Link to="#releasing-your-issue-type">Release</Link>
 
 ## Writing a Detector
@@ -104,7 +104,7 @@ The most current version of this schema is documented here:
 ### Event Schema
 <Link to="https://github.com/getsentry/sentry/blob/ccfb37212102945df5f35e8f55fe38891b70036b/src/sentry/issues/json_schemas.py#L3">Schema</Link>
 
-The event schema should match the <Link to="/event-payloads">Sentry event schema</Link>. Any fields/interfaces defined here can be passed along with your event. It's best to fill in as many of these as makes sense for your issue type.
+The event schema should match the <Link to="/sdk/event-payloads">Sentry event schema</Link>. Any fields/interfaces defined here can be passed along with your event. It's best to fill in as many of these as makes sense for your issue type.
 
 There's a minimum set of fields which should be included:
 - `environment`


### PR DESCRIPTION
Link `/event-payloads` is dead, changing to `/sdk/event-payloads` which works and is most likely what's expected. 