### PR TITLE
ref(mail): Add mail preview docs

### DIFF
--- a/src/docs/services/email.mdx
+++ b/src/docs/services/email.mdx
@@ -10,8 +10,6 @@ Inbound email is fairly limited in use, and currently it only supports processin
 
 You'll need to configure an SMTP provider for outbound email.
 
-TODO: Document mail preview backend.
-
 <dl>
 <dt><code>mail.backend</code></dt>
 <dd><markdown>
@@ -20,6 +18,8 @@ Declared in `config.yml`.
 The backend to be used for email delivery. Options are `smtp`, `console`, and `dummy`.
 
 Defaults to `smtp`. Use `dummy` if you’d like to disable email delivery.
+
+Use `sentry.utils.email.PreviewBackend` to receive mail locally while developing. By default they'll open in the native Mail app if using iOS.
 
 </markdown></dd>
 
@@ -136,8 +136,6 @@ mail.reply-hostname: "inbound.sentry.example.com"
 # incoming replies
 mail.enable-replies: true
 ```
-
-That’s it! You’ll now be able to respond to activity notifications on errors via your email client.
 
 And finally, update Sentry with the appropriate settings:
 

--- a/src/docs/services/email.mdx
+++ b/src/docs/services/email.mdx
@@ -19,7 +19,7 @@ The backend to be used for email delivery. Options are `smtp`, `console`, and `d
 
 Defaults to `smtp`. Use `dummy` if you’d like to disable email delivery.
 
-Use `sentry.utils.email.PreviewBackend` to receive mail locally while developing. By default they'll open in the native Mail app if using a Macbook.
+Use `sentry.utils.email.PreviewBackend` to receive mail locally while developing. By default they'll open in the native Mail app if using a Macbook. Select iCloud as the provider and use the same email address you have set up for Sentry.
 
 </markdown></dd>
 

--- a/src/docs/services/email.mdx
+++ b/src/docs/services/email.mdx
@@ -19,7 +19,7 @@ The backend to be used for email delivery. Options are `smtp`, `console`, and `d
 
 Defaults to `smtp`. Use `dummy` if you’d like to disable email delivery.
 
-Use `sentry.utils.email.PreviewBackend` to receive mail locally while developing. By default they'll open in the native Mail app if using iOS.
+Use `sentry.utils.email.PreviewBackend` to receive mail locally while developing. By default they'll open in the native Mail app if using a Macbook.
 
 </markdown></dd>
 


### PR DESCRIPTION
Update a TODO with information about how to set up the local mail preview so when you're developing you can actually trigger emails. 