### PR TITLE
Remove `user.segment`

### DIFF
--- a/src/docs/sdk/event-payloads/user.mdx
+++ b/src/docs/sdk/event-payloads/user.mdx
@@ -28,10 +28,6 @@ of these attributes and only custom attributes is valid, but not as useful.
 
 : The user's IP address. If the user is unauthenticated, Sentry uses the IP address as a unique identifier for the user. Set to `"{{auto}}"` to let Sentry infer the IP address from the connection.
 
-`segment`
-
-: The user segment, for apps that divide users in user segments.
-
 All other keys are stored as extra information but not specifically processed by
 Sentry.
 


### PR DESCRIPTION
This shouldn't be used as the feature in the product was never implemented. 