### PR TITLE
docs(crons): Document check-in envelope size limit

### DIFF
--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -600,6 +600,7 @@ These limits are subject to future change and defined currently as:
 - *1MB* for event and transaction Items
 - *100 sessions* per Envelope
 - *100 pre-aggregated session buckets* per each `"sessions"` Item
+- *100KB* for monitor check-ins
 
 ## External References
 

--- a/src/docs/sdk/envelopes.mdx
+++ b/src/docs/sdk/envelopes.mdx
@@ -600,7 +600,7 @@ These limits are subject to future change and defined currently as:
 - *1MB* for event and transaction Items
 - *100 sessions* per Envelope
 - *100 pre-aggregated session buckets* per each `"sessions"` Item
-- *100KB* for monitor check-ins
+- *100KB* for monitor Check-ins
 
 ## External References
 


### PR DESCRIPTION
Documents maximum `check-in` size payload in accordance with relay:
https://github.com/getsentry/relay/blob/ee1fc80b46968d803c4a90f6b3ed36c07955fdad/relay-config/src/config.rs#L586