### PR TITLE
Add timer to sending-metrics-sdk

### DIFF
--- a/src/docs/delightful-developer-metrics/sending-metrics-sdk.mdx
+++ b/src/docs/delightful-developer-metrics/sending-metrics-sdk.mdx
@@ -70,6 +70,19 @@ metrics.gauge(
     tags=tags,
 )
 ```
+If you want to measure how much time a specific piece of code takes, you can use:
+
+```python
+from sentry_sdk import metrics
+
+# Emit a distribution metric of the execution time of the function.
+with metrics.timer("..."):
+ pass
+
+@metrics.timer("...")
+def my_function():
+ ...
+```
 
 <Alert title="Note" level="note">
 As of now, only the Python SDK is supporting the new metrics features but we are working on supporting metrics in the JavaScript and Rust SDKs next.

--- a/src/docs/delightful-developer-metrics/sending-metrics-sdk.mdx
+++ b/src/docs/delightful-developer-metrics/sending-metrics-sdk.mdx
@@ -76,12 +76,12 @@ If you want to measure how much time a specific piece of code takes, you can use
 from sentry_sdk import metrics
 
 # Emit a distribution metric of the execution time of the function.
-with metrics.timer("..."):
- pass
+with metrics.timer("my_timer"):
+    pass
 
-@metrics.timer("...")
+@metrics.timer("my_timer")
 def my_function():
- ...
+    pass
 ```
 
 <Alert title="Note" level="note">


### PR DESCRIPTION
Documenting missing capability/example to send timers