### PR TITLE
Add clarification on set_context types

### DIFF
--- a/src/docs/sdk/unified-api/index.mdx
+++ b/src/docs/sdk/unified-api/index.mdx
@@ -201,7 +201,7 @@ Sentry.configureScope(scope =>
 
 - `scope.set_tags(tags)`: Sets an object with key/value pairs, convenience function instead of multiple `set_tag` calls.
 
-- `scope.set_context(key, value)`: Sets the context key to a value, overwriting a potential previous value.  Removing a key is SDK-defined, either with a `remove_context` function or by passing nothing as data. The types are sdk specified.
+- `scope.set_context(key, value)`: Sets the context key to a value, overwriting a potential previous value. The key must be a string, the value must be a hash or dictionary with strings for keys. Removing a key is SDK-defined, either with a `remove_context` function or by passing nothing as data. The types are sdk specified.
 
 - `scope.set_level(level)`: Sets the level of all events sent within this scope.
 


### PR DESCRIPTION
This api has undocumented requirements on the type of the value, particularly, being a hash. This should be documented so that callers can be appraised of the requirement without inspecting the source code.

As there is no api page documenting this individual api for each of the various libraries, seems these requirements should be documented here.