### PR TITLE
feat(backup): Revive stub bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+echo "No-op bump version"
+
+# Note: stubbed out until we can remove from the craft file.


### PR DESCRIPTION
Undoes the deletion in https://github.com/getsentry/develop/pull/1088, but no longer changes the LICENSE. This is necessary to unbreak the release script.