### PR TITLE
Set preReleaseCommand to empty string

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -4,3 +4,4 @@ artifactProvider:
   name: none
 targets:
   - name: github
+preReleaseCommand: ""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eu
-
-echo "No-op bump version"
-
-# Note: stubbed out until we can remove from the craft file.


### PR DESCRIPTION
preReleaseCommand is an optional parameter, when set to empty string, does not run the usual preReleaseCommand script

https://github.com/getsentry/craft/blob/a3844c57fb10ec5265756814fa73cc88291a5d2d/src/commands/prepare.ts#L234