### PR TITLE
ref(devserver): Recommend dev.getsentry.net for devserver

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -29,15 +29,17 @@ sentry devserver --workers
 If you are developing for aesthetics only and do not rely on the async workers, you can omit the `--workers` flag in order
 to use fewer system resources.
 
-Access it at [http://127.0.0.1:8000](http://127.0.0.1:8000) (you'll have to wait a bit for webpack to finish).
+Access it at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000) (you'll have to wait a bit for webpack to finish).
 A superuser account should have been created for you during bootstrap - `admin@sentry.io` with password `admin`.
 You can create other users with `sentry createuser`.
 
 <Alert title="Note" level="info">
-  When asked for the root address of the server, make sure that you use{" "}
-  <a href="http://127.0.0.1:8000">http://127.0.0.1:8000</a>, as both protocol{" "}
-  <em>and</em> port are required in order for DNS and some pages' URLs to be
+
+  When asked for the root address of the server, make sure that you use
+  [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000), as both
+  protocol _and_ port are required in order for DNS and some pages' URLs to be
   displayed correctly.
+
 </Alert>
 
 ## Running the Getsentry Development Server


### PR DESCRIPTION
This is a follow up to GH-1037, recommending dev.getsentry.net for the
`sentry devserver` (we already recommended this for `yarn dev-ui`).