### PR TITLE
feat(https): Add HTTPS setup for devserver

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -68,6 +68,21 @@ by `dev.py` if it exists.
 
 Please refer to [Frontend Development Server](/frontend/development-server/) and [Backend Development Server](/backend/development-server/) for alternative ways to bring up the Sentry UI.
 
+### Enabling HTTPS
+
+You may wish to run the development server in HTTPS mode. This can be done by generating and installing local certificates.
+
+We will be using [mkcert](https://github.com/FiloSottile/mkcert) to create and install a locally-trusted, development certificate. The following will install `mkcert` and then create and install the local certificates.
+
+```shell
+brew install mkcert
+brew install nss # if you use Firefox
+yarn mkcert-localhost
+```
+
+Running `sentry devserver` will automatically use HTTPS when the certificates have been installed.
+
+
 ### Ingestion Pipeline (Relay)
 
 Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. If you need

--- a/src/docs/frontend/development-server.mdx
+++ b/src/docs/frontend/development-server.mdx
@@ -27,7 +27,7 @@ If you see an error similar to the below when accessing the development server:
 
 ![your connection is not private example](../img/connectionNotPrivate.png)
 
-You can either grant a temporary exception in your browser, or create and install a local certificate and use your OS to mark them as "trusted". SSL is required for the frontend development service, since the production API is served over https.
+You can either grant a temporary exception in your browser, or create and install a local certificate and use your OS to mark them as "trusted". TLS is required for the frontend development service, since the production API is served over https.
 
 Follow the steps [To Enable HTTPS for your devserver](/environment/#enabling-https).
 

--- a/src/docs/frontend/development-server.mdx
+++ b/src/docs/frontend/development-server.mdx
@@ -27,15 +27,9 @@ If you see an error similar to the below when accessing the development server:
 
 ![your connection is not private example](../img/connectionNotPrivate.png)
 
-You can either grant a temporary exception in your browser, or create and install a local certificate and use your OS to mark them as "trusted". The instructions below will show you how to create and install a local certificate.
+You can either grant a temporary exception in your browser, or create and install a local certificate and use your OS to mark them as "trusted". SSL is required for the frontend development service, since the production API is served over https.
 
-We will be using [mkcert](https://github.com/FiloSottile/mkcert) to create and install a locally-trusted, development certificate. The following will install `mkcert` and then create and install the local certificates.
-
-```shell
-brew install mkcert
-brew install nss # if you use Firefox
-yarn mkcert-localhost
-```
+Follow the steps [To Enable HTTPS for your devserver](/environment/#enabling-https).
 
 You can now run the dev server with `yarn dev-ui` and open [https://localhost:7999](https://localhost:7999). There should not see a warning about your connection not being private. You should also see a lock or similar icon in the address bar of your browser.
 


### PR DESCRIPTION
This works after https://github.com/getsentry/sentry/pull/60673