### PR TITLE
docs(self-hosted): revamp self hosted related documentation

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -106,6 +106,7 @@ export default () => {
         </div>
         <ul className="list-unstyled" data-sidebar-tree>
           <SidebarLink to="/self-hosted/">Overview</SidebarLink>
+          <SidebarLink to="/self-hosted/productionalizing">Productionalizing</SidebarLink>
           <SidebarLink to="/self-hosted/releases/">Releases & Upgrading</SidebarLink>
           <SidebarLink to="/self-hosted/backup/">Backup & Restore</SidebarLink>
           <SidebarLink to="/self-hosted/custom-ca-roots/">Custom CA Roots</SidebarLink>

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -8,6 +8,15 @@ In addition to making its source code available publicly, Sentry offers and main
 
 Our recommendation is to download the [latest release of the self-hosted repository](https://github.com/getsentry/self-hosted/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).
 
+To have easy maintainability for future upgrades, it is recommended to use Git workflow by cloning the self-hosted repository and check out to a specific CalVer tag. More about this on [Releases & Upgrading](/self-hosted/releases/).
+
+```bash
+git clone https://github.com/getsentry/self-hosted.git
+cd self-hosted
+git checkout 24.1.0
+sudo ./install.sh
+```
+
 ### Self-Hosted Monitoring
 
 When you run `./install.sh`, you have a choice to opt in or out of our monitoring. This monitoring is used for development and debugging purposes so that we're on top of issues you're facing, allowing us to provide a more seamless installation process. For more details please see the [section in the self-hosted README](https://github.com/getsentry/self-hosted#self-hosted-monitoring).
@@ -32,7 +41,7 @@ The following information is reported:
 Note: The contact email is utilized for security announcements, and will never be used outside of such. You can change your opt in/out settings for sending contact info at any time in the settings of the admin panel.
 
 The data reported is minimal and it greatly helps the development team behind Sentry. With that said, you can disable the beacon with the following setting:
-```
+```python
 SENTRY_BEACON = False
 ```
 
@@ -48,7 +57,7 @@ Here are the steps to follow:
 
 1. Set `http_proxy`, `https_proxy` and `no_proxy` variables in the `/etc/environment` file.
 2. To make the `docker pull` command respect your proxy settings, create a `/etc/systemd/system/docker.service.d/http-proxy.conf` file with these contents:
-```
+```systemd
 [Service]
 Environment="HTTP_PROXY=http://proxy:3128"
 Environment="HTTPS_PROXY=http://proxy:3128"
@@ -119,3 +128,11 @@ We strongly recommend using a dedicated load balancer in front of your Sentry se
 Once you have setup a load balancer or reverse proxy to your Sentry instance, you should modify the `system.url-prefix` in the `config.yml` file to match your new URL and protocol. You should also update the SSL/TLS section in the `sentry/sentry.conf.py` script, otherwise you may get CSRF-related errors when performing certain actions such as configuring integrations.
 
 Keep in mind that all this setup uses single-nodes for all services, including Kafka. For larger loads, you'd need a beefy machine with lots of RAM and disk storage. To scale up even further, you are very likely to use clusters with a more complex tool, such as Kubernetes. Due to self-hosted installations' very custom nature, we do not offer any recommendations or guidance around scaling up. We do what works for us for our thousands of customers over at [sentry.io](https://sentry.io/) and would love to have you over when you feel your local install's maintenance becomes a burden instead of a joy.
+
+For further deep dive about production best practices, visit [productionalizing](/self-hosted/productionalizing/).
+
+## Licensing
+
+Sentry is using [FSL (Functional Source License)](https://fsl.software/). Although it's not an OSI-approved license, the source code of Sentry and its' surrounding service & libraries for self-hosted deployment are open and [available on GitHub](https://github.com/orgs/getsentry/repositories?q=has%3Atag-production). For self-hosted, this license means that users can use Sentry and deploy it anywhere (even inside an enterprise ecosystem), but users are prohibited to sell deployed self-hosted Sentry as any kind of offering (SaaS or any kind of business model) and users are prohibited to be a direct competitor of Sentry by using Sentry's code that is FSL-licensed.  After two years, the license converts to Apache 2.0 or MIT.
+
+For further information on the FSL License, you can [visit the fsl.software website](https://fsl.software/) or [read the announcement blog post](https://blog.sentry.io/introducing-the-functional-source-license-freedom-without-free-riding/).

--- a/src/docs/self-hosted/productionalizing.mdx
+++ b/src/docs/self-hosted/productionalizing.mdx
@@ -1,0 +1,48 @@
+---
+title: 'Productionalizing'
+---
+
+This page provides a guide to help users secure their Sentry deployments and make the most out of Sentry. I don't know what else to say here so let's do this (yeah I'm gonna change this sentence later).
+
+## Recommended system resource
+
+Depending on your usage, required system resource to run Sentry may varies.
+
+## Enabling HTTPS
+
+Explain why do we need HTTPS
+
+## Expose Only Ingest Endpoint Publicly
+
+Sometimes, there are self-hosted deployments that requires the dashboard to be accessed via internal network. But, they also need to provide public Sentry ingestion endpoint for client devices. You can expose these endpoints publicly:
+
+- `/api/ingest` 
+- Put some more here...
+
+## Using Dedicated Load Balancer
+
+Put some words here...
+
+### NGINX
+
+Put some NGINX config here... Give link to tune NGINX.
+
+### Caddy
+
+Put some Caddy config here...
+
+### Traefik
+
+Put some Traefik config here...
+
+### HAProxy
+
+Put some HAProxy config here...
+
+## Firewall
+
+It is always good to protect your incoming network to prevent multiple network-level attack.
+
+For Debian/Ubuntu-based, it is recommended to use `ufw`.
+
+For RHEL-based (RedHat, Fedora, CentOS, Rocky Linux, Alma Linux), it is recommended to use `firewalld`.

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -32,6 +32,14 @@ Before starting the upgrade, we shut down all the services and then run some dat
   There are certain hard-stops you need to go through when upgrading from earlier versions. Please read the <Link to="#hard-stops">hard-stops</Link> section below for a list.
 </Alert>
 
+If you downloaded self-hosted repository using Git clone, the upgrade commands should look like this:
+
+```bash
+git fetch
+git checkout 24.3.0
+sudo ./install.sh
+```
+
 ### Hard Stops
 
 We have three hards stops that you need to go through in order to pick up significant database changes:

--- a/src/docs/self-hosted/support.mdx
+++ b/src/docs/self-hosted/support.mdx
@@ -2,7 +2,7 @@
 title: 'Self-Hosted Support'
 ---
 
-We strive to provide a great self-hosted experience for folks willing to try Sentry that way. The [self-hosted repository](https://github.com/getsentry/self-hosted) is geared towards low to medium loads with simplicity in mind. We believe keeping this setup simple is important to show
+We strive to provide a great self-hosted experience for folks willing to try Sentry that way. The [self-hosted repository](https://github.com/getsentry/self-hosted) is geared towards low traffic loads (less than ~1 million submitted Sentry events per month). We believe keeping this setup simple is important to show
 how various components fit together. Folks needing larger setups can expand from here based on their specific needs and environments.
 
 <Alert title="Note" level="info">

--- a/src/docs/self-hosted/troubleshooting.mdx
+++ b/src/docs/self-hosted/troubleshooting.mdx
@@ -2,7 +2,7 @@
 title: "Self-Hosted Troubleshooting"
 ---
 
-Please keep in mind that the [self-hosted repository](https://github.com/getsentry/self-hosted) is geared towards low to medium loads with simplicity in mind. Folks needing larger setups or having event spikes can expand from here based on their specific needs and environments. If this is not your cup of tea, you are always welcome to [try out hosted Sentry](https://sentry.io/signup/).
+Please keep in mind that the [self-hosted repository](https://github.com/getsentry/self-hosted) is geared towards low traffic loads (less than ~1 million submitted Sentry events per month). Folks needing larger setups or having event spikes can expand from here based on their specific needs and environments. If this is not your cup of tea, you are always welcome to [try out hosted Sentry](https://sentry.io/signup/).
 
 ## General
 


### PR DESCRIPTION
This is a work in progress, but I'll appreciate any reviews coming in. I need those anyways.

For context, on self-hosted we have this issue (https://github.com/getsentry/self-hosted/issues/2267) that's going nowhere. My goal with this PR Is to add more documentation for resolving common self-hosted related issues. 

Here are the things I'll write (or add) about on this PR (you can discuss it [on the Discord thread](https://discord.com/channels/621778831602221064/796028405833007104/1186953725370171473)):
- [x] Specific upgrade commands (using Git workflow), because "download or check out version of self-hosted repository" is kinda ambiguous for new people self hosting sentry. (one Github issue [here](https://github.com/getsentry/self-hosted/issues/2303))
- [ ] Setting up load balancer (mainly HAProxy, Caddy, or Nginx) for production use
- [ ] Some Docker specific configuration to lessen logs (see [this Discord link](https://discord.com/channels/621778831602221064/796028405833007104/1166220278041423963)) and to make it not break with people's private IP range (see [this Github link](https://github.com/getsentry/self-hosted/issues/2604#issuecomment-1831875693)).
- [ ] What are the things people can do to enable high traffic self-hosted issue other than migrating to SaaS (I know having users migrate to SaaS is a big win for Sentry, but some companies can't -- for me, it's due to government policy that anything related to customer's data must be kept on my company's own servers, having PII scrubing for this is not ideal, it's hard to debug stuff)
- [ ] How to set up filestore backend to use something other than filesystem such as 'gcs' or 's3' (from @hubertdeng123 -- to be honest I don't know how to setup storage backend other than filesystem)
- [ ] Enabling https for self hosted Sentry (from @hubertdeng123)

If anyone has any ideas or things they think is nice to add here, let me know.