### PR TITLE
docs(ui-lib): Write a blurb about the <ThemeToggle> UI Component Library helper

### DIFF
--- a/src/docs/frontend/component-library.mdx
+++ b/src/docs/frontend/component-library.mdx
@@ -138,6 +138,16 @@ Helper Components:
     />
     ```
 
+- [`<ThemeToggle />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/themeToggle.tsx)<br />
+    A wrapper component to isolate children from the current theme used on the page. Allows quickly toggling an example between <code>light</code>/<code>dark</code> without changing the whole screen (useful at night when you want most things in dark mode).<br/>
+    Use this to emphasize that a component/image has been tested and works well in <code>light</code> or <code>dark</code> mode.
+    ```typescript
+    <ThemeToggle>
+      <LoadingTriangle />
+    </ThemeToggle>
+    ```
+
+
 ### Writing a new story
 
 Now that you are armed and ready with the `storyBook()` template from above, and some helper components, it's time to write your new story. What's it going to say?

--- a/src/docs/frontend/component-library.mdx
+++ b/src/docs/frontend/component-library.mdx
@@ -89,7 +89,7 @@ Helper Components:
 
 - [`<JSXNode />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/jsxNode.tsx)<br />
     Render a formatted JSX component name and some properties.<br />
-    ```typescript
+    ```tsx
     return <JSXNode name="IconFire" props={{color: 'red400', size: 'sm'}} />;
 
     // will render as <code>&lt;IconFire<br/>color="red"<br/>size="sm" \:gt;</code>
@@ -97,7 +97,7 @@ Helper Components:
 
 - [`<JSXProperty />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/jsxProperty.tsx)
     Render a formatted JSX property name & value.<br />
-    ```typescript
+    ```tsx
     return <JSXProperty name="disabled" value={false} />;
 
     // will render as `<code>size={false}</code>`
@@ -105,7 +105,7 @@ Helper Components:
 
 - [`<SideBySide>{children}</SideBySide>`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/sideBySide.tsx)<br />
     A shortcut for `display: flex;` to render multiple items in a row, wrapping as needed
-    ```typescript
+    ```tsx
     return (
       <SideBySide>
         <Badge type="default">Default</Badge>
@@ -118,7 +118,7 @@ Helper Components:
 - [`<SizingWindow />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/sizingWindow.tsx)<br />
     A wrapper component to help demonstrate what the component looks like when the parent size is different or changing.<br />
     By default uses `display:flex; overflow: hidden;` which can test responsive components well. Can also be set to `display: block; overflow: auto;`.<br />
-    ```typescript
+    ```tsx
     <SizingWindow style={{height: '100px'}}>
       <LoadingTriangle />
     </SizingWindow>`
@@ -127,7 +127,7 @@ Helper Components:
 - [`<Matrix />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/matrix.tsx)<br />
     A helper to render multiple pairs of properties and values in a grid.
     For example, we can render all button `priority` values against all possible `size` values which results in a 4x5 matrix of outputs.
-    ```typescript
+    ```tsx
     <Matrix
       render={() => Button}
       propMatrix={{
@@ -141,7 +141,7 @@ Helper Components:
 - [`<ThemeToggle />`](https://github.com/getsentry/sentry/blob/master/static/app/components/stories/themeToggle.tsx)<br />
     A wrapper component to isolate children from the current theme used on the page. Allows quickly toggling an example between <code>light</code>/<code>dark</code> without changing the whole screen (useful at night when you want most things in dark mode).<br/>
     Use this to emphasize that a component/image has been tested and works well in <code>light</code> or <code>dark</code> mode.
-    ```typescript
+    ```tsx
     <ThemeToggle>
       <LoadingTriangle />
     </ThemeToggle>


### PR DESCRIPTION
Introduced with https://github.com/getsentry/sentry/pull/62726 

I think it's handy to
1. Be explicit that theme is something this component cares about (and does well)
2. Not force the reader to switch themes. ie: if they're reading at night, flashing the whole page into light mode is annoying

<img width="779" alt="SCR-20240108-jtds" src="https://github.com/getsentry/develop/assets/187460/304896aa-7e26-4bac-bfc6-7c241a404cb2">