### PR TITLE
Update Content-Security-Policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+##### Security #####
+# require review from security team for content security policy
+/vercel.json @getsentry/security

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
         },
         {
           "key": "Document-Policy",

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
           "value": "1; mode=block"
         },
         {
-          "key": "Content-Security-Policy-Report-Only",
+          "key": "Content-Security-Policy",
           "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
         },
         {

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com www.google-analytics.com; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io *.google-analytics.com stats.g.doubleclick.net; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com www.google.com www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
         },
         {
           "key": "Document-Policy",


### PR DESCRIPTION
Removing unused/un-approved script from the list
Remove google tag manager from CSP: https://github.com/getsentry/develop/pull/1125 
Turning off report-only mode
Adding security team as codeowner for the `vercel.json` file