### PR TITLE
Add Android emulator localhost troubleshooting

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -214,3 +214,9 @@ sentry devservices up
 ```shell
 docker ps
 ```
+
+---
+
+**Problem:** You use an Android emulator with a DSN pointing to localhost, and the events don't show up in your local Sentry instance.
+
+**Solution:** Change `localhost` to `10.0.2.2`. So, for example, change http://d895df97e1cb4a33b4dff8af3e78da09@localhost:8000/2 to http://d895df97e1cb4a33b4dff8af3e78da09@10.0.2.2:8000/2. This is because localhost or `127.0.0.1` refers to the emulator's own loopback interface, not the loopback interface of the host machine. For more information see https://developer.android.com/studio/run/emulator-networking.


### PR DESCRIPTION
Explain how to solve Android emulator events not showing up in local Sentry instance.