### PR TITLE
Revert "Add new thresholds to monitor config payload"

### DIFF
--- a/src/docs/sdk/check-ins.mdx
+++ b/src/docs/sdk/check-ins.mdx
@@ -126,14 +126,6 @@ before an issue is resolved.
 database`](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) string
 representing the timezone which the monitor's execution schedule is in.
 
-`failure_issue_threshold`
-
-: _Number, optional_. How many consecutive failed check-ins it takes to create an issue.
-
-`recovery_threshold`
-
-: _Number, optional_. How many consecutive OK check-ins it takes to resolve an issue.
-
 ### Schedule configuration
 
 <Note>


### PR DESCRIPTION
Reverts getsentry/develop#1132

Woops was already there - added in https://github.com/getsentry/develop/pull/1108, my mistake