### PR TITLE
docs(csp): remove if condition for CSP middleware

### DIFF
--- a/src/docs/self-hosted/csp.mdx
+++ b/src/docs/self-hosted/csp.mdx
@@ -9,8 +9,6 @@ title: "Self-Hosted Content Security Policy (CSP)"
 Starting with Sentry `23.5.0`, it is possible to enable the [CSP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on self-hosted Sentry installations. The good news is that Sentry itself supports [collecting of CSP reports](https://docs.sentry.io/product/security-policy-reporting/). We recommend creating a separate Sentry project for CSP reports. To enable CSP and reports collection, you'll want to configure the following settings in `sentry.conf.py`:
 
 ```python
-if "csp.middleware.CSPMiddleware" not in MIDDLEWARE:
-    MIDDLEWARE = ("csp.middleware.CSPMiddleware",) + MIDDLEWARE
 CSP_REPORT_URI = "https://your-sentry-url-prefix.com/api/{csp-project-id}/security/?sentry_key={sentry-key}"
 CSP_REPORT_ONLY = True
 ```


### PR DESCRIPTION
django-csp middleware has been enabled by default in https://github.com/getsentry/sentry/pull/57130
So we no longer need this if condition.