### PR TITLE
Add troubleshooting problem and solution for yarn link

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -220,3 +220,13 @@ docker ps
 **Problem:** You use an Android emulator with a DSN pointing to localhost, and the events don't show up in your local Sentry instance.
 
 **Solution:** Change `localhost` to `10.0.2.2`. So, for example, change http://d895df97e1cb4a33b4dff8af3e78da09@localhost:8000/2 to http://d895df97e1cb4a33b4dff8af3e78da09@10.0.2.2:8000/2. This is because localhost or `127.0.0.1` refers to the emulator's own loopback interface, not the loopback interface of the host machine. For more information see https://developer.android.com/studio/run/emulator-networking.
+
+---
+
+**Problem:** You can't use `yarn link` to link local versions of packages (i.e the Sentry JavaScript SDK) to your Sentry project
+
+**Solution:** Create a symlink to your `./config/yarn/link` directory within `/.local/share/yarn`:
+
+```shell
+ln -s /Users/<usr>/.config/yarn/link /Users/<usr>/.local/share/yarn
+```


### PR DESCRIPTION
There's a bug (likely a yarn bug) where you cannot use `yarn link` in your sentry project to link local copies of packages for testing, this is a workaround.