### PR TITLE
Report CSP violations to a separate Sentry project

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/1297620/security/?sentry_key=b3cfba5788cb4c138f855c8120f70eab"
+          "value": "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' sentry.io o1.ingest.sentry.io *.algolia.net *.algolianet.com *.algolia.io; img-src * 'self' data: img.shields.io mermaid.ink user-images.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self'; report-uri https://o1.ingest.sentry.io/api/4506631158300672/security/?sentry_key=172ccfe8cd81bc3b72479b556b0de3c4"
         },
         {
           "key": "Document-Policy",


### PR DESCRIPTION
Previously CSP violations from https://docs.sentry.io and https://develop.sentry.dev/ were intermixed in a single `docs-csp` Sentry project.
Now we are going to report them to a separate `develop-csp` project: https://sentry.sentry.io/issues/?project=4506631158300672