### PR TITLE
docs(self-hosted): enabling preview features section

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -129,6 +129,10 @@ You can find more about configuring Sentry at [the configuration section of our
   Once you change your configuration, you'll need to restart all Sentry services by running <code>docker compose restart web worker cron sentry-cleanup</code> (or just <code>docker compose restart</code> to restart everything).
 </Alert>
 
+### Enabling Preview Features
+
+Only features that has reached General Availability (GA) status will be enabled by default on self-hosted. As users, you can try new features before it reaches GA by adding required component and configurations. Preview features are tracked and documented through [GitHub issues with Type: Pre-release Feature labels](https://github.com/getsentry/self-hosted/labels/Type%3A%20Pre-release%20Feature).
+
 ### Configuration Topics
 
 Here is further information on specific configuration topics related to self-hosting:

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -131,7 +131,7 @@ You can find more about configuring Sentry at [the configuration section of our
 
 ### Enabling Preview Features
 
-Only features that has reached General Availability (GA) status will be enabled by default on self-hosted. As users, you can try new features before it reaches GA by adding required component and configurations. Preview features are tracked and documented through [GitHub issues with Type: Pre-release Feature labels](https://github.com/getsentry/self-hosted/labels/Type%3A%20Pre-release%20Feature).
+Only features that have reached General Availability (GA) status will be enabled by default for self-hosted. As users, you can try new features before it reaches GA by adding required infrastructure components and feature flags. Preview features are tracked and documented through [GitHub issues with Type: Pre-release Feature labels](https://github.com/getsentry/self-hosted/labels/Type%3A%20Pre-release%20Feature).
 
 ### Configuration Topics
 


### PR DESCRIPTION
A while ago, Chad created a new label on self-hosted repo. The label is used to track preview features.

Adding this to docs helps guide people to the right path for enabling new features.

/cc @chadwhitacre @azaslavsky @hubertdeng123 