### PR TITLE
docs: resolve typo in Breaking Changes part of self-hosted docs

### DIFF
--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -83,8 +83,8 @@ These builds are usually stable, but you may occasionally hit a broken version a
 
 - The `24.1.2` release will change the memcached backend from
   `django.core.cache.backends.memcached.MemcachedCache` to
-  `django.core.cache.backends.memcached.PyMemcachedCache`. This will require changing the `CACHES`
+  `django.core.cache.backends.memcached.PyMemcacheCache`. This will require changing the `CACHES`
   setting in your `sentry.conf.py` file in a manner similar to what is seen
   [here](https://github.com/getsentry/self-hosted/commit/9936376f4e933781feaae85e0071ef72c7f1c03f).
-  In particular, the `OPTIONS` API for `PyMemcachedCache` is different from that of
+  In particular, the `OPTIONS` API for `PyMemcacheCache` is different from that of
   `MemcachedCache`, and may require changes depending on how it has been configured.


### PR DESCRIPTION
According to the example config file, it should be `PyMemcacheCache` not `PyMemcachedCache`