### PR TITLE
Update case naming

### DIFF
--- a/src/docs/api/design.mdx
+++ b/src/docs/api/design.mdx
@@ -42,8 +42,8 @@ Hierarchy here does not necessarily mean that one collection belongs to a parent
 ### Naming Guidance
 - Collection names should be lowercase and hyphenated, e.g. `commit-files`.
 - Collection names must be plural. Avoid using uncountable words because the user can’t know whether the GET returns one item or a list.
-- Query params and body params should be `CamelCase`.
-- For sorting and filtering, stick with the common param names: sortBy (e.g. date_created), orderBy (either asc or desc), groupBy, limit
+- Query params and body params should be `camelBacked`. eg. `userId` or `dateCreated`.
+- For sorting and filtering, stick with the common param names: `sortBy` (e.g. `sortBy=-dateCreated`), `orderBy` (either `asc` or `desc`), `groupBy`, `limit`
 - Path params should be `snake_case`
 
 ## Functionality


### PR DESCRIPTION
We dont' use CamelCase, we use camelBacked. While camelBack is generally synonymous with CamelCase, the first letter should be lowercase.