### PR TITLE
feat: Document new multi craft config feature

### DIFF
--- a/src/docs/sdk/craft-quick-start.mdx
+++ b/src/docs/sdk/craft-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Craft Quick Start'
+title: "Craft Quick Start"
 ---
 
 This guide goes over the minimal setup needed to publish something via
@@ -45,8 +45,8 @@ We're just interested in making a GitHub release and a PyPI release so our
 ```yaml
 minVersion: 0.28.1
 targets:
-  - name: pypi
-  - name: github
+- name: pypi
+- name: github
 ```
 
 ### `scripts/bump-version.sh`
@@ -101,7 +101,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: 'Release a new version'
+    name: "Release a new version"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -122,7 +122,7 @@ jobs:
 
 Here's [an example PR] and the [follow-up to fix `fetch-depth`].
 
-[an example pr]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/2
+[an example PR]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/2
 [follow-up to fix `fetch-depth`]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/3
 
 ## Setting Up Permissions

--- a/src/docs/sdk/craft-quick-start.mdx
+++ b/src/docs/sdk/craft-quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Craft Quick Start"
+title: 'Craft Quick Start'
 ---
 
 This guide goes over the minimal setup needed to publish something via
@@ -45,8 +45,8 @@ We're just interested in making a GitHub release and a PyPI release so our
 ```yaml
 minVersion: 0.28.1
 targets:
-- name: pypi
-- name: github
+  - name: pypi
+  - name: github
 ```
 
 ### `scripts/bump-version.sh`
@@ -101,7 +101,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: "Release a new version"
+    name: 'Release a new version'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -122,7 +122,7 @@ jobs:
 
 Here's [an example PR] and the [follow-up to fix `fetch-depth`].
 
-[an example PR]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/2
+[an example pr]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/2
 [follow-up to fix `fetch-depth`]: https://github.com/getsentry/uwsgi-dogstatsd-plugin/pull/3
 
 ## Setting Up Permissions
@@ -144,3 +144,47 @@ This will create an [issue in `publish`] which you'll need an approver to
 add a label to.
 
 [issue in `publish`]: https://github.com/getsentry/publish/issues
+
+## [Optional] Using Multiple Craft Configs in a Repo
+
+In some cases, we need to maintain multiple or diverging publishing configs in a repository.
+For example, when we have to maintain multiple major versions of a package we release (e.g. Sentry JavaScript SDK v7 and v8), where we added or removed artifacts or publishing targets.
+
+By default, our publishing process is configured to take the `craft.yml` config from the repo's default branch as the single source of truth for publishing.
+
+You can opt your repo into using the config from a specific merge target branch (can be configured when triggering the Prepare Release Action) in two steps:
+
+### 1. Release Preparation:
+
+Add `craft_config_from_merge_target: true` when calling `getsentry/action-prepare-release` in your repo's release workflow:
+
+```yml
+# ...
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: 'Release a new version'
+    steps:
+      # ...
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        with:
+          # ...
+          craft_config_from_merge_target: true
+```
+
+### 2. Publish Configuration
+
+Add the branch(es) you want to take the config from to the `publish.yml` workflow in `getsentry/publish`:
+
+```yml
+# ...
+- name: Set target repo checkout branch
+  if: |
+    fromJSON(steps.inputs.outputs.result).repo == 'sentry-javascript' && fromJSON(steps.inputs.outputs.result).merge_target == 'v7'
+```
+
+Note: The branch(es) registered in this step **MUST BE** protected in the target repository.
+Disable direct pushing to the branch and require approvals for PRs before they can be merged.
+
+Good job! Now you can let your craft configs diverge across the different merge target branches and the publishing process will pick up the correct config based on the branch you're setting as a merge target.


### PR DESCRIPTION
This PR adds documentation to our Craft/publishing setup guide in the develop docs: Since we completed the work on https://github.com/getsentry/publish/issues/3441, we now document how to configure a repo's publishing process to use multiple craft configs, depending on the selected merge target branch. 