### PR TITLE
docs(environment): Add devservices script to setup

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -22,7 +22,7 @@ Simply run `devenv sync` inside of your sentry or getsentry repo.
 
 ## Running the Development Server
 
-The `devservices` ensure that you have all the services required for local development running. See the [devservices docs](../services/devservices) for more information on managing services.
+The `devservices` ensure that you have all the services required for local development running. See the [devservices docs](/services/devservices/) for more information on managing services.
 When setting up `sentry`, execute the following command in the `sentry` folder:
 
 ```shell

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -22,6 +22,15 @@ Simply run `devenv sync` inside of your sentry or getsentry repo.
 
 ## Running the Development Server
 
+The `devservices` ensure that you have all the services required for local development running. See the [devservices docs](../services/devservices) for more information on managing services.
+When setting up `sentry`, execute the following command in the `sentry` folder:
+
+```shell
+sentry devservices up
+```
+
+After that, you can start the development server inside the `sentry` folder:
+
 ```shell
 sentry devserver --workers
 ```
@@ -49,6 +58,14 @@ You can create other users with `sentry createuser`.
 </Alert>
 
 See also: <Link to="/sentry-vs-getsentry/">Sentry vs Getsentry</Link>
+
+Just like running `sentry` (see above), you can start the `devservices` using the following command in the `getsentry` folder:
+
+```shell
+sentry devservices up
+```
+
+After that, you can start the development server inside the `getsentry` folder:
 
 ```shell
 getsentry devserver --workers


### PR DESCRIPTION
...as `devservices` need to be started before running the `devserver`