### PR TITLE
chore(metrics): Clarify metrics span seeking/creating mode

### DIFF
--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -78,8 +78,10 @@ In **span seeking** mode, the span is determined based on the current span on th
 APIs such as `.increment()`, `.distribution()`, `.gauge()` and `.set()` operate in span 
 seeking mode.
 
-In **span creating** mode a new active span is started and pushed onto the scope.
-The `.timing()` API shall operate in span creating mode with the following 
+In **span creating** mode a new active span is started.
+The `.timing()` API operates in span creating mode.
+
+In this mode the span should be setup the following way:
 * `span.op = "metric.timing"`
 * `span.description = key` (the metric key)
 * the metric tags should be applied to the span as well

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -79,8 +79,11 @@ APIs such as `.increment()`, `.distribution()`, `.gauge()` and `.set()` operate 
 seeking mode.
 
 In **span creating** mode a new active span is started and pushed onto the scope.
-The `.timing()` API shall operate in span creating mode, and the span is finished once 
-the timing callback finishes. The provided metric tags should be applied to the span as well.
+The `.timing()` API shall operate in span creating mode with the following 
+* `span.op = "metric.timing"`
+* `span.description = key` (the metric key)
+* the metric tags should be applied to the span as well
+* the span is finished once the timing callback finishes
 
 From there two things shall be happening unless they are disabled:  
 * **Common tag attaching:** the tags `transaction`, `release` and `environment`

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -69,15 +69,23 @@ SDKs should permit any string unit, but some of them are known to the system and
 will in the future permit recalculations.  They are documented as part of
 relay: [`MetricUnit`](https://getsentry.github.io/relay/relay_metrics/enum.MetricUnit.html).
 
-## Trace Seeking
+## Span Seeking and Span Creating Mode
 
-When a metric is emitted it needs to find the current trace (trace seeking),
-most specifically the current span.  From there two things shall be happening
-unless they are disabled:
+When a metric is emitted it shall either determine the current span (span seeking) or 
+create a new span (span creating).
 
+In **span seeking** mode, the span is determined based on the current span on the scope.
+APIs such as `.increment()`, `.distribution()`, `.gauge()` and `.set()` operate in span 
+seeking mode.
+
+In **span creating** mode a new active span is started and pushed onto the scope.
+The `.timing()` API shall operate in span creating mode, and the span is finished once 
+the timing callback finishes. The provided metric tags should be applied to the span as well.
+
+From there two things shall be happening unless they are disabled:  
 * **Common tag attaching:** the tags `transaction`, `release` and `environment`
   shall be automatically added to the metric.
-* **Span local aggregation:** the metric shall be attached to the current span
+* **Span local aggregation:** the metric shall be attached to the determined span
   as a local summary (a form of gauge).  For more information see below.
 
 ## API

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -81,7 +81,7 @@ seeking mode.
 In **span creating** mode a new active span is started.
 The `.timing()` API operates in span creating mode.
 
-In this mode the span should be setup the following way:
+In span creating mode the span should be setup the following way:
 * `span.op = "metric.timing"`
 * `span.description = key` (the metric key)
 * the metric tags should be applied to the span as well


### PR DESCRIPTION
Clarify the span creating mode docs based on the [metric correlation RFC](https://github.com/getsentry/rfcs/blob/main/text/0123-metrics-correlation.md#basics).  