### PR TITLE
chore: Expand DSN docs to cover subdomain semantics.

### DIFF
--- a/src/docs/sdk/overview.mdx
+++ b/src/docs/sdk/overview.mdx
@@ -107,6 +107,12 @@ The final endpoint you’ll be sending requests to is constructed per the follow
 '{BASE_URI}/api/{PROJECT_ID}/{ENDPOINT}/'
 ```
 
+Within the `HOST` segment you will find the ingest domain for your organization.
+For self-hosted instance this will be the base host of your instance, and for
+sentry.io it will contain a host in the pattern of
+`o{orgid}.ingest.{region}.sentry.io`. For US based accounts
+`o{orgid}.ingest.sentry.io` will also work.
+
 <Alert title="Note" level="warning">
 All segments, including PROJECT_ID, are of type String.
 </Alert>


### PR DESCRIPTION
Explain what the various subdomains are in a DSN and explain the backwards compatibility for US accounts