### PR TITLE
Add a mapping from old to new hub API

### DIFF
--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -166,13 +166,13 @@ For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI
 
 Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
 
-| Old API                              | New API                                 | Note                                                                                                     |
-| ------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                          |
-| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
-|                                      | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
-| `with push_scope() as scope`         | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
-|                                      | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+| Old API                              | New API                                 | Note                                                                                                       |
+| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                            |
+| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`   | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).           |
+|                                        `scope = Scope.get_current_scope()`       Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.       |
+| `with push_scope() as scope`         | * `with isolation_scope() as scope`     | * We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
+|                                        * `with new_scope() as scope`             * Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -187,7 +187,7 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 		</tr>
 		<tr>
 			<td><code>scope = Scope.get_current_scope()</code></td>
-			<td>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.</td>
+			<td>Should affect the whole span or a part of code isolated via a forked current scope with <ode>new_scope</code>.</td>
 		</tr>
 		<tr>
 			<td rowspan="2" style="vertical-align: middle;"><code>with push_scope() as scope</code></td>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -164,7 +164,7 @@ This image illustrates the behavior of these new APIs and how scope data is appl
 
 For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI=/?share_link_id=140058397661" target="_blank">Miro Board</a>
 
-Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
+Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for which context the changed/forked scope should be active.
 
 <table>
 	<thead>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -166,13 +166,40 @@ For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI
 
 Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
 
-| Old API                              | New API                                 | Note                                                                                                     |
-| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------|
-| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                          |
-| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`   | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
-|                                      | `scope = Scope.get_current_scope()`     | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
-| `with push_scope() as scope`         | `with isolation_scope() as scope`       | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
-|                                      | `with new_scope() as scope`             | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+<table>
+	<thead>
+		<tr>
+			<th>Old API</th>
+			<th>New API</th>
+			<th>Note</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>`hub = Hub(Hub.current)` (hub clone)</td>
+			<td>`with isolation_scope() as scope`</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td rowspan="2">`with configure_scope() as scope`</td>
+			<td>`scope = Scope.get_isolation_scope()`</td>
+			<td>Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).</td>
+		</tr>
+		<tr>
+			<td>`scope = Scope.get_current_scope()`</td>
+			<td>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.</td>
+		</tr>
+		<tr>
+			<td rowspan="2">`with push_scope() as scope`</td>
+			<td>`with isolation_scope() as scope`</td>
+			<td>We're starting a new transaction-worthy unit (request/response cycle, etc.).</td>
+		</tr>
+		<tr>
+			<td>`with new_scope() as scope`</td>
+			<td>Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event.</td>
+		</tr>
+	</tbody>
+</table>
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -169,10 +169,10 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 | Old API                              | New API                               | Note                                                                                                     |
 | ------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`     |                                                                                                          |
-| `with configure_scope as scope`      | `scope = Scope.get_isolation_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
-| `with configure_scope as scope`      | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
-| `with push_scope as scope`           | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
-| `with push_scope as scope`           | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
+| `with configure_scope() as scope`    | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
+| `with push_scope() as scope`         | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
+| `with push_scope() as scope`         | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -164,6 +164,16 @@ This image illustrates the behavior of these new APIs and how scope data is appl
 
 For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI=/?share_link_id=140058397661" target="_blank">Miro Board</a>
 
+Here's how the new APIs roughly map to the old-style APIs:
+
+| Old API                              | New API                               | Note                                                                                                                     |
+| ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`     |                                                                                                                          |
+| `with configure_scope as scope`      | `scope = Scope.get_isolation_scope()` | The change should affect the whole transaction (one request/response cycle, one execution of task, etc.).                |
+| `with configure_scope as scope`      | `scope = Scope.get_current_scope()`   | The change should affect the whole span or a part of code the user isolated via a forked current scope with `new_scope`. |
+| `with push_scope as scope`           | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                                             |
+| `with push_scope as scope`           | `with new_scope() as scope`           | This should only affect a localized part of the code, e.g. if the user wants to add specific data to a specific event.   |
+
 ---
 
 ## F) Use OTel for Performance Instrumentation (POtel)

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -176,26 +176,26 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 	</thead>
 	<tbody>
 		<tr>
-			<td><pre>hub = Hub(Hub.current)</pre> (hub clone)</td>
-			<td><pre>with isolation_scope() as scope</pre></td>
+			<td><code>hub = Hub(Hub.current)</code> (hub clone)</td>
+			<td><code>with isolation_scope() as scope</code></td>
 			<td></td>
 		</tr>
 		<tr>
-			<td rowspan="2" style="vertical-align: middle;"><pre>with configure_scope() as scope</pre></td>
-			<td><pre>scope = Scope.get_isolation_scope()</pre></td>
+			<td rowspan="2" style="vertical-align: middle;"><code>with configure_scope() as scope</code></td>
+			<td><code>scope = Scope.get_isolation_scope()</code></td>
 			<td>Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).</td>
 		</tr>
 		<tr>
-			<td><pre>scope = Scope.get_current_scope()</pre></td>
+			<td><code>scope = Scope.get_current_scope()</code></td>
 			<td>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.</td>
 		</tr>
 		<tr>
-			<td rowspan="2" style="vertical-align: middle;"><pre>with push_scope() as scope</pre></td>
-			<td><pre>with isolation_scope() as scope</pre></td>
+			<td rowspan="2" style="vertical-align: middle;"><code>with push_scope() as scope</code></td>
+			<td><code>with isolation_scope() as scope</code></td>
 			<td>We're starting a new transaction-worthy unit (request/response cycle, etc.).</td>
 		</tr>
 		<tr>
-			<td><pre>with new_scope() as scope</pre></td>
+			<td><code>with new_scope() as scope</code></td>
 			<td>Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event.</td>
 		</tr>
 	</tbody>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -166,13 +166,13 @@ For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI
 
 Here's how the new APIs roughly map to the old-style APIs:
 
-| Old API                              | New API                               | Note                                                                                                                     |
-| ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`     |                                                                                                                          |
-| `with configure_scope as scope`      | `scope = Scope.get_isolation_scope()` | The change should affect the whole transaction (one request/response cycle, one execution of task, etc.).                |
-| `with configure_scope as scope`      | `scope = Scope.get_current_scope()`   | The change should affect the whole span or a part of code the user isolated via a forked current scope with `new_scope`. |
-| `with push_scope as scope`           | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                                             |
-| `with push_scope as scope`           | `with new_scope() as scope`           | This should only affect a localized part of the code, e.g. if the user wants to add specific data to a specific event.   |
+| Old API                              | New API                               | Note                                                                                                     |
+| ------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`     |                                                                                                          |
+| `with configure_scope as scope`      | `scope = Scope.get_isolation_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
+| `with configure_scope as scope`      | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
+| `with push_scope as scope`           | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
+| `with push_scope as scope`           | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -169,10 +169,8 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 | Old API                              | New API                                 | Note                                                                                                       |
 | ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                            |
-| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`   | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).           |
-|                                        `scope = Scope.get_current_scope()`       Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.       |
-| `with push_scope() as scope`         | * `with isolation_scope() as scope`     | * We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
-|                                        * `with new_scope() as scope`             * Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`<br><br>`scope = Scope.get_current_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.). <br>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`. |
+| `with push_scope() as scope`         | `with isolation_scope() as scope`<br><br>`with new_scope() as scope` | We're starting a new transaction-worthy unit (request/response cycle, etc.).<br>Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -166,11 +166,13 @@ For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI
 
 Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
 
-| Old API                              | New API                                 | Note                                                                                                       |
-| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                            |
-| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`<br><br>`scope = Scope.get_current_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.). <br>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`. |
-| `with push_scope() as scope`         | `with isolation_scope() as scope`<br><br>`with new_scope() as scope` | We're starting a new transaction-worthy unit (request/response cycle, etc.).<br>Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+| Old API                              | New API                                 | Note                                                                                                     |
+| ------------------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------|
+| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                          |
+| `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()`   | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
+|                                      | `scope = Scope.get_current_scope()`     | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
+| `with push_scope() as scope`         | `with isolation_scope() as scope`       | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
+|                                      | `with new_scope() as scope`             | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -176,26 +176,26 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 	</thead>
 	<tbody>
 		<tr>
-			<td>`hub = Hub(Hub.current)` (hub clone)</td>
-			<td>`with isolation_scope() as scope`</td>
+			<td><pre>hub = Hub(Hub.current)</pre> (hub clone)</td>
+			<td><pre>with isolation_scope() as scope</pre></td>
 			<td></td>
 		</tr>
 		<tr>
-			<td rowspan="2">`with configure_scope() as scope`</td>
-			<td>`scope = Scope.get_isolation_scope()`</td>
+			<td rowspan="2"><pre>with configure_scope() as scope</pre></td>
+			<td><pre>scope = Scope.get_isolation_scope()</pre></td>
 			<td>Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).</td>
 		</tr>
 		<tr>
-			<td>`scope = Scope.get_current_scope()`</td>
+			<td><pre>scope = Scope.get_current_scope()</pre></td>
 			<td>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.</td>
 		</tr>
 		<tr>
-			<td rowspan="2">`with push_scope() as scope`</td>
-			<td>`with isolation_scope() as scope`</td>
+			<td rowspan="2"><pre>with push_scope() as scope</pre></td>
+			<td><pre>with isolation_scope() as scope</pre></td>
 			<td>We're starting a new transaction-worthy unit (request/response cycle, etc.).</td>
 		</tr>
 		<tr>
-			<td>`with new_scope() as scope`</td>
+			<td><pre>with new_scope() as scope</pre></td>
 			<td>Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event.</td>
 		</tr>
 	</tbody>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -166,13 +166,13 @@ For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI
 
 Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
 
-| Old API                              | New API                               | Note                                                                                                     |
-| ------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`     |                                                                                                          |
+| Old API                              | New API                                 | Note                                                                                                     |
+| ------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `hub = Hub(Hub.current)` (hub clone) | `with isolation_scope() as scope`       |                                                                                                          |
 | `with configure_scope() as scope`    | `scope = Scope.get_isolation_scope()` | Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).         |
-| `with configure_scope() as scope`    | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
+|                                      | `scope = Scope.get_current_scope()`   | Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.     |
 | `with push_scope() as scope`         | `with isolation_scope() as scope`     | We're starting a new transaction-worthy unit (request/response cycle, etc.).                             |
-| `with push_scope() as scope`         | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
+|                                      | `with new_scope() as scope`           | Should affect a localized part of code, e.g. if the user wants to add specific data to a specific event. |
 
 ---
 

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -164,7 +164,7 @@ This image illustrates the behavior of these new APIs and how scope data is appl
 
 For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI=/?share_link_id=140058397661" target="_blank">Miro Board</a>
 
-Here's how the new APIs roughly map to the old-style APIs:
+Here's how the new APIs roughly map to the old-style APIs. In the case of `configure_scope` and `push_scope` it's clear cut whether to use the current or the isolation scope. The choice essentially depends on how long the changed/forked scope should be active. 
 
 | Old API                              | New API                               | Note                                                                                                     |
 | ------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -187,7 +187,7 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 		</tr>
 		<tr>
 			<td><code>scope = Scope.get_current_scope()</code></td>
-			<td>Should affect the whole span or a part of code isolated via a forked current scope with <ode>new_scope</code>.</td>
+			<td>Should affect the whole span or a part of code isolated via a forked current scope with <code>new_scope</code>.</td>
 		</tr>
 		<tr>
 			<td rowspan="2" style="vertical-align: middle;"><code>with push_scope() as scope</code></td>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -181,7 +181,7 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 			<td></td>
 		</tr>
 		<tr>
-			<td rowspan="2"><pre>with configure_scope() as scope</pre></td>
+			<td rowspan="2" style="vertical-align: middle;"><pre>with configure_scope() as scope</pre></td>
 			<td><pre>scope = Scope.get_isolation_scope()</pre></td>
 			<td>Should affect the whole transaction (one request/response cycle, one execution of a task, etc.).</td>
 		</tr>
@@ -190,7 +190,7 @@ Here's how the new APIs roughly map to the old-style APIs. In case of `configure
 			<td>Should affect the whole span or a part of code isolated via a forked current scope with `new_scope`.</td>
 		</tr>
 		<tr>
-			<td rowspan="2"><pre>with push_scope() as scope</pre></td>
+			<td rowspan="2" style="vertical-align: middle;"><pre>with push_scope() as scope</pre></td>
 			<td><pre>with isolation_scope() as scope</pre></td>
 			<td>We're starting a new transaction-worthy unit (request/response cycle, etc.).</td>
 		</tr>

--- a/src/docs/sdk/hub_and_scope_refactoring.mdx
+++ b/src/docs/sdk/hub_and_scope_refactoring.mdx
@@ -164,7 +164,7 @@ This image illustrates the behavior of these new APIs and how scope data is appl
 
 For a zoomable version visit the <a href="https://miro.com/app/board/uXjVNtPiOfI=/?share_link_id=140058397661" target="_blank">Miro Board</a>
 
-Here's how the new APIs roughly map to the old-style APIs. In the case of `configure_scope` and `push_scope` it's clear cut whether to use the current or the isolation scope. The choice essentially depends on how long the changed/forked scope should be active. 
+Here's how the new APIs roughly map to the old-style APIs. In case of `configure_scope` and `push_scope` it's not clear-cut whether to use the current or the isolation scope. The choice essentially depends on how long/for what context the changed/forked scope should be active.
 
 | Old API                              | New API                               | Note                                                                                                     |
 | ------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Rendered preview: https://develop-git-ivana-old-to-new-hub-api.sentry.dev/sdk/hub_and_scope_refactoring/#what-does-the-new-api-look-like

![Screenshot 2024-03-22 at 14 40 06](https://github.com/getsentry/develop/assets/131587164/ddb443bf-d548-423f-af65-712fe7619e05)
