### PR TITLE
feat: add Linux distributions to the os context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -273,6 +273,14 @@ output of the `uname` syscall.
 system. For some well-known runtimes, Sentry will attempt to parse `name` and
 `version` from this string, if they are not explicitly given.
 
+`distribution`
+
+: _Optional_. An object that provides meta-data for Linux distributions. Contains the following keys:
+
+- `name`: A name that is stable for each distribution (examples: `ubuntu`, `rhel`, `alpine`).
+- `version`: _Optional_. Typically identifies at least the major release version number. Distributions with rolling releases only, will not provide a version.
+- `pretty_name`: _Optional_. Typically provides the full name, full version, and release alias (examples: `Ubuntu 22.04.4 LTS`, `Raspian GNU/Linux 10 (buster)`).
+
 ### Example OS Context
 
 The OS Context for the 3 major OSs should look like this:
@@ -295,8 +303,12 @@ The OS Context for the 3 major OSs should look like this:
   "linux": {
     "type": "os",
     "name": "Linux",
-    "version": "5.10.6",
-    "build": "arch1-1"
+    "version": "6.1.82(99.168.amzn2023.x86_64)",
+    "distribution": {
+      "name": "amzn",
+      "version": "2023",
+      "pretty_name": "Amazon Linux 2023.4.20240401"
+    }
   }
 }
 ```

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -275,11 +275,11 @@ system. For some well-known runtimes, Sentry will attempt to parse `name` and
 
 `distribution`
 
-: _Optional_. An object that provides meta-data for Linux distributions. Contains the following keys:
+: _Optional_. An object that provides meta-data for Linux distributions. The values correspond to entries from the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#Options) configuration. Contains the following keys:
 
-- `name`: A name that is stable for each distribution (examples: `ubuntu`, `rhel`, `alpine`).
-- `version`: _Optional_. Typically identifies at least the major release version number. Distributions with rolling releases only, will not provide a version.
-- `pretty_name`: _Optional_. Typically provides the full name, full version, and release alias (examples: `Ubuntu 22.04.4 LTS`, `Raspian GNU/Linux 10 (buster)`).
+- `name`: A stable name for each distribution. This maps to `ID` in `/etc/os-release` (examples: `ubuntu`, `rhel`, `alpine`; a full list of tested identifiers is available in the [Native SDK repository](https://github.com/getsentry/sentry-native/blob/master/tests/fixtures/os_releases/distribution_names.txt).
+- `version`: _Optional_. Typically identifies at least the major release version number. This maps to `VERSION_ID` in `/etc/os-release`. Distributions with rolling releases only, will not provide a version.
+- `pretty_name`: _Optional_. Typically provides the full name, full version, and release alias. This maps to `PRETTY_NAME` in `/etc/os-release` (examples: `Ubuntu 22.04.4 LTS`, `Raspian GNU/Linux 10 (buster)`).
 
 ### Example OS Context
 


### PR DESCRIPTION
Users of the Native SDK would prefer to identify and search for Linux distributions their events come from: https://github.com/getsentry/sentry-native/issues/943.

After a preliminary implementation (https://github.com/getsentry/sentry-native/pull/963 and https://github.com/getsentry/relay/pull/3443), I think it is time to nail down the specification of the context attributes.

I consider the current naming of the attributes to be preliminary. I didn't want to force the naming scheme from `/etc/os-release` onto the attributes here (but maybe we should?), and the selection of the attributes is also a bit arbitrary. 

Only `name` and ` version` make sense as indexable entries because the support of other attributes varies wildly between distributions (not only in availability but sometimes also in meaning). Most users probably want to know where issues occur on a specific distribution version rather than necessarily seeing the URL of a distro's issue tracker. 

Nonetheless, we could add all other attributes we find in `/etc/os-release` (in which case I would use the original names. The current mapping is:


| os context name  | /etc/os-release name | Comment
| ------------- | ------------- | ------------- |
| `name` | `ID`  | the actual `NAME` attribute is not stable and changes in some distros between versions
| `version` | `VERSION_ID` | the `VERSION` attribute often includes version aliases
| `pretty_name` | `PRETTY_NAME` |

I am also unsure whether exposing `distribution` as an object rather than prefixed flat attributes is preferred. All these decisions are easy to revert right now, whereas they can be painful once events are out there.

Cc: @kahest 

