### PR TITLE
Add link to live workshop about migrating to SaaS

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -4,7 +4,7 @@ title: 'Self-Hosted Sentry'
 
 In addition to making its source code available publicly, Sentry offers and maintains a minimal setup that works out-of-the-box for simple use cases. This repository also serves as a blueprint for how various Sentry services connect for a complete setup, which is useful for folks willing to maintain larger installations. For the sake of simplicity, we have chosen to use [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) for this, along with a bash-based install and upgrade script.
 
-If you're self-hosting Sentry and want to know how to switch to Sentry SaaS, check out this [live workshop](https://sentry.io/resources/migrate-to-sentry-saas-workshop/) on April 30th to learn more about our relocation tooling and get your questions answered live.
+If you're self-hosting Sentry and want to know how to switch to Sentry SaaS, check out this [live workshop](https://sentry.io/resources/migrate-to-sentry-saas-workshop/) on April 30th to learn more about our relocation tooling and to get your questions answered live.
 
 ## Getting Started
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -4,7 +4,7 @@ title: 'Self-Hosted Sentry'
 
 In addition to making its source code available publicly, Sentry offers and maintains a minimal setup that works out-of-the-box for simple use cases. This repository also serves as a blueprint for how various Sentry services connect for a complete setup, which is useful for folks willing to maintain larger installations. For the sake of simplicity, we have chosen to use [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) for this, along with a bash-based install and upgrade script.
 
-If you're self-hosting Sentry and want to know how to switch to Sentry SaaS, check out this [live workshop](https://sentry.io/resources/migrate-to-sentry-saas-workshop/) on April 30th to learn more about our relocation tooling and to get your questions answered live.
+If you're self-hosting Sentry and want to know how to switch to Sentry SaaS, check out this [live workshop](https://sentry.io/resources/migrate-to-sentry-saas-workshop/) on April 30th to learn more about our relocation tooling and ask any questions you might have.
 
 ## Getting Started
 

--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -4,6 +4,8 @@ title: 'Self-Hosted Sentry'
 
 In addition to making its source code available publicly, Sentry offers and maintains a minimal setup that works out-of-the-box for simple use cases. This repository also serves as a blueprint for how various Sentry services connect for a complete setup, which is useful for folks willing to maintain larger installations. For the sake of simplicity, we have chosen to use [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) for this, along with a bash-based install and upgrade script.
 
+If you're self-hosting Sentry and want to know how to switch to Sentry SaaS, check out this [live workshop](https://sentry.io/resources/migrate-to-sentry-saas-workshop/) on April 30th to learn more about our relocation tooling and get your questions answered live.
+
 ## Getting Started
 
 Our recommendation is to download the [latest release of the self-hosted repository](https://github.com/getsentry/self-hosted/releases/latest), and then run `./install.sh` inside this directory. This script will take care of all the things you need to get started, including a base-line configuration, and then will tell you to run `docker compose up -d` to start Sentry. Sentry binds to port `9000` by default. You should be able to reach the login page at [http://127.0.0.1:9000](http://127.0.0.1:9000/).


### PR DESCRIPTION
Add link to workshop until April 30th, then change to recorded video once date passes.