### PR TITLE
Let the sidebar scroll independant of the main content

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -21,21 +21,19 @@ type Props = {
 export default ({children, sidebar, pageContext = {}}: Props): JSX.Element => {
   return (
     <div className="document-wrapper">
-      <div className="sidebar">
-        <Header />
-
-        <div
-          className="d-md-flex flex-column align-items-stretch collapse navbar-collapse"
-          id="sidebar"
-        >
-          <div className="toc">
-            <div className="text-white p-3">{sidebar ? sidebar : <Sidebar />}</div>
-          </div>
+      <Header />
+      <div
+        className="d-md-flex flex-column align-items-stretch collapse navbar-collapse"
+        id="sidebar"
+      >
+        <div className="toc">
+          <div className="text-white p-3">{sidebar ? sidebar : <Sidebar />}</div>
         </div>
       </div>
+      
 
       <main role="main" className="px-0">
-        <div className="flex-grow-1">
+        
           <div className="d-none d-md-block">
             <Navbar
               {...(pageContext.platform && {
@@ -50,7 +48,7 @@ export default ({children, sidebar, pageContext = {}}: Props): JSX.Element => {
             </div>
             {children}
           </section>
-        </div>
+        
       </main>
     </div>
   );

--- a/src/css/_includes/grid.scss
+++ b/src/css/_includes/grid.scss
@@ -22,11 +22,17 @@ body {
 
 .document-wrapper {
   display: flex;
-  min-height: 100%;
   flex-direction: column;
+  min-height: 100%;
+  
   overflow: hidden;
 
+  > .global-header {
+    grid-area: header;
+  }
+
   > main {
+    grid-area: main;
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
@@ -36,13 +42,21 @@ body {
 
 @include media-breakpoint-up(md) {
   .document-wrapper {
-    flex-direction: row;
-    max-height: 100%;
+    display: grid;
+    grid-template-areas:
+      'header main'
+      'sidebar main';
+    grid-template-rows: auto 1fr;
+    grid-template-columns: 270px 1fr;
+    max-height: 100vh;
+    overflow: scroll;
   }
 
-  .sidebar {
-    flex-basis: 270px;
-    flex-shrink: 0;
+  #sidebar {
+    grid-area: sidebar;
+    position: sticky;
+    top: 0em;
+    max-height: 100%;
   }
 }
 

--- a/src/css/_includes/sidebar.scss
+++ b/src/css/_includes/sidebar.scss
@@ -1,8 +1,6 @@
-.sidebar {
-  position: relative;
-  min-height: 100%;
-  flex-direction: column;
+#sidebar {
   display: flex;
+  flex-direction: column;
 
   .global-header {
     flex-shrink: 0;
@@ -13,9 +11,18 @@
     flex: 1;
     overflow: auto;
     overflow-x: hidden;
-    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    // border-right: 1px solid rgba(0, 0, 0, 0.1);
     box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.02);
 
+    &::after {
+      content: '';
+      position: absolute;
+      width: 1px;
+      background: rgba(0, 0, 0, 0.1);
+      top: 0px;
+      right: 0px;
+      height: 100%;
+    }
     // &::-webkit-scrollbar {
     //   width: 10px;
     // }
@@ -152,7 +159,7 @@
   // Work around Firefox bug
   // https://moduscreate.com/blog/how-to-fix-overflow-issues-in-css-flex-layouts/
   min-height: 0;
-  margin-top: 2px;
+  overflow: auto;
 }
 
 .section-nav {


### PR DESCRIPTION
**Before** you'd often have cases like this where the main content is gone, and you're scrolling to find some item in the sidebar:
<img width="1104" alt="SCR-20240419-pcak" src="https://github.com/getsentry/develop/assets/187460/675bc96b-3ae3-4846-a6dc-81057d8ecd98">

**After** the sidebar has it's own scrollbar, so you can be at the top of the content, and still nav around:
<img width="1405" alt="SCR-20240419-pcjg" src="https://github.com/getsentry/develop/assets/187460/fa5a9fd4-0e12-4d1b-a77d-fac92f833953">


There are three breakpoints to check:
1. >=992px is the 3 column layout
    In this layout both the left & right "On this page" sidebars are sticky
2. >=768px && <992px is a 2 column layout
    The right sidebar drops to the bottom of the page
4. <768px is one column
    The left sidebar stacks on top of the content, right sidebar is still below.
    Left sidebar can be toggled with the big "Table of contents" button at the top.

There's one buggy thing visible in the 2nd screenshot above. When the content is scrolled & the sidebar becomes sticky, the height of the sidebar doesn't grow, so there's an empty space at the bottom, the border doesn't go all the way either.