### PR TITLE
chore(lockreason): Update Lock Reason docs

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -212,9 +212,6 @@ export default () => {
             <SidebarLink to="/sdk/event-payloads/exception/">
               Exception Interface
             </SidebarLink>
-            <SidebarLink to="/sdk/event-payloads/lockreason/">
-              Lock Reason Interface
-            </SidebarLink>
             <SidebarLink to="/sdk/event-payloads/message/">Message Interface</SidebarLink>
             <SidebarLink to="/sdk/event-payloads/request/">Request Interface</SidebarLink>
             <SidebarLink to="/sdk/event-payloads/sdk/">SDK Interface</SidebarLink>

--- a/src/docs/sdk/event-payloads/index.mdx
+++ b/src/docs/sdk/event-payloads/index.mdx
@@ -319,7 +319,6 @@ The core data interfaces are:
 
 - [Debug Meta Interface](debugmeta/)
 - [SDK Interface](sdk/)
-- [Lock Reason Interface](lockreason/)
 
 ## Type Definitions
 

--- a/src/docs/sdk/event-payloads/lockreason.mdx
+++ b/src/docs/sdk/event-payloads/lockreason.mdx
@@ -6,6 +6,12 @@ Represents an instance of a held lock (monitor object) in a thread. Typically, t
 to determine which other thread is holding the lock in case the current thread is blocked. In languages like
 `Java` or `Kotlin` this typically will be represented by a `java.lang.Object` type.
 
+<Note>
+
+Lock reasons are always part of a thread. They cannot be declared as a top-level event property. 
+
+</Note>
+
 ## Attributes
 
 `type`

--- a/src/docs/sdk/event-payloads/lockreason.mdx
+++ b/src/docs/sdk/event-payloads/lockreason.mdx
@@ -8,7 +8,7 @@ to determine which other thread is holding the lock in case the current thread i
 
 <Note>
 
-Lock reasons are always part of a thread. They cannot be declared as a top-level event property. 
+Lock reasons are always part of a [thread](/sdk/event-payloads/threads/). They cannot be declared as a top-level event property. 
 
 </Note>
 


### PR DESCRIPTION
As discussed - Lock Reason is not a top level field but rather part of the threads interface. This PR aims to reflect that by removing it from the sidbar and Event Paylods index page, and adding a note to that effect