### PR TITLE
docs(frontend): Remove sidebar link to old DefaultProps frontend page

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -134,7 +134,6 @@ export default () => {
           <SidebarLink to="/frontend/development-server/">Development Server</SidebarLink>
           <SidebarLink to="/frontend/component-library/">Component Library</SidebarLink>
           <SidebarLink to="/frontend/network-requests/">Network Requests</SidebarLink>
-          <SidebarLink to="/frontend/defaultprops/">Typing DefaultProps</SidebarLink>
           <SidebarLink to="/frontend/using-hooks/">Using hooks</SidebarLink>
           <SidebarLink to="/frontend/using-rtl/">Using React Testing Library</SidebarLink>
           <SidebarLink to="/frontend/working-on-getting-started-docs/">


### PR DESCRIPTION
I just removed this page in https://github.com/getsentry/develop/pull/1239, need to remove the link as well