### PR TITLE
Add SDK features to event payload

### DIFF
--- a/src/docs/sdk/event-payloads/sdk.mdx
+++ b/src/docs/sdk/event-payloads/sdk.mdx
@@ -54,6 +54,13 @@ have all enabled integrations, including default integrations. Default
 integrations are included because different SDK releases may contain different
 default integrations.
 
+`features`
+
+: _Optional_. A list of feature names identifying enabled SDK features. This list
+should contain all enabled SDK features. On some SDKs, enabling a feature in the
+options also adds an integration. We encourage tracking such features with either
+integrations or features but not both to reduce the payload size.
+
 `packages`
 
 : _Optional_. A list of packages that were installed as part of this SDK or the
@@ -73,6 +80,7 @@ attributes for simplicity.
     "name": "sentry.javascript.react-native",
     "version": "1.0.0",
     "integrations": ["redux"],
+    "features": ["capture_failed_requests"],
     "packages": [
       {
         "name": "npm:@sentry/react-native",


### PR DESCRIPTION
Add a new field features to the SDK event payload, which is handy for tracking the adoption of features.

This is for https://github.com/getsentry/team-sdks/issues/83.