### PR TITLE
feat: Add `app.app_arch` context

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -364,6 +364,10 @@ ID.
 
 : _Optional_. Amount of memory used by the application in bytes.
 
+`app_arch`
+
+: _Optional_. The CPU architecture of the application. This may differ from the device CPU architecture.
+
 `in_foreground`
 
 : _Optional_. A flag indicating whether the app is in foreground or not. An app is in foreground when it's visible to the user.

--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -379,7 +379,7 @@ If a platform doesn't provide capabilities to identify whether a permission has 
 
 `view_names`
 
-: _Optional_. A list of visibile UI screens at the current point in time.
+: _Optional_. A list of visible UI screens at the current point in time.
 
 ## Browser Context
 
@@ -647,7 +647,7 @@ Additional information that allows Sentry to connect multiple transactions, span
 
 - Example: `"ok"`
 
-- List of availabale status plus description:
+- List of available status plus description:
 
   | State                        | Description                                                                                                  | HTTP status code equivalent |
   | ---------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------- |


### PR DESCRIPTION
There is already `device.arch` but I couldn't find a suitable property to include the app arch. 

The app and device architecture can differ, for example when running through Rosetta or Windows WOW64 emulation.

I also fixed a couple of typos!