### PR TITLE
Add ttid/ttfd contribution flags to span data convention

### DIFF
--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -56,8 +56,8 @@ Below describes the conventions for the Span interface for the `data` field on t
 
 | Attribute                         | Type   | Description                                 | Examples              |
 | --------------------------------- | ------ | ------------------------------------------- | --------------------- |
-| `ui.contributes_ttid`    | boolean |  Whether the span execution contributed to the TTID (time to initial display) metric.  |   `true`   |
-| `ui.contributes_ttfd`    | boolean |  Whether the span execution contributed to the TTFD (time to fully drawn) metric. |   `true`   |
+| `ui.contributes_to_ttid`    | boolean |  Whether the span execution contributed to the TTID (time to initial display) metric.  |   `true`   |
+| `ui.contributes_to_ttfd`    | boolean |  Whether the span execution contributed to the TTFD (time to fully drawn) metric. |   `true`   |
 
 
 ## Database

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -43,6 +43,8 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `frames.slow`     | int | The number of slow frames rendered during the lifetime of the span.     |   `2`   |
 | `frames.frozen`   | int | The number of frozen frames rendered during the lifetime of the span.   |   `1`   |
 | `frames.delay`    | number | The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see <Link to="/sdk/performance/frames-delay/">frames delay</Link>.   |   `1.3246`   |
+| `contributes_ttid`    | boolean |  Whether the span execution contributed to the TTID (time to initial display) metric.  |   `true`   |
+| `contributes_ttfd`    | boolean |  Whether the span execution contributed to the TTFD (time to fully drawn) metric. |   `true`   |
 
 ## Browser
 

--- a/src/docs/sdk/performance/span-data-conventions.mdx
+++ b/src/docs/sdk/performance/span-data-conventions.mdx
@@ -43,8 +43,6 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `frames.slow`     | int | The number of slow frames rendered during the lifetime of the span.     |   `2`   |
 | `frames.frozen`   | int | The number of frozen frames rendered during the lifetime of the span.   |   `1`   |
 | `frames.delay`    | number | The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see <Link to="/sdk/performance/frames-delay/">frames delay</Link>.   |   `1.3246`   |
-| `contributes_ttid`    | boolean |  Whether the span execution contributed to the TTID (time to initial display) metric.  |   `true`   |
-| `contributes_ttfd`    | boolean |  Whether the span execution contributed to the TTFD (time to fully drawn) metric. |   `true`   |
 
 ## Browser
 
@@ -53,6 +51,14 @@ Below describes the conventions for the Span interface for the `data` field on t
 | `url`                             | string | The URL of the resource that was fetched.   | `https://example.com` |
 | `type`                            | string | The type of the resource that was fetched.  | `xhr`                 |
 | `resource.render_blocking_status` | string | The render blocking status of the resource. | `non-blocking`        |
+
+## UI
+
+| Attribute                         | Type   | Description                                 | Examples              |
+| --------------------------------- | ------ | ------------------------------------------- | --------------------- |
+| `ui.contributes_ttid`    | boolean |  Whether the span execution contributed to the TTID (time to initial display) metric.  |   `true`   |
+| `ui.contributes_ttfd`    | boolean |  Whether the span execution contributed to the TTFD (time to fully drawn) metric. |   `true`   |
+
 
 ## Database
 


### PR DESCRIPTION
Add `ui.ui.contributes_to_ttid` and `ui.ui.contributes_to_ttfd` to the span data bag. The SDKs should set those flags on all spans which contribute to ttid / ttfd.

I'm still not 100% happy with the naming, if you have something better in mind, feel free to suggest!

Based on previous discussions here: https://www.notion.so/sentry/span-contribution-9b5a0979a81645789db6877593729cf4

Java impl: https://github.com/getsentry/sentry-java/pull/3386

Preview deeplink: https://develop-git-feat-ttidttfdcontributingflags.sentry.dev/sdk/performance/span-data-conventions/#ui
