### PR TITLE
docs(self-hosted): avoid version confusion by specifying that we assume the version

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -13,6 +13,8 @@ Our recommendation is to download the [latest release of the self-hosted reposi
 To have easy maintainability for future upgrades, it is recommended to use Git workflow by cloning the self-hosted repository and check out to a specific CalVer tag. More about this on [Releases & Upgrading](/self-hosted/releases/).
 
 ```bash
+# Assuming current latest version is 24.1.0
+# Current actual version can be acquired from the Releases page on GitHub
 VERSION="24.1.0"
 git clone https://github.com/getsentry/self-hosted.git
 cd self-hosted

--- a/src/docs/self-hosted/releases.mdx
+++ b/src/docs/self-hosted/releases.mdx
@@ -35,6 +35,7 @@ Before starting the upgrade, we shut down all the services and then run some dat
 If you downloaded self-hosted repository using Git clone, the upgrade commands should look like this:
 
 ```bash
+# Assuming your destination upgrade version is 24.3.0
 VERSION="24.3.0"
 git fetch
 git checkout ${VERSION}


### PR DESCRIPTION
There have been cases where people said on Discord or on GitHub issues that the version is misleading, that it's not the correct current version or the version's not exists yet (at that time of complaint, 24.3.0 wasn't released yet). So I hope by specifying "We assume the current version is 24.1.0", it'd make people aware to go ahead and check the current version themself.

/cc @hubertdeng123 @azaslavsky 