### PR TITLE
Empty pages for all performance modules. To be filled in separate PRs

### DIFF
--- a/src/docs/sdk/performance/modules/app-starts.mdx
+++ b/src/docs/sdk/performance/modules/app-starts.mdx
@@ -1,0 +1,5 @@
+---
+title: 'App Starts Module'
+---
+
+to be defined ...

--- a/src/docs/sdk/performance/modules/caches.mdx
+++ b/src/docs/sdk/performance/modules/caches.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cache
+title: 'Caches Module'
 ---
 
 The SDK's caching integration is agnostic to the underlying engine used. In most cases, the SDK will instrument existing cache abstractions in certain frameworks or libraries.

--- a/src/docs/sdk/performance/modules/index.mdx
+++ b/src/docs/sdk/performance/modules/index.mdx
@@ -4,5 +4,10 @@ title: 'Performance Modules'
 
 The list below contains SDK documentation for our various Performance Modules.
 
-- [Cache Module](/sdk/performance/modules/cache/)
-- [Queue Module](/sdk/performance/modules/queue/)
+- [App Starts](/sdk/performance/modules/app-starts/)
+- [Caches](/sdk/performance/modules/caches/)
+- [Queues](/sdk/performance/modules/queues/)
+- [Requests](/sdk/performance/modules/requests/)
+- [Resources](/sdk/performance/modules/resources/)
+- [Screen Loads](/sdk/performance/modules/screen-loads/)
+- [Web Vitals](/sdk/performance/modules/web-vitals/)

--- a/src/docs/sdk/performance/modules/queries.mdx
+++ b/src/docs/sdk/performance/modules/queries.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Queries Module'
+---
+
+to be defined ...

--- a/src/docs/sdk/performance/modules/queues.mdx
+++ b/src/docs/sdk/performance/modules/queues.mdx
@@ -1,5 +1,5 @@
 ---
-title: Queue Module
+title: 'Queues Module'
 ---
 
 The SDK's queue integration is agnostic to the underlying engine used. In most cases, the SDK will instrument existing queue abstractions in certain frameworks or libraries.

--- a/src/docs/sdk/performance/modules/requests.mdx
+++ b/src/docs/sdk/performance/modules/requests.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Requests Module'
+---
+
+to be defined ...

--- a/src/docs/sdk/performance/modules/resources.mdx
+++ b/src/docs/sdk/performance/modules/resources.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Resources Module'
+---
+
+to be defined ...

--- a/src/docs/sdk/performance/modules/screen-loads.mdx
+++ b/src/docs/sdk/performance/modules/screen-loads.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Screen Loads Module'
+---
+
+to be defined ...

--- a/src/docs/sdk/performance/modules/web-vitals.mdx
+++ b/src/docs/sdk/performance/modules/web-vitals.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Web Vitals Module'
+---
+
+to be defined ...


### PR DESCRIPTION
This are all the performance modules we currently have. We should document what makes spans eligible to show up in those modules, to make it easier for all the SDKs implement those requirements in their auto instrumentation (and to make it also easy to add documentation for manual instrumentation that should fill those modules with data.)