### PR TITLE
docs(self-hosted): Add missing slash in caddy reverse-proxy path_regexp example

### DIFF
--- a/src/docs/self-hosted/reverse-proxy.mdx
+++ b/src/docs/self-hosted/reverse-proxy.mdx
@@ -130,7 +130,7 @@ sentry.yourcompany.com {
 
     # To expose only ingest endpoint publicly, add the named matcher below before `reverse_proxy` directive
     # @ingest_endpoint {
-    #     path_regexp /api/[1-9]\d+(envelope|minidump|security|store|unreal)/
+    #     path_regexp /api/[1-9]\d+/(envelope|minidump|security|store|unreal)/
     # }
 }
 ```


### PR DESCRIPTION
This took me wayyy to long to realize...