### PR TITLE
docs(screenloads): Document span conditions for screen loads metrics

### DIFF
--- a/src/docs/sdk/performance/modules/screen-loads.mdx
+++ b/src/docs/sdk/performance/modules/screen-loads.mdx
@@ -4,6 +4,14 @@ title: 'Screen Loads Module'
 
 The Screen Loads module records metrics from spans in `ui.load` transactions using specific span operations.
 
+# Transaction Conventions
+
+## Transaction Measurements
+| Key | Unit | Description | Conditions |
+|:--|:--|:--|:--|
+| `time_to_initial_display` | milliseconds | The time it took to load the first frame | required |
+| `time_to_full_display` | milliseconds | The time it took to fully load the screen | optional, requires manual instrumentation |
+
 # Span Conventions
 
 ## Span Operations
@@ -20,8 +28,3 @@ The Screen Loads module records metrics from spans in `ui.load` transactions usi
 | `ui.load.full_display` | When the screen has fully completed loading |
 | `ui.load.initial_display` | When the screen has rendered its first frame |
 
-## Span Measurements
-| Key | Unit | Description |
-|:--|:--|:--|
-| `time_to_initial_display` | milliseconds | The time it took to load the first frame |
-| `time_to_full_display` | milliseconds | The time it took to fully load the screen |

--- a/src/docs/sdk/performance/modules/screen-loads.mdx
+++ b/src/docs/sdk/performance/modules/screen-loads.mdx
@@ -2,4 +2,26 @@
 title: 'Screen Loads Module'
 ---
 
-to be defined ...
+The Screen Loads module records metrics from spans in `ui.load` transactions using specific span operations.
+
+# Span Conventions
+
+## Span Operations
+| Span OP | Description |
+|:--|:--|
+| `db.sql.query` | A database query |
+| `db.sql.room` | A database query using the Room library on Android |
+| `db.sql.transaction` | - |
+| `db` | An operation on the database |
+| `file.read` | Reading a file from the file system |
+| `file.write` | Writing to a file on the file system |
+| `http.client` | An outgoing network request |
+| `ui.load` | An operation on a mobile UI |
+| `ui.load.full_display` | When the screen has fully completed loading |
+| `ui.load.initial_display` | When the screen has rendered its first frame |
+
+## Span Measurements
+| Key | Unit | Description |
+|:--|:--|:--|
+| `time_to_initial_display` | milliseconds | The time it took to load the first frame |
+| `time_to_full_display` | milliseconds | The time it took to fully load the screen |


### PR DESCRIPTION
Documents the conditions for collecting span metrics to satisfy the screen loads module.

The screen loads module filters for specifically `ui.load` transactions and will surface data from the following spans.