### PR TITLE
feat(metrics): Add maximum length for metric components

### DIFF
--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -62,10 +62,10 @@ class Aggregator:
 ## Normalization
 
 Normalization shall be done for `statsd` envelope items with unicode support if possible:
-* **Metric Name:** regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
-* **Metric Namespaces and Unit:** regex `[^a-zA-Z0-9_]+` with no replacement character.
-* **Metric Tag Keys:** regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
-* **Metric Tag Values:** See below
+* **Metric Name**: regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
+* **Metric Namespaces and Unit**: regex `[^a-zA-Z0-9_]+` with no replacement character.
+* **Metric Tag Keys**: regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
+* **Metric Tag Values**: see below.
 
 {/* Internal note: We can't use `\w` instead of `a-zA-Z0-9` because on some Regex engines `\w` includes chars such as `ä`, `ö` or `é`. */}
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -62,10 +62,10 @@ class Aggregator:
 ## Normalization
 
 Normalization shall be done for `statsd` envelope items with unicode support if possible:
-* **Metric Name**: regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
-* **Metric Namespaces and Unit**: regex `[^a-zA-Z0-9_]+` with no replacement character.
-* **Metric Tag Keys**: regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
-* **Metric Tag Values**: see below.
+* **Metric Name**: Regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
+* **Metric Namespaces and Unit**: Regex `[^a-zA-Z0-9_]+` with no replacement character.
+* **Metric Tag Keys**: Regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
+* **Metric Tag Values**: See below.
 
 {/* Internal note: We can't use `\w` instead of `a-zA-Z0-9` because on some Regex engines `\w` includes chars such as `ä`, `ö` or `é`. */}
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -61,12 +61,11 @@ class Aggregator:
 
 ## Normalization
 
-Normalization shall be done for `statsd` envelope items with unicode support if possible.
-
-* **Namespaces and Units:** regex `[^a-zA-Z0-9_]+` with no replacement character.
-* **Metric Keys/Names:** regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
-* **Tag Keys:** regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
-* **Tag Values:** See below
+Normalization shall be done for `statsd` envelope items with unicode support if possible:
+* **Metric Name:** regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
+* **Metric Namespaces and Unit:** regex `[^a-zA-Z0-9_]+` with no replacement character.
+* **Metric Tag Keys:** regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
+* **Metric Tag Values:** See below
 
 {/* Internal note: We can't use `\w` instead of `a-zA-Z0-9` because on some Regex engines `\w` includes chars such as `ä`, `ö` or `é`. */}
 
@@ -86,9 +85,11 @@ Reserved characters for Tag Values are `\n`, `\r`, `\t`, `\`, `|`, `,`. The repl
 
 ### Maximum Lengths
 
-The lengths of the following components of the `statsd` envelope items are limited:
-- **Metric Keys/Names**: 150 characters.
-- **Units**: 15 characters.
+The lengths of the following components of the `statsd` envelope items should be limited:
+- **Metric Name**: 150 characters.
+- **Metric Unit**: 15 characters.
+- **Metric Tag Keys**: 32 characters.
+- **Metric Tag Values**: 200 characters.
 
 ## Units
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -64,8 +64,8 @@ class Aggregator:
 Normalization shall be done for `statsd` envelope items with unicode support if possible:
 * **Metric Name**: Regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
 * **Metric Namespace and Unit**: Regex `[^a-zA-Z0-9_]+` with no replacement character.
-* **Metric Tag Keys**: Regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
-* **Metric Tag Values**: See below.
+* **Metric Tag Key**: Regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
+* **Metric Tag Value**: See below.
 
 {/* Internal note: We can't use `\w` instead of `a-zA-Z0-9` because on some Regex engines `\w` includes chars such as `ä`, `ö` or `é`. */}
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -88,8 +88,6 @@ Reserved characters for Tag Values are `\n`, `\r`, `\t`, `\`, `|`, `,`. The repl
 The lengths of the following components of the `statsd` envelope items should be limited:
 - **Metric Name**: 150 characters.
 - **Metric Unit**: 15 characters.
-- **Metric Tag Keys**: 32 characters.
-- **Metric Tag Values**: 200 characters.
 
 ## Units
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -63,7 +63,7 @@ class Aggregator:
 
 Normalization shall be done for `statsd` envelope items with unicode support if possible:
 * **Metric Name**: Regex `[^a-zA-Z0-9_\-.]+` with replacement character `_`.
-* **Metric Namespaces and Unit**: Regex `[^a-zA-Z0-9_]+` with no replacement character.
+* **Metric Namespace and Unit**: Regex `[^a-zA-Z0-9_]+` with no replacement character.
 * **Metric Tag Keys**: Regex `[^a-zA-Z0-9_\-.\/]+` with no replacement character.
 * **Metric Tag Values**: See below.
 

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -84,6 +84,12 @@ Reserved characters for Tag Values are `\n`, `\r`, `\t`, `\`, `|`, `,`. The repl
 | Pipe (`\|`) | `\u{7c}` |
 | Comma (`,`) | `\u{2c}` |
 
+### Maximum Lengths
+
+The lengths of the following components of the `statsd` envelope items are limited:
+- **Metric Keys/Names**: 150 characters.
+- **Units**: 15 characters.
+
 ## Units
 
 SDKs should permit any string unit, but some of them are known to the system and


### PR DESCRIPTION
This PR updates our develop docs with the updated limits for metric name and unit lengths.

Related to: https://github.com/getsentry/relay/pull/3628