### PR TITLE
docs(app-starts): Add SDK requirements

### DIFF
--- a/src/docs/sdk/performance/modules/app-starts.mdx
+++ b/src/docs/sdk/performance/modules/app-starts.mdx
@@ -2,4 +2,36 @@
 title: 'App Starts Module'
 ---
 
-to be defined ...
+The App Starts module records metrics from spans in `ui.load` transactions using specific span operations.
+
+# Transaction Conventions
+
+## Transaction Measurements
+| Key | Unit | Description | Conditions |
+|:--|:--|:--|:--|
+| `app_start_cold` | milliseconds | The time it took to load the first frame during a cold app start | required for cold app starts |
+| `app_start_warm` | milliseconds | The time it took to load the first frame during a warm app start | required for warm app starts |
+
+# Span Conventions
+
+## Span Operations
+| Span OP | Description | Conditions |
+|:--|:--|:--|
+| `app.start.cold` | An operation during cold start | At least one span with the description "Cold Start" must be present in a transaction |
+| `app.start.warm` | An operation during warm start | At least one span with the description "Warm Start" must be present in a transaction |
+| `db.sql.query` | A database query | - |
+| `db.sql.transaction` | - | - |
+| `db` | An operation on the database | - |
+| `file.read` | Reading a file from the file system | - |
+| `file.write` | Writing to a file on the file system | - |
+| `http.client` | An outgoing network request | - |
+| `ui.load` | An operation on a mobile UI | - |
+
+## Android-Specific Span Operations
+| Span OP | Description |
+|:--|:--|
+| `activity.load` | Calling `onCreate` for an activity |
+| `application.load` | Calling the application `onCreate` |
+| `contentprovider.load` | Calling `onCreate` for a content provider |
+| `db.sql.room` | A database query using the Room library | - |
+| `process.load` | Duration of time spent by the OS prior to the first content provider initialization |


### PR DESCRIPTION
Reflects what conditions are required for ingestion of app start metrics in relay to support the app start module.

I had to split out the Android specific ops because iOS uses `app.start.cold` or `app.start.warm` and varies the description to identify different operations.