### PR TITLE
docs(queues): Clarify where to set span data

### DIFF
--- a/src/docs/sdk/performance/modules/queues.mdx
+++ b/src/docs/sdk/performance/modules/queues.mdx
@@ -26,7 +26,7 @@ The following data attributes must be set on both the consumer and the producer 
 | `messaging.destination.name` | string | the destination name where the message is being consumed from, e.g. the queue name or topic |
 | `messaging.system` | string | the name of the messaging system, e.g. `kafka`, `aws_sqs ` |
 
-The following data attributes are only to be set if exposed by the instrumented queuing abstraction or retrievable with minimal overhead. When possible, they should also be set on both the producer and consumer spans.
+The following data attributes are only to be set if exposed by the instrumented queuing abstraction or retrievable with minimal overhead. When possible, the attributes should be set on both the producer and consumer spans.
 
 | Data Key | Type | Description | Conditions
 |:--|:--|:--|:--|


### PR DESCRIPTION
Clarify that span data should be set on both consumer and producer spans, where possible.