### PR TITLE
docs(analytics): Add info about testing locally

### DIFF
--- a/src/docs/analytics.mdx
+++ b/src/docs/analytics.mdx
@@ -249,6 +249,10 @@ All events should be typed which specifies what the payload should be. We also d
 
 Our current naming convention for Reload events is `descriptor.action` e.g. what we have above with `example_tutorial.created` and `example_tutorial.deleted` . You want these to be specific enough to capture the action of interest but not too specific that you have a million distinctly named events with information that could be captured in the data object. For example, if you can create your example tutorial from multiple places, fight the urge to have the source as part of your descriptor i.e. `example_tutorial_onboarding.created` and `example_tutorial_settings.created`. Your future self running analytics will thank you. Amplitude event names should be similar to the Reload event name except you should capitalize the words and use spaces instead of underscores.
 
+### Testing your Analytics Event 
+
+When developing locally, analytics events will not be sent to Reload or Amplitude. To test to see if your event is sending as expected and with the correct data, you can set "DEBUG_ANALYTICS" to "1" in local storage on your browser. Then it will log the analytics event data to your console, whenever it would've sent an analytics event, allowing to check your analytics locally. 
+
 **getsentry**
 
 ```jsx


### PR DESCRIPTION
this pr adds a line about testing analytics events locally