### PR TITLE
doc(metrics): Metric tags can only have a single value

### DIFF
--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -43,7 +43,7 @@ exist:
 * **Background Aggregation:** SDKs are encouraged to defer flushing and aggregation
   into a background thread.  For SDKs where `fork()` is to be expected, the background
   thread needs to ensure it restarts after fork (eg: python).
-* **Tagging:** metrics are tagged by key value pairs. Both keys and values are limited to strings,
+* **Tagging:** metrics can be tagged with a unique key and an optional value for each key. Both keys and values are limited to strings,
   but the SDK can expose other types if it has a reasonable way to stringify these.
 
 In abstract terms the aggregator is recommended to look a bit like this:

--- a/src/docs/sdk/metrics.mdx
+++ b/src/docs/sdk/metrics.mdx
@@ -43,9 +43,8 @@ exist:
 * **Background Aggregation:** SDKs are encouraged to defer flushing and aggregation
   into a background thread.  For SDKs where `fork()` is to be expected, the background
   thread needs to ensure it restarts after fork (eg: python).
-* **Tagging:** metrics are tagged by key value pairs, where each key can have more
-  than one value.  Both keys and values are limited to strings, but the SDK can
-  expose other types if it has a reasonable way to stringify these.
+* **Tagging:** metrics are tagged by key value pairs. Both keys and values are limited to strings,
+  but the SDK can expose other types if it has a reasonable way to stringify these.
 
 In abstract terms the aggregator is recommended to look a bit like this:
 


### PR DESCRIPTION
Neither Relay nor storage support multi-value tags.

Fixes https://github.com/getsentry/relay/issues/3691.