### PR TITLE
Discord "SDK Contributor" chat is no longer used. Moved to "SDK-Chat"

### DIFF
--- a/src/docs/sdk/basics.mdx
+++ b/src/docs/sdk/basics.mdx
@@ -35,10 +35,10 @@ When sending events just substitute `orgXXX.ingest.sentry.io` with `localhost:30
 whichever port you ended up chosing.  Also note that a local relay will out of the box
 be available via HTTP only so don't try to send HTTPS requests there.
 
-Join the SDK maintainers channel on Discord
+Join the SDK chat on Discord
 ---------------------
 
-You can reach out to Sentry open source contributors and find other SDK maintainers in the [Sentry Discord server](https://discord.gg/sentry). Make sure to say hi on `#sdk-maintainers`.
+You can reach out to Sentry open source contributors and talk with other SDK maintainers in the [Sentry Discord server](https://discord.gg/sentry). Make sure to say hi in the `#sdk-chat`.
 
 Consult Existing SDKs
 ---------------------


### PR DESCRIPTION
<img width="721" alt="image" src="https://github.com/getsentry/develop/assets/106361624/7883fe20-aef2-4abe-b338-b3f7f28419b5">

Channel is Archived on discord. updated channel is 
<img width="243" alt="image" src="https://github.com/getsentry/develop/assets/106361624/e60ca4e2-f3a0-4062-9f22-908f69c568fc">
