### PR TITLE
fix(environment): restructure subheadings and clarify ingest setup

### DIFF
--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -202,7 +202,7 @@ environment, you can create `getsentry/conf/settings/devlocal.py` and put the
 configuration option overrides there. This module will be automatically imported
 by `dev.py` if it exists.
 
-To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-(relay)">here</Link> and run ```shell
+To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run ```shell
 getsentry devserver --workers --ingest
 
 ## Troubleshooting

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -202,8 +202,9 @@ environment, you can create `getsentry/conf/settings/devlocal.py` and put the
 configuration option overrides there. This module will be automatically imported
 by `dev.py` if it exists.
 
-To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run ```shell
-getsentry devserver --workers --ingest
+To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run 
+```shell
+getsentry devserver --workers --ingest```
 
 ## Troubleshooting
 

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -132,7 +132,8 @@ by `dev.py` if it exists.
 
 To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run 
 ```shell
-getsentry devserver --workers --ingest```
+getsentry devserver --workers --ingest
+```
 
 
 ## Running siloed instances

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -202,7 +202,7 @@ environment, you can create `getsentry/conf/settings/devlocal.py` and put the
 configuration option overrides there. This module will be automatically imported
 by `dev.py` if it exists.
 
-To enable the ingest workers, follow the steps described <Link to="###Ingestion Pipeline (Relay)">here</Link> and run ```shell
+To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-(relay)">here</Link> and run ```shell
 getsentry devserver --workers --ingest
 
 ## Troubleshooting

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -99,6 +99,42 @@ sentry devservices rm snuba
 sentry devservices up snuba
 ```
 
+## Running the Getsentry Development Server
+
+<Alert title="Employees Only" level="warning">
+  Only Sentry employees have access to getsentry.
+</Alert>
+
+See also: <Link to="/sentry-vs-getsentry/">Sentry vs Getsentry</Link>
+
+Just like running `sentry` (see above), you can start the `devservices` using the following command in the `getsentry` folder:
+
+```shell
+sentry devservices up
+```
+
+After that, you can start the development server inside the `getsentry` folder:
+
+```shell
+getsentry devserver --workers
+```
+
+**Note**: You **cannot** have both sentry and getsentry devserver running at the same time.
+
+After the server warms up for a little while, you must access it
+at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/).
+Using localhost doesn't work.
+
+If you need to overwrite configuration options for your local
+environment, you can create `getsentry/conf/settings/devlocal.py` and put the
+configuration option overrides there. This module will be automatically imported
+by `dev.py` if it exists.
+
+To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run 
+```shell
+getsentry devserver --workers --ingest```
+
+
 ## Running siloed instances
 
 By default `sentry devserver` will run a monolith mode application server. You can also run ``devserver`` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.
@@ -170,41 +206,6 @@ SENTRY_SILO_DEVSERVER=1 SENTRY_SILO_MODE=CONTROL getsentry django shell
 # Start a region silo shell
 SENTRY_SILO_DEVSERVER=1 SENTRY_SILO_MODE=REGION SENTRY_REGION=us getsentry django shell
 ```
-
-## Running the Getsentry Development Server
-
-<Alert title="Employees Only" level="warning">
-  Only Sentry employees have access to getsentry.
-</Alert>
-
-See also: <Link to="/sentry-vs-getsentry/">Sentry vs Getsentry</Link>
-
-Just like running `sentry` (see above), you can start the `devservices` using the following command in the `getsentry` folder:
-
-```shell
-sentry devservices up
-```
-
-After that, you can start the development server inside the `getsentry` folder:
-
-```shell
-getsentry devserver --workers
-```
-
-**Note**: You **cannot** have both sentry and getsentry devserver running at the same time.
-
-After the server warms up for a little while, you must access it
-at [http://dev.getsentry.net:8000](http://dev.getsentry.net:8000/).
-Using localhost doesn't work.
-
-If you need to overwrite configuration options for your local
-environment, you can create `getsentry/conf/settings/devlocal.py` and put the
-configuration option overrides there. This module will be automatically imported
-by `dev.py` if it exists.
-
-To enable the ingest workers, follow the steps described <Link to="#ingestion-pipeline-relay">here</Link> and run 
-```shell
-getsentry devserver --workers --ingest```
 
 ## Troubleshooting
 

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -49,6 +49,55 @@ You can create other users with `sentry createuser`.
   displayed correctly.
 </Alert>
 
+### Frontend Only & Backend Only
+
+Please refer to [Frontend Development Server](/frontend/development-server/) and [Backend Development Server](/backend/development-server/) for alternative ways to bring up the Sentry UI.
+
+### Enabling HTTPS
+
+You may wish to run the development server in HTTPS mode. This can be done by generating and installing local certificates.
+
+We will be using [mkcert](https://github.com/FiloSottile/mkcert) to create and install a locally-trusted, development certificate. The following will install `mkcert` and then create and install the local certificates.
+
+```shell
+brew install mkcert
+brew install nss # if you use Firefox
+yarn mkcert-localhost
+```
+
+Running `sentry devserver` will automatically use HTTPS when the certificates have been installed.
+
+
+### Ingestion Pipeline (Relay)
+
+Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers.
+
+<b>If you need to ingest errors, but don't require metrics ingestion: </b> Set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` is currently up, make sure to restart it after you make the change. This will launch Relay as part of the `devserver` workflow.
+
+Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices` command will not update Relay automatically in that case, to do this manually run:
+
+```shell
+sentry devservices up --skip-only-if relay
+sentry devserver --workers --ingest
+```
+
+<b>If you want to enable the entire metrics ingestion pipeline:</b> You need to add the following to your config at `~/.sentry/sentry.conf.py`:
+
+```python
+SENTRY_USE_RELAY = True
+SENTRY_USE_METRICS_DEV = True
+SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
+SENTRY_FEATURES['organizations:metrics-extraction'] = True  # Enables session metrics
+SENTRY_FEATURES['organizations:transaction-metrics-extraction'] = True  # Enables transaction metrics
+```
+
+After enabling `KafkaEventStream` the `snuba` service has to be reset to pick up the new configuration:
+
+```shell
+sentry devservices rm snuba
+sentry devservices up snuba
+```
+
 ## Running siloed instances
 
 By default `sentry devserver` will run a monolith mode application server. You can also run ``devserver`` with siloed application instances. Before you do, you need to <Link to="/database-migrations/#cloning-a-monolith-database">create split silo databases</Link>.
@@ -72,24 +121,20 @@ In the above setup your local environment will use org slug domains, and send re
 
 ### Ngrok and siloed servers
 
-To combine ngrok and local development servers you’ll need to reserve multiple domains in ngrok, and create a configuration file for ngrok:
+To combine ngrok and local development servers you’ll need to reserve two domains in ngrok, and create a configuration file for ngrok:
 
 ```yaml
 version: '2'
 authtoken: <YOUR-NGROK-AUTHTOKEN>
 tunnels:
-  acme-org:
-    proto: http
-    hostname: acme.<yourname>.ngrok.dev
-    addr: 8000
   control-silo:
     proto: http
-    hostname: <yourname>.ngrok.dev
+    hostname: $yourname.ngrok.dev
     host_header: 'rewrite'
     addr: 8000
   region-silo:
     proto: http
-    hostname: us.<yourname>.ngrok.dev
+    hostname: us.$yourname.ngrok.dev
     addr: 8010
     host_header: 'rewrite'
 ```
@@ -98,16 +143,16 @@ Then run all the required servers
 
 ```shell
 # Run a control silo with ngrok
-sentry devserver --silo=control --ngrok <yourname>.ngrok.dev
+sentry devserver --silo=control --ngrok $yourname.ngrok.dev
 
 # Run a region silo without ngrok
-sentry devserver --silo=region --ngrok <yourname>.ngrok.dev
+sentry devserver --silo=region --ngrok $yourname.ngrok.dev
 
 # Run ngrok
 ngrok start --all --config regions.yml
 ```
 
-This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/backend/development-server/">developement server</Link>.
+This setup will result in both the region and control servers responding to different domains, and CORS will work similar to production.
 
 ### Siloed Django Shell
 
@@ -152,59 +197,9 @@ environment, you can create `getsentry/conf/settings/devlocal.py` and put the
 configuration option overrides there. This module will be automatically imported
 by `dev.py` if it exists.
 
-
-### Frontend Only & Backend Only
-
-Please refer to [Frontend Development Server](/frontend/development-server/) and [Backend Development Server](/backend/development-server/) for alternative ways to bring up the Sentry UI.
-
-### Enabling HTTPS
-
-You may wish to run the development server in HTTPS mode. This can be done by generating and installing local certificates.
-
-We will be using [mkcert](https://github.com/FiloSottile/mkcert) to create and install a locally-trusted, development certificate. The following will install `mkcert` and then create and install the local certificates.
-
-```shell
-brew install mkcert
-brew install nss # if you use Firefox
-yarn mkcert-localhost
+To enable the ingest workers, follow the steps described <Link to="###Ingestion Pipeline (Relay)">here</Link> and run ```shell
+getsentry devserver --workers --ingest
 ```
-
-Running `sentry devserver` will automatically use HTTPS when the certificates have been installed.
-
-
-### Ingestion Pipeline (Relay)
-
-Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. If you need
-a more production-like environment in development, you can set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` is currently up ,make sure to restart it after you make the change. This will launch Relay
-as part of the `devserver` workflow.
-
-Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
-command will not update Relay automatically in that case, to do this manually run:
-
-```shell
-sentry devservices up --skip-only-if relay
-sentry devserver --workers --ingest
-```
-
-If you want to enable the entire metrics ingestion pipeline, you need to add the following to your config at `~/.sentry/sentry.conf.py`:
-
-```python
-SENTRY_USE_RELAY = True
-SENTRY_USE_METRICS_DEV = True
-SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
-SENTRY_FEATURES['organizations:metrics-extraction'] = True  # Enables session metrics
-SENTRY_FEATURES['organizations:transaction-metrics-extraction'] = True  # Enables transaction metrics
-```
-
-After enabling `KafkaEventStream` the `snuba` service has to be reset to pick up the new configuration:
-
-```shell
-sentry devservices rm snuba
-sentry devservices up snuba
-```
-
-
-## Troubleshooting
 
 You might also be interested in <Link to="/continuous-integration/#troubleshooting-ci">troubleshooting CI</Link>.
 

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -71,7 +71,7 @@ Running `sentry devserver` will automatically use HTTPS when the certificates ha
 
 Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. 
 
-<b>If you need to ingest errors, but don't require metrics ingestion: </b> Set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` 
+**If you need to ingest errors, but don't require metrics ingestion:** Set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` 
 is currently up, make sure to restart it after you make the change. This will launch Relay as part of the `devserver` workflow.
 
 Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
@@ -82,7 +82,7 @@ sentry devservices up --skip-only-if relay
 sentry devserver --workers --ingest
 ```
 
-<b>If you want to enable the entire metrics ingestion pipeline:</b> You need to add the following to your config at `~/.sentry/sentry.conf.py`:
+**If you want to enable the entire metrics ingestion pipeline:** You need to add the following to your config at `~/.sentry/sentry.conf.py`:
 
 ```python
 SENTRY_USE_RELAY = True

--- a/src/docs/environment/index.mdx
+++ b/src/docs/environment/index.mdx
@@ -67,14 +67,15 @@ yarn mkcert-localhost
 
 Running `sentry devserver` will automatically use HTTPS when the certificates have been installed.
 
-
 ### Ingestion Pipeline (Relay)
 
-Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers.
+Some services are not run in all situations. Among those are <Link to="/services/relay/">Relay</Link> and the ingest workers. 
 
-<b>If you need to ingest errors, but don't require metrics ingestion: </b> Set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` is currently up, make sure to restart it after you make the change. This will launch Relay as part of the `devserver` workflow.
+<b>If you need to ingest errors, but don't require metrics ingestion: </b> Set `SENTRY_USE_RELAY=True` in `~/.sentry/sentry.conf.py`. If `sentry devservices` 
+is currently up, make sure to restart it after you make the change. This will launch Relay as part of the `devserver` workflow.
 
-Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices` command will not update Relay automatically in that case, to do this manually run:
+Additionally, you can explicitly control this during `devserver` usage with the `--ingest` and `--no-ingest` flags. The `sentry devservices`
+command will not update Relay automatically in that case, to do this manually run:
 
 ```shell
 sentry devservices up --skip-only-if relay
@@ -121,20 +122,24 @@ In the above setup your local environment will use org slug domains, and send re
 
 ### Ngrok and siloed servers
 
-To combine ngrok and local development servers you’ll need to reserve two domains in ngrok, and create a configuration file for ngrok:
+To combine ngrok and local development servers you’ll need to reserve multiple domains in ngrok, and create a configuration file for ngrok:
 
 ```yaml
 version: '2'
 authtoken: <YOUR-NGROK-AUTHTOKEN>
 tunnels:
+  acme-org:
+    proto: http
+    hostname: acme.<yourname>.ngrok.dev
+    addr: 8000
   control-silo:
     proto: http
-    hostname: $yourname.ngrok.dev
+    hostname: <yourname>.ngrok.dev
     host_header: 'rewrite'
     addr: 8000
   region-silo:
     proto: http
-    hostname: us.$yourname.ngrok.dev
+    hostname: us.<yourname>.ngrok.dev
     addr: 8010
     host_header: 'rewrite'
 ```
@@ -143,16 +148,16 @@ Then run all the required servers
 
 ```shell
 # Run a control silo with ngrok
-sentry devserver --silo=control --ngrok $yourname.ngrok.dev
+sentry devserver --silo=control --ngrok <yourname>.ngrok.dev
 
 # Run a region silo without ngrok
-sentry devserver --silo=region --ngrok $yourname.ngrok.dev
+sentry devserver --silo=region --ngrok <yourname>.ngrok.dev
 
 # Run ngrok
 ngrok start --all --config regions.yml
 ```
 
-This setup will result in both the region and control servers responding to different domains, and CORS will work similar to production.
+This setup will result in both the region and control servers responding to different domains. The multi-region setup with ngrok also enables customer-domains and you'll need ngrok domains for each organization you plan on using. In this configuration, CORS will work similar to production. For ngrok setup with non-siloed development server see <Link to="/backend/development-server/">developement server</Link>.
 
 ### Siloed Django Shell
 
@@ -199,7 +204,8 @@ by `dev.py` if it exists.
 
 To enable the ingest workers, follow the steps described <Link to="###Ingestion Pipeline (Relay)">here</Link> and run ```shell
 getsentry devserver --workers --ingest
-```
+
+## Troubleshooting
 
 You might also be interested in <Link to="/continuous-integration/#troubleshooting-ci">troubleshooting CI</Link>.
 


### PR DESCRIPTION
The subsubheadings 'Frontend Only & Backend Only'/'Enabling HTTPS'/'Ingestion Pipeline (Relay)' are not specific to Getsentry, so it makes more sense for them to be structured under the Sentry subhead.

Additionally clarify which settings should be used when configuring the devserver for error ingestion vs metrics ingestion.