### PR TITLE
Update requests.mdx

### DIFF
--- a/src/docs/sdk/performance/modules/requests.mdx
+++ b/src/docs/sdk/performance/modules/requests.mdx
@@ -9,7 +9,7 @@ The SDK should auto-instrument all outgoing HTTP requests, regardless of the lib
 | Attribute | Description | Notes |
 |:--|:--|:--|
 | `op` | Always `"http.client"` | Required |
-| `description` | A string including the HTTP request method, and the full URL. e.g., `"GET https://example.com/data.json?filter=all"` | Required [^1] |
+| `description` | A string including the HTTP request method, and the full URL. e.g., `"GET https://example.com/data.json"` | Required [^1] |
 | `data` | A key-value mapping of span attributes. (e.g., `{"http.query": "filter=all", "server.address": "prod-2.example.com"}`) | Required for full experience. See [Span Data](#span-data) for details |
 
 ### Span Data
@@ -31,7 +31,7 @@ Should result in the following span, assuming the request was successful:
 
 ```json
 {
-  "description": "GET /data.json?user=1",
+  "description": "GET /data.json",
   "op": "http.client",
   "data": {
     "http.query": "user=1",


### PR DESCRIPTION
SDKs should not set query parameters as the span description, as this could leak Pii/sensitive data which is not reliable scrubbed in Relay.