### PR TITLE
Specify extension and format

### DIFF
--- a/src/docs/self-hosted/custom-ca-roots.mdx
+++ b/src/docs/self-hosted/custom-ca-roots.mdx
@@ -2,7 +2,7 @@
 title: "Self-Hosted Custom CA Roots"
 ---
 
-Starting with Sentry `21.8.0`, if you need to have Sentry access services which do not have TLS certificates from publicly trusted CA roots, it's now possible to easily add them to the containers. Just add the certificates to the `certificates` folder inside the root of your Sentry install and restart the containers. Your custom CA roots will be used in addition to the publicly trusted CA roots.
+Starting with Sentry `21.8.0`, if you need to have Sentry access services which do not have TLS certificates from publicly trusted CA roots, it's now possible to easily add them to the containers. Just add your `.crt` certificates in the PEM format to the `certificates` folder inside the root of your Sentry install and restart the containers. Your custom CA roots will be used in addition to the publicly trusted CA roots.
 
 <Alert title="Note" level="info">
   While you can run <a href="https://manpages.debian.org/buster/ca-certificates/update-ca-certificates.8.en.html"><code>update-ca-certificates</code></a> in each container, that will update the system's root bundle on disk, but does nothing for any copies in memory. Restarting the container will update the bundle and make sure it is used.


### PR DESCRIPTION
`update-ca-certificates` is a bit picky and will silently ignore files without the `.crt` extension.