### PR TITLE
docs(self-hosted): provide product links to ommited features on errors-only

### DIFF
--- a/src/docs/self-hosted/index.mdx
+++ b/src/docs/self-hosted/index.mdx
@@ -109,7 +109,9 @@ You can disable this feature by adding `SENTRY_BEACON = False` into `sentry.conf
 
 ## Errors-only Self-hosted Sentry
 
-**Disclaimer: This is an experimental beta feature. This means that features and workflows are not completely tested, so use at your own risk!**
+<Alert level="warning" title="Disclaimer">
+  <b>This is an experimental beta feature. This means that features and workflows are not completely tested, so use at your own risk!</b>
+</Alert>
 
 Starting from 24.8.0+, users will have the ability to choose between two distinct types of self-hosted Sentry deployments.
 
@@ -128,13 +130,14 @@ In order to enable errors only self-hosted, you'll need to update your [.env fil
 **Feature Complete**
 
 This is our default version of self-hosted Sentry. It includes most of the features that are available on our SaaS product. This includes everything offered in the Errors Only version, plus the following:
-1. Traces
-2. Profiles
-3. Replays
-4. Insights (Requests, Queries, Assets, etc)
-5. User Feedback
-6. Performance
-7. Crons
+1. Trace Explorer ([product documentation](https://docs.sentry.io/product/explore/traces/))
+2. Profiles ([product documentation](https://docs.sentry.io/product/explore/profiling/))
+3. Replays ([product documentation](https://docs.sentry.io/product/explore/session-replay/))
+4. Insights (Requests, Queries, Assets, etc) ([product documentation](https://docs.sentry.io/product/insights/))
+5. User Feedback ([product documentation](https://docs.sentry.io/product/user-feedback/))
+6. Performance ([product documentation](https://docs.sentry.io/product/performance/))
+7. Crons ([product documentation](https://docs.sentry.io/product/crons/))
+8. Metrics ([product documentation](https://docs.sentry.io/product/explore/metrics/))
 
 This version of Sentry is enabled by default upon installation. Ensure that your [.env file](https://github.com/getsentry/self-hosted/blob/master/.env) includes `COMPOSE_PROFILES=feature-complete`.
 


### PR DESCRIPTION
Since some people has been asking about what the feature is, but we don't exactly point them to the correct product documentation.

cc @hubertdeng123 @IanWoodard 