### PR TITLE
feat(contexts): Add app start type

### DIFF
--- a/src/docs/sdk/event-payloads/contexts.mdx
+++ b/src/docs/sdk/event-payloads/contexts.mdx
@@ -393,6 +393,10 @@ If a platform doesn't provide capabilities to identify whether a permission has 
 
 : _Optional_. A list of visible UI screens at the current point in time.
 
+`start_type`
+
+: _Optional_. The way the OS started the app. For example, `cold`, `warm`, `cold.prewarmed`, or `warm.prewarmed`.
+
 ## Browser Context
 
 Browser context carries information about the browser or user agent for


### PR DESCRIPTION
Add start_type to the app context, which both sentry-java and sentry-cocoa already send.